### PR TITLE
chore: update next js to 15.0.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # dependencies
 /node_modules
 /.pnp
+/.pnpm-store
 .pnp.*
 .yarn/*
 !.yarn/patches
@@ -43,3 +44,4 @@ next-env.d.ts
 .wrangler
 
 package-lock.json
+pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "immer": "^10.1.1",
     "lucide-react": "^0.460.0",
     "motion": "^12.4.1",
-    "next": "15.0.5",
+    "next": "15.0.7",
     "next-themes": "^0.4.4",
     "react": "19.0.0",
     "react-dom": "19.0.0",


### PR DESCRIPTION
CVE-2025-55183, CVE-2025-55184

https://nextjs.org/blog/security-update-2025-12-11