### PR TITLE
Avoid caching missing contexts

### DIFF
--- a/web/lib/firebase/firebase-server.ts
+++ b/web/lib/firebase/firebase-server.ts
@@ -39,6 +39,13 @@ import type {
   SourceDocument,
 } from './firebase.types';
 
+class ContextNotFoundError extends Error {
+  constructor(contextId: string) {
+    super(`Context not found: ${contextId}`);
+    this.name = 'ContextNotFoundError';
+  }
+}
+
 async function getServerApp({
   useHeaders = true,
 }: { useHeaders?: boolean } = {}) {
@@ -163,14 +170,38 @@ async function getContextImpl(contextId: string) {
       `[Firestore] FAILED to fetch context "/contexts/${contextId}":`,
       error,
     );
-    return undefined;
+    throw error;
   }
 }
 
-export const getContext = cache(getContextImpl, ['getContext', 'v2'], {
-  revalidate: 3600,
-  tags: [CacheTags.CONTEXTS],
-});
+const getContextCached = cache(
+  async (contextId: string) => {
+    const context = await getContextImpl(contextId);
+
+    if (!context) {
+      throw new ContextNotFoundError(contextId);
+    }
+
+    return context;
+  },
+  ['getContext', 'v3'],
+  {
+    revalidate: 3600,
+    tags: [CacheTags.CONTEXTS],
+  },
+);
+
+export async function getContext(contextId: string) {
+  try {
+    return await getContextCached(contextId);
+  } catch (error) {
+    if (error instanceof ContextNotFoundError) {
+      return undefined;
+    }
+
+    return getContextImpl(contextId);
+  }
+}
 
 async function getPartiesForContextImpl(contextId: string) {
   try {


### PR DESCRIPTION
## Problem
In production, a context could appear in the homepage dropdown but still redirect away or behave like a missing route when opened directly. In practice, that meant a valid context like `landtagswahl-baden-wuerttemberg-2026` could temporarily look unavailable until the Vercel cache was flushed.

The underlying issue was that `getContext(contextId)` used a cached Firestore lookup that treated `undefined` as a cacheable result. If one request hit a transient Firestore/runtime failure or otherwise resolved through the missing-context path, that negative result could be stored in the cache. After that, the route-specific lookup could keep behaving as if the context did not exist, even while other parts of the app still showed the context as available.

## Fix
This PR changes the context lookup so that missing contexts are not cached as normal values.

Specifically:
- real context hits are still cached
- true missing contexts are mapped to a `ContextNotFoundError` inside the cached helper instead of caching `undefined`
- the public `getContext(contextId)` wrapper returns `undefined` immediately for a true miss
- real Firestore/runtime failures now throw out of `getContextImpl()` and are handled separately from the not-found case
- on those real failures, `getContext(contextId)` falls back to a direct uncached read instead of trusting the cached path
- the cache key version is bumped from `v2` to `v3` so existing stale negative cache entries are not reused

## Result
This keeps the route-level context lookup from getting stuck in a false “missing context” state due to a cached negative result. The expected behavior after this change is:
- if a context really exists, cached hits still work normally
- if a context really does not exist, the app follows the existing missing-context flow
- if Firestore has a transient problem, the request gets one fresh uncached read instead of persisting the bad cached outcome

The rest of the Firestore loading flow is intentionally left unchanged so the diff stays focused on the context-cache behavior that caused the production issue.