### PR TITLE
add: prolific support for wahl-agent

### DIFF
--- a/components/agent/agent-chat-view.tsx
+++ b/components/agent/agent-chat-view.tsx
@@ -138,6 +138,7 @@ export default function AgentChatView() {
   const router = useRouter();
 
   const topic = useAgentStore((state) => state.topic);
+  const prolificMetadata = useAgentStore((state) => state.prolificMetadata);
   const conversationId = useAgentStore((state) => state.conversationId);
   const isStreaming = useAgentStore((state) => state.isStreaming);
   const initialMessageReceived = useAgentStore(
@@ -266,7 +267,7 @@ export default function AgentChatView() {
 
       try {
         // Create conversation
-        const response = await createConversation(topic);
+        const response = await createConversation(topic, prolificMetadata);
         setConversationId(response.conversation_id);
 
         // Save to localStorage and update URL
@@ -291,6 +292,7 @@ export default function AgentChatView() {
     initializeConversation();
   }, [
     topic,
+    prolificMetadata,
     conversationId,
     initialMessageReceived,
     setConversationId,

--- a/components/agent/agent-entry-point.tsx
+++ b/components/agent/agent-entry-point.tsx
@@ -5,14 +5,29 @@ import { getStoredConversationId } from '@/lib/agent/conversation-storage';
 import { useEffect, useState } from 'react';
 import AgentFlowController from './agent-flow-controller';
 import ResumeConversationPrompt from './resume-conversation-prompt';
+import { useSearchParams } from 'next/navigation';
+import { captureProlificParams } from '@/lib/prolific-study/prolific-metadata';
 
 export default function AgentEntryPoint() {
   const step = useAgentStore((state) => state.step);
+  const setProlificMetadata = useAgentStore(
+    (state) => state.setProlificMetadata,
+  );
   const [storedConversationId, setStoredConversationId] = useState<
     string | null
   >(null);
   const [hasCheckedStorage, setHasCheckedStorage] = useState(false);
   const [showResumePrompt, setShowResumePrompt] = useState(false);
+
+  const searchParams = useSearchParams();
+
+  // Capture Prolific URL Params on mount
+  useEffect(() => {
+    const metadata = captureProlificParams(searchParams);
+    if (metadata) {
+      setProlificMetadata(metadata);
+    }
+  }, []);
 
   // Check localStorage on mount
   useEffect(() => {

--- a/components/agent/completion-screen.tsx
+++ b/components/agent/completion-screen.tsx
@@ -3,9 +3,18 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Heart, PartyPopper } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { isProlificStudy } from '@/lib/prolific-study/prolific-metadata';
+import CompletionCode from '@/components/prolific-study/completion-code';
 
 export default function CompletionScreen() {
   const [showConfetti, setShowConfetti] = useState(false);
+  const [showCompletionCode, setShowCompletionCode] = useState(false);
+
+  useEffect(() => {
+    if (isProlificStudy()) {
+      setShowCompletionCode(true);
+    }
+  }, []);
 
   useEffect(() => {
     // Trigger confetti animation after mount
@@ -48,6 +57,8 @@ export default function CompletionScreen() {
             </>
           )}
         </div>
+
+        {showCompletionCode && <CompletionCode />}
 
         {/* Thank You Card */}
         <Card className="border-green-200 bg-green-50/50 dark:border-green-900 dark:bg-green-950/30">

--- a/lib/agent/agent-api.ts
+++ b/lib/agent/agent-api.ts
@@ -1,5 +1,6 @@
 import type { AgentTopic, ConversationStage } from '@/lib/stores/agent-store';
 import type { Source } from '@/lib/stores/chat-store.types';
+import { ProlificMetadata } from '@/lib/prolific-study/prolific-metadata';
 
 // Use Next.js API routes as proxy to avoid CORS issues
 const API_BASE_URL = '/api/agent';
@@ -46,15 +47,22 @@ export interface StreamEvent {
  */
 export async function createConversation(
   topic: AgentTopic,
+  prolificMetadata: ProlificMetadata | null,
 ): Promise<CreateConversationResponse> {
+  const body: Record<string, unknown> = {
+    topic,
+  };
+
+  if (prolificMetadata) {
+    body.prolific_metadata = prolificMetadata;
+  }
+
   const response = await fetch(`${API_BASE_URL}/chat-start`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({
-      topic,
-    }),
+    body: JSON.stringify(body),
   });
 
   if (!response.ok) {

--- a/lib/stores/agent-store.ts
+++ b/lib/stores/agent-store.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import type { Source } from '@/lib/stores/chat-store.types';
+import type { ProlificMetadata } from '@/lib/prolific-study/prolific-metadata';
 import { generateUuid } from '@/lib/utils';
 import { createStore } from 'zustand/vanilla';
 
@@ -57,6 +58,9 @@ export interface AgentState {
 
   topic: AgentTopic | null;
 
+  // Study metadata
+  prolificMetadata: ProlificMetadata | null;
+
   // Conversation
   conversationId: string | null;
   conversationStage: ConversationStage | null;
@@ -87,6 +91,8 @@ export interface AgentActions {
 
   setTopic: (topic: AgentTopic) => void;
 
+  setProlificMetadata: (prolificMetadata: ProlificMetadata) => void;
+
   // Conversation actions
   setConversationId: (id: string) => void;
   setConversationStage: (stage: ConversationStage) => void;
@@ -110,6 +116,7 @@ const initialState: AgentState = {
   step: 'consent',
   consentGiven: false,
   topic: null,
+  prolificMetadata: null,
   conversationId: null,
   conversationStage: null,
   messages: [],
@@ -158,6 +165,9 @@ export const createAgentStore = (initState: Partial<AgentState> = {}) => {
         topic,
         step: 'chat',
       }),
+
+    // Study metadata
+    setProlificMetadata: (prolificMetadata) => set({ prolificMetadata }),
 
     // Conversation actions
     setConversationId: (conversationId) => set({ conversationId }),


### PR DESCRIPTION
### TL;DR

Added Prolific study integration to the agent chat interface, allowing for participant tracking and completion code display.

### What changed?

- Added functionality to capture Prolific study metadata from URL parameters
- Modified the conversation creation API to include Prolific metadata when available
- Added a completion code component that displays when a user is part of a Prolific study
- Updated the agent store to track Prolific metadata
- Added logging for conversation creation

### How to test?

1. Test with Prolific parameters by appending them to the URL: `?PROLIFIC_PID=123&STUDY_ID=456&SESSION_ID=789`
2. Verify that these parameters are captured and sent when creating a conversation
3. Complete a conversation and verify that the completion code appears on the completion screen for Prolific participants
4. Check the console logs to confirm conversation creation with the correct ID and topic

### Why make this change?

This integration enables running user studies through the Prolific platform, allowing for proper participant tracking and compensation. The completion code ensures participants can confirm they've completed the task and receive credit for their participation.