### PR TITLE
add open call button to landing page

### DIFF
--- a/web/app/[contextId]/(home)/page.tsx
+++ b/web/app/[contextId]/(home)/page.tsx
@@ -4,6 +4,7 @@ import GitHubCard from '@/components/home/github-card';
 import HomeInput from '@/components/home/home-input';
 import HowToCard from '@/components/home/how-to-card';
 import KnownFrom from '@/components/home/known-from';
+import OpenCallCard from '@/components/home/open-call-card';
 import SupportUsCard from '@/components/home/support-us-card';
 import {
   getHomeInputProposedQuestions,
@@ -52,6 +53,7 @@ export default async function ContextHome({ params }: Props) {
           <SupportUsCard />
           <ContactCard />
           <GitHubCard />
+          <OpenCallCard />
           <HowToCard />
         </section>
       )}

--- a/web/app/[contextId]/(home)/page.tsx
+++ b/web/app/[contextId]/(home)/page.tsx
@@ -4,7 +4,9 @@ import GitHubCard from '@/components/home/github-card';
 import HomeInput from '@/components/home/home-input';
 import HowToCard from '@/components/home/how-to-card';
 import KnownFrom from '@/components/home/known-from';
-import OpenCallCard from '@/components/home/open-call-card';
+import OpenCallCard, {
+  getAvailableOpenCallUrl,
+} from '@/components/home/open-call-card';
 import SupportUsCard from '@/components/home/support-us-card';
 import {
   getHomeInputProposedQuestions,
@@ -22,11 +24,13 @@ type Props = {
 export default async function ContextHome({ params }: Props) {
   const { contextId } = await params;
 
-  const [wahlChatQuestions, systemStatus, user] = await Promise.all([
-    getHomeInputProposedQuestions(),
-    getSystemStatus(),
-    getUser(),
-  ]);
+  const [wahlChatQuestions, systemStatus, user, openCallUrl] =
+    await Promise.all([
+      getHomeInputProposedQuestions(),
+      getSystemStatus(),
+      getUser(),
+      getAvailableOpenCallUrl(),
+    ]);
 
   return (
     <>
@@ -52,8 +56,8 @@ export default async function ContextHome({ params }: Props) {
         <section className="grid w-full grid-cols-1 flex-wrap gap-2 md:grid-cols-2 md:gap-2">
           <SupportUsCard />
           <ContactCard />
-          <GitHubCard />
-          <OpenCallCard />
+          <GitHubCard fullWidth={!openCallUrl} />
+          {openCallUrl && <OpenCallCard url={openCallUrl} />}
           <HowToCard />
         </section>
       )}

--- a/web/components/home/github-card.tsx
+++ b/web/components/home/github-card.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 
 function GitHubCard() {
   return (
-    <div className="flex flex-col rounded-md border border-border md:col-span-2">
+    <div className="flex flex-col rounded-md border border-border">
       <div className="flex grow flex-col justify-between p-4">
         <div>
           <h2 className="font-bold">

--- a/web/components/home/github-card.tsx
+++ b/web/components/home/github-card.tsx
@@ -2,9 +2,13 @@ import GithubIcon from '@/components/icons/github-icon';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 
-function GitHubCard() {
+function GitHubCard({ fullWidth = false }: { fullWidth?: boolean }) {
   return (
-    <div className="flex flex-col rounded-md border border-border">
+    <div
+      className={`flex flex-col rounded-md border border-border${
+        fullWidth ? ' md:col-span-2' : ''
+      }`}
+    >
       <div className="flex grow flex-col justify-between p-4">
         <div>
           <h2 className="font-bold">

--- a/web/components/home/open-call-card.tsx
+++ b/web/components/home/open-call-card.tsx
@@ -44,9 +44,8 @@ function OpenCallCard({ url }: { url: string }) {
         <div>
           <h2 className="font-bold">Masterarbeiten mit Impact</h2>
           <p className="mb-4 text-sm text-muted-foreground">
-            Du willst mit deiner Masterarbeit politische Transparenz und die
-            Überprüfbarkeit von Wahlversprechen erforschen und umsetzen? Dann
-            bewirb dich jetzt!
+            Erforsche politische Transparenz und Fact-Checking zusammen mit Open
+            Parliament TV und der University of Cambridge. Bewirb dich jetzt!
           </p>
         </div>
         <Button asChild variant="secondary" className="w-full">

--- a/web/components/home/open-call-card.tsx
+++ b/web/components/home/open-call-card.tsx
@@ -4,9 +4,40 @@ import Link from 'next/link';
 
 const OPEN_CALL_PATH =
   'public/additional_documents/hiring/WahlChatOpenCall.pdf';
-const OPEN_CALL_URL = `https://firebasestorage.googleapis.com/v0/b/${process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET}/o/${encodeURIComponent(OPEN_CALL_PATH)}?alt=media`;
 
-function OpenCallCard() {
+function buildOpenCallUrl(): string | null {
+  const bucket = process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET;
+  if (!bucket) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error(
+        '[OpenCallCard] NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET is not set — card will not render.',
+      );
+    }
+    return null;
+  }
+  const url = new URL('https://firebasestorage.googleapis.com');
+  url.pathname = `/v0/b/${bucket}/o/${encodeURIComponent(OPEN_CALL_PATH)}`;
+  url.searchParams.set('alt', 'media');
+  return url.toString();
+}
+
+/** Server-side check: returns the URL if the document exists, null otherwise.
+ *  Result is cached for 1 hour via Next.js fetch ISR. */
+export async function getAvailableOpenCallUrl(): Promise<string | null> {
+  const url = buildOpenCallUrl();
+  if (!url) return null;
+  try {
+    const res = await fetch(url, {
+      method: 'HEAD',
+      next: { revalidate: 3600 },
+    });
+    return res.ok ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function OpenCallCard({ url }: { url: string }) {
   return (
     <div className="flex flex-col rounded-md border border-border">
       <div className="flex grow flex-col justify-between p-4">
@@ -19,7 +50,7 @@ function OpenCallCard() {
           </p>
         </div>
         <Button asChild variant="secondary" className="w-full">
-          <Link href={OPEN_CALL_URL} target="_blank" rel="noopener noreferrer">
+          <Link href={url} target="_blank" rel="noopener noreferrer">
             <GraduationCapIcon className="size-5" />
             Open Call
           </Link>

--- a/web/components/home/open-call-card.tsx
+++ b/web/components/home/open-call-card.tsx
@@ -1,0 +1,32 @@
+import { Button } from '@/components/ui/button';
+import { GraduationCapIcon } from 'lucide-react';
+import Link from 'next/link';
+
+const OPEN_CALL_PATH =
+  'public/additional_documents/hiring/WahlChatOpenCall.pdf';
+const OPEN_CALL_URL = `https://firebasestorage.googleapis.com/v0/b/${process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET}/o/${encodeURIComponent(OPEN_CALL_PATH)}?alt=media`;
+
+function OpenCallCard() {
+  return (
+    <div className="flex flex-col rounded-md border border-border">
+      <div className="flex grow flex-col justify-between p-4">
+        <div>
+          <h2 className="font-bold">Masterarbeiten mit Impact</h2>
+          <p className="mb-4 text-sm text-muted-foreground">
+            Du willst mit deiner Masterarbeit politische Transparenz und die
+            Überprüfbarkeit von Wahlversprechen erforschen und umsetzen? Dann
+            bewirb dich jetzt!
+          </p>
+        </div>
+        <Button asChild variant="secondary" className="w-full">
+          <Link href={OPEN_CALL_URL} target="_blank" rel="noopener noreferrer">
+            <GraduationCapIcon className="size-5" />
+            Open Call
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default OpenCallCard;


### PR DESCRIPTION
This pull request adds a new "Open Call" card to the home page, which advertises opportunities for master's theses. The card is only shown if a relevant document is available in Firebase Storage. Additionally, the GitHub card layout is improved to adapt based on the presence of the Open Call card. The main changes are grouped below:

**Feature: Open Call Card for Master's Theses**
- Added a new `OpenCallCard` component that displays a call for master's thesis applications, including a link to a PDF stored in Firebase Storage. The card only renders if the document exists, determined by a server-side check with caching. (`web/components/home/open-call-card.tsx`)
- Integrated the Open Call card into the home page, fetching the document URL and conditionally rendering the card if available. (`web/app/[contextId]/(home)/page.tsx`) ([web/app/[contextId]/(home)/page.tsxR7-R9](diffhunk://#diff-4393435a19999d51ba4872f883e3b30d5e1719ee20858404348308e5d5993849R7-R9), [web/app/[contextId]/(home)/page.tsxL24-R32](diffhunk://#diff-4393435a19999d51ba4872f883e3b30d5e1719ee20858404348308e5d5993849L24-R32), [web/app/[contextId]/(home)/page.tsxL54-R60](diffhunk://#diff-4393435a19999d51ba4872f883e3b30d5e1719ee20858404348308e5d5993849L54-R60))

**UI Improvements**
- Modified the `GitHubCard` component to accept a `fullWidth` prop, allowing it to span the full width of its container if the Open Call card is not present, improving the layout responsiveness. (`web/components/home/github-card.tsx`, `web/app/[contextId]/(home)/page.tsx`) ([web/components/home/github-card.tsxL5-R11](diffhunk://#diff-2d8dfbbdbe3f55db71c55a2b28b68bb59d414cd4081cff59f57d75ef67c5afa7L5-R11), [web/app/[contextId]/(home)/page.tsxL54-R60](diffhunk://#diff-4393435a19999d51ba4872f883e3b30d5e1719ee20858404348308e5d5993849L54-R60))