### PR TITLE
fix(firebase): store context party source refs under source_documents

### DIFF
--- a/firebase/functions/main.py
+++ b/firebase/functions/main.py
@@ -385,7 +385,7 @@ def add_source_document_to_firebase(
         party_id: The party identifier (e.g., 'spd')
         source: The PartySource object with document metadata
 
-    Firestore path: sources/{context_id}/parties/{party_id}/documents/{document_id}
+    Firestore path: sources/{context_id}/parties/{party_id}/source_documents/{document_id}
     """
     firestore_client: google.cloud.firestore.Client = firestore.client()
     source_info_ref = (
@@ -393,7 +393,7 @@ def add_source_document_to_firebase(
         .document(context_id)
         .collection("parties")
         .document(party_id)
-        .collection("documents")
+        .collection("source_documents")
         .document(document_id)
     )
 
@@ -410,7 +410,7 @@ def delete_source_document_from_firebase(
         context_id: The context identifier (e.g., 'bundestagswahl-2025')
         party_id: The party identifier (e.g., 'spd')
 
-    Firestore path: sources/{context_id}/parties/{party_id}/documents/{document_id}
+    Firestore path: sources/{context_id}/parties/{party_id}/source_documents/{document_id}
     """
     firestore_client: google.cloud.firestore.Client = firestore.client()
     source_info_ref = (
@@ -418,7 +418,7 @@ def delete_source_document_from_firebase(
         .document(context_id)
         .collection("parties")
         .document(party_id)
-        .collection("documents")
+        .collection("source_documents")
         .document(document_id)
     )
     source_info_ref.delete()


### PR DESCRIPTION
Use source_documents instead of documents in Firebase upload/delete Firestore writes.

Updated upload/delete helpers to write to:
sources/{contextId}/parties/{partyId}/source_documents/{documentId}
Aligns backend with frontend reads and Firestore rules.
Prevents missing source docs due to path mismatch.