### PR TITLE
add: open call button to post positions on wahlchat

### DIFF
--- a/web/app/[contextId]/(home)/page.tsx
+++ b/web/app/[contextId]/(home)/page.tsx
@@ -4,7 +4,9 @@ import GitHubCard from '@/components/home/github-card';
 import HomeInput from '@/components/home/home-input';
 import HowToCard from '@/components/home/how-to-card';
 import KnownFrom from '@/components/home/known-from';
-import OpenCallCard from '@/components/home/open-call-card';
+import OpenCallCard, {
+  getAvailableOpenCallUrl,
+} from '@/components/home/open-call-card';
 import SupportUsCard from '@/components/home/support-us-card';
 import {
   getHomeInputProposedQuestions,
@@ -22,11 +24,13 @@ type Props = {
 export default async function ContextHome({ params }: Props) {
   const { contextId } = await params;
 
-  const [wahlChatQuestions, systemStatus, user] = await Promise.all([
-    getHomeInputProposedQuestions(),
-    getSystemStatus(),
-    getUser(),
-  ]);
+  const [wahlChatQuestions, systemStatus, user, openCallUrl] =
+    await Promise.all([
+      getHomeInputProposedQuestions(),
+      getSystemStatus(),
+      getUser(),
+      getAvailableOpenCallUrl(),
+    ]);
 
   return (
     <>
@@ -52,8 +56,8 @@ export default async function ContextHome({ params }: Props) {
         <section className="grid w-full grid-cols-1 flex-wrap gap-2 md:grid-cols-2 md:gap-2">
           <SupportUsCard />
           <ContactCard />
-          <GitHubCard />
-          <OpenCallCard />
+          <GitHubCard fullWidth={!openCallUrl} />
+          {openCallUrl && <OpenCallCard url={openCallUrl} />}
           <HowToCard />
         </section>
       )}

--- a/web/components/home/github-card.tsx
+++ b/web/components/home/github-card.tsx
@@ -2,9 +2,13 @@ import GithubIcon from '@/components/icons/github-icon';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 
-function GitHubCard() {
+function GitHubCard({ fullWidth = false }: { fullWidth?: boolean }) {
   return (
-    <div className="flex flex-col rounded-md border border-border">
+    <div
+      className={`flex flex-col rounded-md border border-border${
+        fullWidth ? ' md:col-span-2' : ''
+      }`}
+    >
       <div className="flex grow flex-col justify-between p-4">
         <div>
           <h2 className="font-bold">

--- a/web/components/home/open-call-card.tsx
+++ b/web/components/home/open-call-card.tsx
@@ -4,9 +4,40 @@ import Link from 'next/link';
 
 const OPEN_CALL_PATH =
   'public/additional_documents/hiring/WahlChatOpenCall.pdf';
-const OPEN_CALL_URL = `https://firebasestorage.googleapis.com/v0/b/${process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET}/o/${encodeURIComponent(OPEN_CALL_PATH)}?alt=media`;
 
-function OpenCallCard() {
+function buildOpenCallUrl(): string | null {
+  const bucket = process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET;
+  if (!bucket) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error(
+        '[OpenCallCard] NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET is not set — card will not render.',
+      );
+    }
+    return null;
+  }
+  const url = new URL('https://firebasestorage.googleapis.com');
+  url.pathname = `/v0/b/${bucket}/o/${encodeURIComponent(OPEN_CALL_PATH)}`;
+  url.searchParams.set('alt', 'media');
+  return url.toString();
+}
+
+/** Server-side check: returns the URL if the document exists, null otherwise.
+ *  Result is cached for 1 hour via Next.js fetch ISR. */
+export async function getAvailableOpenCallUrl(): Promise<string | null> {
+  const url = buildOpenCallUrl();
+  if (!url) return null;
+  try {
+    const res = await fetch(url, {
+      method: 'HEAD',
+      next: { revalidate: 3600 },
+    });
+    return res.ok ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function OpenCallCard({ url }: { url: string }) {
   return (
     <div className="flex flex-col rounded-md border border-border">
       <div className="flex grow flex-col justify-between p-4">
@@ -19,7 +50,7 @@ function OpenCallCard() {
           </p>
         </div>
         <Button asChild variant="secondary" className="w-full">
-          <Link href={OPEN_CALL_URL} target="_blank" rel="noopener noreferrer">
+          <Link href={url} target="_blank" rel="noopener noreferrer">
             <GraduationCapIcon className="size-5" />
             Open Call
           </Link>


### PR DESCRIPTION
This pull request adds a new "Open Call" card to the home page, inviting users to apply for master thesis projects related to political transparency. The card links to a PDF hosted on Firebase Storage. Additionally, a minor layout adjustment was made to the GitHub card.

New feature: Open Call card

* Added a new `OpenCallCard` component that displays information about master thesis opportunities and includes a button linking to an external PDF with more details.
* Imported and rendered the `OpenCallCard` on the home page (`page.tsx`). ([web/app/[contextId]/(home)/page.tsxR7](diffhunk://#diff-4393435a19999d51ba4872f883e3b30d5e1719ee20858404348308e5d5993849R7), [web/app/[contextId]/(home)/page.tsxR56](diffhunk://#diff-4393435a19999d51ba4872f883e3b30d5e1719ee20858404348308e5d5993849R56))

UI adjustments

* Removed the `md:col-span-2` class from the `GitHubCard` component to standardize its layout with other cards.