### PR TITLE
V2 stack 3/9: Abgeordnetenwatch votes connector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,27 @@ test-local-mode:
 # / ENV are overridden (see the QDRANT_ENV block above).
 # Requires: make stores-up first for local runs.
 
+# run-abgeordnetenwatch-votes: loops the connector over ALL configured federal
+# (Bundestag) legislature IDs — the connector requires an explicit
+# AW_LEGISLATURE_ID (no silent default period), and a federal run must cover
+# every configured period, not just the oldest. IDs come from
+# FEDERAL_LEGISLATURE_IDS in legislature_config.py (single-sourced).
 run-abgeordnetenwatch-votes: bootstrap-collection
-	cd ai-backend && $(QDRANT_ENV) uv run python -m src.ingestion.run --connector abgeordnetenwatch_votes
+	@failed=""; \
+	for id in $$(cd ai-backend && uv run python -c \
+	    "from src.ingestion.connectors.abgeordnetenwatch.legislature_config import FEDERAL_LEGISLATURE_IDS; print(*FEDERAL_LEGISLATURE_IDS)"); do \
+	    echo "=== Bundestag legislature_id=$$id ==="; \
+	    if ! (cd ai-backend && AW_LEGISLATURE_ID=$$id $(QDRANT_ENV) \
+	        uv run python -m src.ingestion.run --connector abgeordnetenwatch_votes $(ARGS)); then \
+	        echo "!!! Bundestag legislature_id=$$id FAILED"; \
+	        failed="$$failed $$id"; \
+	    fi; \
+	done; \
+	if [ -n "$$failed" ]; then \
+	    echo "=== run-abgeordnetenwatch-votes: FAILED legislature ids:$$failed ==="; \
+	    exit 1; \
+	fi; \
+	echo "=== run-abgeordnetenwatch-votes: all federal legislatures completed ==="
 
 # run-all-landtage-votes: loops the connector over all 16 Landtag legislature IDs (run
 # selectivity).  IDs are sourced from LANDTAG_LEGISLATURE_IDS in legislature_config.py so the
@@ -159,7 +178,7 @@ run-all-landtage-votes: bootstrap-collection
 	    "from src.ingestion.connectors.abgeordnetenwatch.legislature_config import LANDTAG_LEGISLATURE_IDS; print(*LANDTAG_LEGISLATURE_IDS)"); do \
 	    echo "=== Landtag legislature_id=$$id ==="; \
 	    if ! (cd ai-backend && AW_LEGISLATURE_ID=$$id $(QDRANT_ENV) \
-	        uv run python -m src.ingestion.run --connector abgeordnetenwatch_votes); then \
+	        uv run python -m src.ingestion.run --connector abgeordnetenwatch_votes $(ARGS)); then \
 	        echo "!!! Landtag legislature_id=$$id FAILED"; \
 	        failed="$$failed $$id"; \
 	    fi; \

--- a/ai-backend/src/ingestion/connector.py
+++ b/ai-backend/src/ingestion/connector.py
@@ -58,6 +58,22 @@ class BaseConnector(ABC):
     # Optional discriminator within a shared source_type (see class docstring).
     source: Optional[str] = None
 
+    # Runner-bound store handle (see bind_store). None until the runner binds.
+    _store_client = None
+    _store_collection: Optional[str] = None
+
+    def bind_store(self, qdrant, collection_name: str) -> None:  # noqa: ANN001
+        """Hand the connector the runner's store handle before discover().
+
+        Store-aware discovery (e.g. set-difference against already-ingested
+        ids) must read the SAME client/collection the runner will upsert into;
+        a connector-constructed client can silently diverge under an injected
+        test client, a non-default collection, or a migration. Connectors that
+        never read the store simply ignore the stored references.
+        """
+        self._store_client = qdrant
+        self._store_collection = collection_name
+
     @property
     def cursor_source(self) -> Optional[str]:
         """Source scope for the runner's cursor read. Defaults to ``source``.

--- a/ai-backend/src/ingestion/connectors/__init__.py
+++ b/ai-backend/src/ingestion/connectors/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""Ingestion connectors package.
+
+Each module in this package is a concrete BaseConnector subclass for one
+upstream data source.  Imports are deferred (only triggered by the factory
+functions in registry.py) so the package itself has no side effects at
+import time.
+"""

--- a/ai-backend/src/ingestion/connectors/__init__.py
+++ b/ai-backend/src/ingestion/connectors/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/src/ingestion/connectors/abgeordnetenwatch/__init__.py
+++ b/ai-backend/src/ingestion/connectors/abgeordnetenwatch/__init__.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""Abgeordnetenwatch connector package.
+
+Single-store shape: produces ChunkRecord list directly from normalize() —
+no Firestore, no GCS, no matcher dual-write.
+
+Package structure:
+  client.py           — AW v2 API session + fixed-delay pacing
+  connector.py        — AbgeordnetenwatchVotesConnector(BaseConnector)
+  mappers/            — pure transforms (no I/O)
+    stance.py         — tally -> stance + fraction -> party
+    corpus.py         — poll -> vote_record ChunkRecord list
+
+The party_manifesto corpus is produced by the separate manifestos connector
+package (connectors/manifestos/) — this package produces vote_record only.
+"""

--- a/ai-backend/src/ingestion/connectors/abgeordnetenwatch/__init__.py
+++ b/ai-backend/src/ingestion/connectors/abgeordnetenwatch/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/src/ingestion/connectors/abgeordnetenwatch/client.py
+++ b/ai-backend/src/ingestion/connectors/abgeordnetenwatch/client.py
@@ -1,0 +1,343 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+AWClient — the single I/O home for all Abgeordnetenwatch v2 API calls.
+
+Design goals:
+  - All outbound HTTP to AW routes through this module.  No other module calls
+    requests.get() against the AW host.
+  - Fixed >=2s inter-request delay enforces the <=30 req/min fair-use ceiling
+    (simple fixed-spacing pacing).
+  - Retrying session with exponential backoff on 429/5xx.
+  - Absolute-index pagination: range_start/range_end are absolute position
+    indices (verified from live API).
+  - meta.status guard: any response with meta.status != 'ok' raises ValueError
+    so callers never silently process bad data.
+
+Security notes:
+  SSRF mitigation: ``_AW_BASE`` is a module-level constant string
+  literal.  ``get()`` and ``get_all()`` accept only a ``path`` segment, never
+  a full URL or host.  The host cannot be overridden by a caller argument.
+
+  Denial of Service (unbounded pagination): ``get_all`` stops when
+  ``start >= meta.result.total``; ``get_votes_for_poll`` uses a single call
+  with range_end=800 (verified: 19th Bundestag polls have <=750 votes each).
+
+  Denial of Service (AW 429 cascade): Fixed >=2s spacing keeps us
+  at <=30 req/min.  ``Retry(respect_retry_after_header=True)`` backs off on
+  429 responses from the server side.
+
+  Tampering (malformed JSON): ``raise_for_status()`` on HTTP errors;
+  meta.status guard raises on API error envelope; timeout=30 bounds hangs.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Optional
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants (SSRF guard — pinned module-level constant, never derived
+# from a method argument or user input)
+# ---------------------------------------------------------------------------
+
+# The AW v2 base URL is a pinned constant.  It is NEVER constructed from a
+# method argument.  callers supply only the path segment after this base.
+_AW_BASE = "https://www.abgeordnetenwatch.de/api/v2"
+
+# Fixed inter-request delay enforcing <=30 req/60s fair-use ceiling.
+# Overridable via env var for testing/calibration; production default is 2.0s.
+_AW_REQUEST_DELAY_S = float(os.getenv("AW_REQUEST_DELAY_S", "2.0"))
+
+# Retry configuration.
+_MAX_RETRIES = 5
+
+# User-Agent identifying wahl.chat to the AW API (fair-use policy asks
+# consumers to identify themselves so they can be contacted about usage).
+_USER_AGENT = "wahl.chat-ingestion/2.0 (https://wahl.chat)"
+
+# Number of items requested per page in get_all() (absolute-index pagination).
+_PAGE_SIZE = 100
+
+# Hard page cap for get_all().  meta.result.total is server-controlled;
+# a malicious or buggy AW response advertising a huge total would otherwise drive
+# millions of 2s-paced requests (effectively an infinite loop).  At _PAGE_SIZE=100
+# this caps a single get_all() at 10_000 items, which is far above any real AW
+# legislature poll/fraction count — exceeding it signals a bad response.
+_MAX_PAGES = 100
+
+# Single-call vote fetch window.  Verified: 19th Bundestag polls
+# have at most ~750 votes each (poll 3602 = 709, poll 4539 = 736, poll 5957 = 733).
+# get_votes_for_poll RAISES if meta.result.total exceeds this so other
+# legislatures with larger fractions cannot silently truncate the vote list.
+_VOTES_RANGE_END = 800
+
+
+# ---------------------------------------------------------------------------
+# AWClient
+# ---------------------------------------------------------------------------
+
+
+class AWClient:
+    """Paced, retrying HTTP client for the Abgeordnetenwatch v2 JSON API.
+
+    All AW API calls route through this class.  It enforces:
+    - Fixed >=2s inter-request sleep before each call (<=30 req/min)
+    - Retrying session with backoff on 429/5xx
+    - meta.status guard — raises ValueError on API error envelopes
+    - Absolute-index pagination in get_all()
+    - Pinned base URL (SSRF guard)
+
+    Usage::
+
+        client = AWClient()
+        poll = client.get("polls/3602")
+        polls = client.get_all("polls", {"field_legislature": 111})
+        votes = client.get_votes_for_poll(3602)
+    """
+
+    def __init__(self) -> None:
+        self._session: Optional[requests.Session] = None
+
+    def _get_session(self) -> requests.Session:
+        """Build the retrying session lazily on first use.
+
+        Importing this module is side-effect-free; the session is not created
+        until the first live get() call.
+
+        Retry policy:
+          - Retry(total=5) — up to 5 retries on top of the original request,
+            i.e. up to 6 attempts in total
+          - backoff_factor=1.0 — urllib3 2.x sleeps 1s, 2s, 4s, 8s, 16s before
+            the successive retries
+          - status_forcelist=(429, 500, 502, 503, 504)
+          - respect_retry_after_header=True — honours server-side 429 Retry-After
+          - allowed_methods={"GET"} — only idempotent GETs are retried
+
+        The session identifies wahl.chat via a User-Agent header (AW fair-use
+        policy asks API consumers to identify themselves).
+        """
+        if self._session is None:
+            retry = Retry(
+                total=_MAX_RETRIES,
+                backoff_factor=1.0,
+                status_forcelist=(429, 500, 502, 503, 504),
+                allowed_methods=frozenset({"GET"}),
+                respect_retry_after_header=True,
+            )
+            adapter = HTTPAdapter(max_retries=retry)
+            session = requests.Session()
+            session.mount("https://", adapter)
+            session.headers.update({"User-Agent": _USER_AGENT})
+            self._session = session
+        return self._session
+
+    def get(self, path: str, params: dict | None = None) -> dict:
+        """Make a single paced GET request to the AW v2 API.
+
+        The inter-request sleep happens BEFORE the HTTP call so that even the
+        first call in a batch is counted against the ceiling.
+
+        Args:
+            path: Path segment after _AW_BASE (e.g., ``"polls/3602"`` or
+                  ``"polls"``).  Must NOT include a host or scheme — the host
+                  is always _AW_BASE.
+            params: Optional query parameters dict (e.g., ``{"field_legislature": 111}``).
+
+        Returns:
+            The full parsed JSON response dict (including meta and data).
+
+        Raises:
+            requests.HTTPError: On non-200 HTTP responses (via raise_for_status).
+            ValueError: When meta.status != "ok" — the API returned an error
+                        envelope.
+            requests.exceptions.Timeout: When the request exceeds 30s.
+        """
+        # Sleep before every request — even the first call in a batch.
+        # This ensures 30 sequential calls take >=60s (>=58s after float rounding).
+        time.sleep(_AW_REQUEST_DELAY_S)
+
+        url = f"{_AW_BASE}/{path}"
+        response = self._get_session().get(url, params=params, timeout=30)
+        response.raise_for_status()
+
+        d: dict = response.json()
+
+        # meta.status guard — raises instead of returning bad data.
+        # A meta.status != "ok" response (e.g., invalid parameter name)
+        # still returns HTTP 200; we must check the envelope explicitly.
+        if d.get("meta", {}).get("status") != "ok":
+            status_message = d.get("meta", {}).get("status_message", "unknown error")
+            raise ValueError(f"AW API error: {status_message}")
+
+        return d
+
+    def get_all(self, path: str, params: dict | None = None) -> list:
+        """Paginate through all results, advancing by the delivered row count.
+
+        AW's ``range_end`` is the NUMBER of rows to return, not an absolute end
+        index: ``range_start=100&range_end=200`` returns 200 rows from position
+        100. Each page therefore requests a fixed window of ``_PAGE_SIZE`` rows
+        (``range_end=_PAGE_SIZE``) and advances ``range_start`` by the number of
+        rows actually delivered, until ``range_start >= meta.result.total``.
+        (Requesting ``range_end=start+_PAGE_SIZE`` would grow the window every
+        page and re-fetch already-collected rows.)
+        A hard page cap (_MAX_PAGES) bounds the loop even if the
+        server-controlled ``total`` is absurdly large, and the envelope is read
+        with guarded ``.get()`` so a 200-OK response missing ``result``/``data``
+        raises the ValueError contract instead of a bare KeyError.
+
+        Args:
+            path: Path segment after _AW_BASE (e.g., ``"polls"``).
+            params: Base query parameters (e.g., ``{"field_legislature": 111}``).
+                    range_start and range_end are managed internally and will
+                    override any values passed here.
+
+        Returns:
+            Concatenated ``data`` lists from all pages.
+
+        Raises:
+            ValueError: When a page envelope is missing ``meta.result.total`` or
+                        a list ``data``.
+        """
+        # Work from a copy so we don't mutate the caller's dict
+        page_params: dict = dict(params or {})
+        start = 0
+        all_data: list = []
+        total: int | None = None
+        pages = 0
+
+        while total is None or start < total:
+            # Hard page cap — never loop more than _MAX_PAGES times even if
+            # the server advertises an absurd total.
+            if pages >= _MAX_PAGES:
+                logger.warning(
+                    "get_all: page cap _MAX_PAGES=%s hit for path=%r "
+                    "(total advertised=%s, fetched=%s) — stopping pagination early.",
+                    _MAX_PAGES,
+                    path,
+                    total,
+                    len(all_data),
+                )
+                break
+
+            page_params["range_start"] = start
+            # range_end is a ROW COUNT (not an absolute end index): request a
+            # fixed page of _PAGE_SIZE rows. Using start+_PAGE_SIZE here would
+            # request an ever-larger window and re-fetch already-collected rows.
+            page_params["range_end"] = _PAGE_SIZE
+
+            resp = self.get(path, page_params)
+
+            # Guarded envelope access — a 200-OK envelope missing
+            # result/data raises the ValueError contract, not a bare KeyError.
+            meta_result = resp.get("meta", {}).get("result")
+            if not isinstance(meta_result, dict) or "total" not in meta_result:
+                raise ValueError(
+                    f"AW API response for path={path!r} missing meta.result.total"
+                )
+            total = meta_result["total"]
+
+            data = resp.get("data")
+            if not isinstance(data, list):
+                raise ValueError(
+                    f"AW API response for path={path!r} missing or non-list 'data'"
+                )
+
+            all_data.extend(data)
+            pages += 1
+
+            # Advance by the rows ACTUALLY delivered — correct for a full page,
+            # the short final tail, or a server cap below _PAGE_SIZE, and it
+            # never skips or overlaps. A page returning nothing while more rows
+            # are advertised would loop forever, so stop (results may be short).
+            if not data:
+                if total is not None and start < total:
+                    logger.warning(
+                        "get_all: path=%r returned 0 rows at range_start=%s "
+                        "(total advertised=%s) — stopping; results may be incomplete.",
+                        path,
+                        start,
+                        total,
+                    )
+                break
+            start += len(data)
+
+        return all_data
+
+    def get_votes_for_poll(self, poll_id: int) -> list:
+        """Fetch all per-mandate votes for a single poll in one API call.
+
+        The AW votes endpoint returns ~700-750 votes per Bundestag legislature
+        poll.  Using range_end=800 fetches all of them in a single request
+        without pagination, minimising the number of API calls.
+
+        Verified: 19th Bundestag polls have at most ~750 votes (poll 3602 = 709,
+        poll 4539 = 736, poll 5957 = 733) — well within range_end=800.
+
+        The connector is parameterized by AW_LEGISLATURE_ID and is meant
+        to serve other legislatures.  If a poll reports more than _VOTES_RANGE_END
+        total votes, the single-call fetch would silently truncate the vote list
+        and produce wrong tallies/stances.  We read ``meta.result.total`` and
+        RAISE loudly rather than truncate — a multi-legislature correctness guard.
+
+        Args:
+            poll_id: AW integer poll ID (e.g., 3602).
+
+        Returns:
+            The ``data`` list from the votes endpoint response — a list of
+            per-mandate vote dicts each with ``vote``, ``fraction``, ``mandate``,
+            and ``poll`` fields.
+
+        Raises:
+            ValueError: When the votes endpoint reports more total votes than
+                        _VOTES_RANGE_END (would silently truncate).
+        """
+        resp = self.get(
+            "votes",
+            params={"poll": poll_id, "range_start": 0, "range_end": _VOTES_RANGE_END},
+        )
+
+        # A missing/non-int total must itself raise — otherwise the overflow guard below
+        # is silently bypassed and a truncated list could pass through as complete.
+        total = resp.get("meta", {}).get("result", {}).get("total")
+        if not isinstance(total, int):
+            raise ValueError(
+                f"AW votes response for poll {poll_id} has missing/non-int "
+                f"meta.result.total={total!r}; cannot verify the vote list is complete."
+            )
+
+        # Detect overflow — raise instead of silently truncating.
+        if total > _VOTES_RANGE_END:
+            raise ValueError(
+                f"AW poll {poll_id} reports {total} votes, exceeding the "
+                f"single-call window _VOTES_RANGE_END={_VOTES_RANGE_END}. "
+                "Single-call fetch would silently truncate the vote list and "
+                "corrupt tallies. Paginate via get_all or raise the window."
+            )
+
+        data = resp.get("data")
+        if not isinstance(data, list):
+            raise ValueError(
+                f"AW votes response for poll {poll_id} missing or non-list 'data'"
+            )
+        # Detect UNDER-delivery — the endpoint may cap items per response even below
+        # range_end. If fewer than `total` votes came back, tallies would be computed
+        # from a truncated list. Raise rather than silently under-count.
+        if len(data) != total:
+            raise ValueError(
+                f"AW votes for poll {poll_id}: expected {total} votes but received "
+                f"{len(data)} in a single call (server-side page cap?). Tallies would be "
+                "wrong — paginate via get_all instead of a single-call fetch."
+            )
+        return data

--- a/ai-backend/src/ingestion/connectors/abgeordnetenwatch/client.py
+++ b/ai-backend/src/ingestion/connectors/abgeordnetenwatch/client.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -11,8 +11,9 @@ Design goals:
   - Fixed >=2s inter-request delay enforces the <=30 req/min fair-use ceiling
     (simple fixed-spacing pacing).
   - Retrying session with exponential backoff on 429/5xx.
-  - Absolute-index pagination: range_start/range_end are absolute position
-    indices (verified from live API).
+  - Row-count pagination in get_all(): range_end is the NUMBER of rows to
+    return; range_start advances by the rows actually delivered (verified
+    against the live API).
   - meta.status guard: any response with meta.status != 'ok' raises ValueError
     so callers never silently process bad data.
 
@@ -66,7 +67,8 @@ _MAX_RETRIES = 5
 # consumers to identify themselves so they can be contacted about usage).
 _USER_AGENT = "wahl.chat-ingestion/2.0 (https://wahl.chat)"
 
-# Number of items requested per page in get_all() (absolute-index pagination).
+# Rows requested per page in get_all() — range_end is a row COUNT, so every
+# page asks for exactly this many rows (see get_all's pagination notes).
 _PAGE_SIZE = 100
 
 # Hard page cap for get_all().  meta.result.total is server-controlled;
@@ -95,7 +97,7 @@ class AWClient:
     - Fixed >=2s inter-request sleep before each call (<=30 req/min)
     - Retrying session with backoff on 429/5xx
     - meta.status guard — raises ValueError on API error envelopes
-    - Absolute-index pagination in get_all()
+    - Row-count pagination in get_all() (range_end = rows per page)
     - Pinned base URL (SSRF guard)
 
     Usage::

--- a/ai-backend/src/ingestion/connectors/abgeordnetenwatch/connector.py
+++ b/ai-backend/src/ingestion/connectors/abgeordnetenwatch/connector.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -10,8 +10,10 @@ This connector implements the 3-method synchronous ABC
 normalize() — no Firestore, no GCS, no work_queue, no matcher dual-write.
 
 The runner (run.py) owns embed + upsert; this connector is pure data-transform.
-The cursor (since) is derived by the runner from Qdrant max(external_id) for
-"vote_record" and passed to discover() — no watermark methods needed.
+The runner still passes its Qdrant-derived cursor to discover() (ABC contract),
+but discover() deliberately IGNORES it: discovery is a per-legislature
+set-difference against the store (see discover()), which re-surfaces failures
+a max(external_id) watermark would permanently skip.
 
 Security notes:
     GDPR Art. 9 wall: NO code path reads users/{uid}.  This invariant
@@ -93,7 +95,10 @@ class AbgeordnetenwatchVotesConnector(BaseConnector):
                         None (default) reads AW_LEGISLATURE_ID from the
                         environment at CONSTRUCTION time (not import time, so a
                         long-lived process can construct one connector per
-                        legislature), falling back to 111 (19th Bundestag).
+                        legislature). REQUIRED: when neither the argument nor
+                        the env var is set, construction fails — a silent
+                        default would quietly limit a production run to one
+                        historical period while newer periods never ingest.
     """
 
     # Class attribute: used by runner.get_cursor() to scope the Qdrant scroll.
@@ -107,7 +112,17 @@ class AbgeordnetenwatchVotesConnector(BaseConnector):
         # would freeze the value for the process lifetime and force one process
         # invocation per legislature.
         if legislature_id is None:
-            legislature_id = int(os.getenv("AW_LEGISLATURE_ID", "111"))
+            raw_env = os.getenv("AW_LEGISLATURE_ID", "").strip()
+            if not raw_env:
+                raise ValueError(
+                    "AbgeordnetenwatchVotesConnector needs an explicit "
+                    "legislature: pass legislature_id or set AW_LEGISLATURE_ID. "
+                    "There is deliberately no default — every configured period "
+                    "must be run explicitly (the make targets "
+                    "run-abgeordnetenwatch-votes / run-all-landtage-votes loop "
+                    "over all federal / Landtag periods)."
+                )
+            legislature_id = int(raw_env)
         self._legislature_id = legislature_id
 
         cfg = LEGISLATURE_CONFIG.get(legislature_id)
@@ -132,16 +147,26 @@ class AbgeordnetenwatchVotesConnector(BaseConnector):
         # Initialised on first call to _get_qdrant().
         self._qdrant: Optional[QdrantClient] = None
 
+        # Poll ids found in the store but no longer upstream (AW_REFRESH runs
+        # only). fetch() short-circuits these; normalize() maps them to an
+        # authoritative [] so the runner deletes their stored footprint.
+        self._upstream_removed_ids: set[int] = set()
+
     # ------------------------------------------------------------------
     # 1a. Qdrant lazy singleton (per-legislature cursor)
     # ------------------------------------------------------------------
 
     def _get_qdrant(self) -> QdrantClient:
-        """Return the per-instance Qdrant client, initializing on first call.
+        """Return the store client for discovery reads.
 
-        Mirrors the module-level singleton in retrieve.py (lines 52-65).
-        Kept as an instance method so tests can monkeypatch it per-connector.
+        The runner binds its own client via ``bind_store()`` before discover(),
+        so one run has ONE Qdrant contract (discovery reads the same store the
+        upserts target). The self-constructed client exists only for standalone
+        use outside the runner. Kept as an instance method so tests can
+        monkeypatch it per-connector.
         """
+        if self._store_client is not None:
+            return self._store_client
         if self._qdrant is None:
             self._qdrant = QdrantClient(
                 url=os.getenv("QDRANT_URL", "http://localhost:6333"),
@@ -165,6 +190,7 @@ class AbgeordnetenwatchVotesConnector(BaseConnector):
         from src.ingestion.setup_collection import COLLECTION_NAME
 
         qdrant = self._get_qdrant()
+        collection_name = self._store_collection or COLLECTION_NAME
         ingested: set[int] = set()
         next_offset: Optional[qdrant_models.ExtendedPointId] = None
         scroll_filter = qdrant_models.Filter(
@@ -181,7 +207,7 @@ class AbgeordnetenwatchVotesConnector(BaseConnector):
         )
         while True:
             points, next_offset = qdrant.scroll(
-                collection_name=COLLECTION_NAME,
+                collection_name=collection_name,
                 scroll_filter=scroll_filter,
                 limit=1000,
                 offset=next_offset,
@@ -277,10 +303,19 @@ class AbgeordnetenwatchVotesConnector(BaseConnector):
         # AW_REFRESH=1 forces a full reconcile: return ALL polls so run.py's change-aware
         # upsert can re-write any whose content_hash changed (e.g. an AW tally corrected
         # after first ingest). Unchanged polls are skipped there without re-embedding.
+        # A full reconcile also PRUNES: a poll retracted upstream never appears
+        # in the API response again, so the inverse set-difference
+        # (store − source) finds parents whose stored footprint must be
+        # deleted. Those ids are surfaced at the END of the discover output;
+        # fetch()/normalize() turn them into an authoritative empty result.
         refresh = os.getenv("AW_REFRESH", "").strip().lower() in ("1", "true", "yes")
+        self._upstream_removed_ids = set()
         if not refresh:
             ingested_ids = self._get_ingested_poll_ids()
             polls = [p for p in polls if p["id"] not in ingested_ids]
+        else:
+            upstream_ids = {p["id"] for p in polls}
+            self._upstream_removed_ids = self._get_ingested_poll_ids() - upstream_ids
 
         # Optional date floor — read inside discover() so tests can monkeypatch per-call.
         aw_poll_since = os.getenv("AW_POLL_SINCE", "").strip()
@@ -300,7 +335,10 @@ class AbgeordnetenwatchVotesConnector(BaseConnector):
         # polls surface. Sorting by date could reorder the batch window run-to-run.
         # (ids are guaranteed int by the isinstance filter above.)
         polls_sorted = sorted(polls, key=lambda p: p["id"])
-        return [str(p["id"]) for p in polls_sorted]
+        ids = [str(p["id"]) for p in polls_sorted]
+        # Upstream-removed ids last, so live content wins the batch budget.
+        ids.extend(str(i) for i in sorted(self._upstream_removed_ids))
+        return ids
 
     # ------------------------------------------------------------------
     # 2. fetch
@@ -313,10 +351,25 @@ class AbgeordnetenwatchVotesConnector(BaseConnector):
             external_id: String poll id (e.g., "3602").
 
         Returns:
-            Dict with keys "poll" (single poll item) and "votes" (list of vote items).
+            Dict with keys "poll" (single poll item) and "votes" (list of vote
+            items) — or ``{"upstream_removed": True, ...}`` when the poll no
+            longer exists upstream (reconcile-discovered removal or a live
+            404), which normalize() turns into an authoritative empty result
+            so the runner deletes the stored footprint.
         """
+        import requests  # noqa: PLC0415
+
         poll_id = int(external_id)
-        poll_resp = self._client.get(f"polls/{poll_id}")
+        if poll_id in self._upstream_removed_ids:
+            return {"poll": None, "votes": [], "upstream_removed": True}
+        try:
+            poll_resp = self._client.get(f"polls/{poll_id}")
+        except requests.HTTPError as exc:
+            # ONLY an explicit 404 is proof of removal; any other status is a
+            # transient failure and must keep the skip-and-warn semantics.
+            if exc.response is not None and exc.response.status_code == 404:
+                return {"poll": None, "votes": [], "upstream_removed": True}
+            raise
         poll = poll_resp["data"]
         votes = self._client.get_votes_for_poll(poll_id)
         return {"poll": poll, "votes": votes}
@@ -353,6 +406,12 @@ class AbgeordnetenwatchVotesConnector(BaseConnector):
                 unparseable poll date, or belongs to a different legislature
                 than this connector is configured for.
         """
+        # A poll that vanished upstream (reconcile or live 404): return the
+        # authoritative empty list — the runner deletes the stored footprint.
+        # Distinct from the ValueError skips below, which leave the store as-is.
+        if raw.get("upstream_removed"):
+            return []
+
         poll: dict = raw["poll"]
 
         poll_id: int = poll["id"]

--- a/ai-backend/src/ingestion/connectors/abgeordnetenwatch/connector.py
+++ b/ai-backend/src/ingestion/connectors/abgeordnetenwatch/connector.py
@@ -1,0 +1,413 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+AbgeordnetenwatchVotesConnector — synchronous single-pass connector.
+
+This connector implements the 3-method synchronous ABC
+(discover/fetch/normalize) and produces list[ChunkRecord] directly from
+normalize() — no Firestore, no GCS, no work_queue, no matcher dual-write.
+
+The runner (run.py) owns embed + upsert; this connector is pure data-transform.
+The cursor (since) is derived by the runner from Qdrant max(external_id) for
+"vote_record" and passed to discover() — no watermark methods needed.
+
+Security notes:
+    GDPR Art. 9 wall: NO code path reads users/{uid}.  This invariant
+    is enforced by a grep-based static test in test_connector.py::TestGdprWall.
+
+    Skip-and-warn on zero-tally: a poll producing zero usable tallies
+    raises ValueError so run_connector skip-and-continue applies; the cursor
+    does not advance past it (idempotent upsert handles re-processing).
+
+    external_id integer index: normalize() stamps raw int poll_id
+    (no "aw_poll:" prefix) so the Qdrant integer cursor stays sound.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from dataclasses import dataclass
+from datetime import date as date_type
+from typing import Optional
+
+from qdrant_client import QdrantClient
+
+from src.ingestion.connector import BaseConnector
+from src.ingestion.connectors.abgeordnetenwatch.client import AWClient
+from src.ingestion.connectors.abgeordnetenwatch.legislature_config import (
+    LEGISLATURE_CONFIG,
+)
+from src.ingestion.connectors.abgeordnetenwatch.mappers import corpus as corpus_mapper
+from src.ingestion.ids import compute_source_item_id
+from src.ingestion.schemas import AuthorityTier, ChunkRecord, SourceType
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Zero-polls grace window (days since the period's date_from). A legitimately
+# NEW term (e.g. BW/RP 2026-2031 in their first weeks) plausibly has zero polls
+# for a while — only a period older than this window turns "zero polls from the
+# API" into a hard misconfiguration error.
+_ZERO_POLLS_GRACE_DAYS = 90
+
+
+@dataclass(frozen=True)
+class _SourceItem:
+    """Frozen source-item envelope fed to corpus_mapper.chunk_poll().
+
+    Satisfies the structural SourceItemLike protocol in mappers/corpus.py —
+    the five attributes chunk_poll() reads from its first argument.
+    """
+
+    source_item_id: uuid.UUID
+    region: str
+    authority_tier: AuthorityTier
+    source_type: SourceType
+    publish_date: date_type
+
+
+# ---------------------------------------------------------------------------
+# AbgeordnetenwatchVotesConnector
+# ---------------------------------------------------------------------------
+
+
+class AbgeordnetenwatchVotesConnector(BaseConnector):
+    """Connector for Abgeordnetenwatch poll votes → vote_record ChunkRecords.
+
+    Synchronous single-pass connector:
+        discover(since) → fetch → normalize → [runner embeds + upserts]
+
+    The cursor (since) is the max external_id (raw integer poll_id) already
+    committed to Qdrant for "vote_record", derived by the runner via
+    get_cursor().  No Firestore, no GCS, no work queue.
+
+    Args:
+        legislature_id: AW legislature (parliament_period) ID to scope discovery.
+                        None (default) reads AW_LEGISLATURE_ID from the
+                        environment at CONSTRUCTION time (not import time, so a
+                        long-lived process can construct one connector per
+                        legislature), falling back to 111 (19th Bundestag).
+    """
+
+    # Class attribute: used by runner.get_cursor() to scope the Qdrant scroll.
+    source_type: str = SourceType.VOTE_RECORD.value
+
+    def __init__(
+        self,
+        legislature_id: Optional[int] = None,
+    ) -> None:
+        # Env read lives in the __init__ BODY: an import-time default arg
+        # would freeze the value for the process lifetime and force one process
+        # invocation per legislature.
+        if legislature_id is None:
+            legislature_id = int(os.getenv("AW_LEGISLATURE_ID", "111"))
+        self._legislature_id = legislature_id
+
+        cfg = LEGISLATURE_CONFIG.get(legislature_id)
+        if cfg is None:
+            raise ValueError(
+                f"Legislature {legislature_id} not in LEGISLATURE_CONFIG. "
+                f"Add a LegislatureConfig row in legislature_config.py before running."
+            )
+        # Period key (globally unique AW parliament_period int).
+        self._period_id: int = cfg.parliament_period_id
+        # ISO 3166-2 region code (e.g. "DE-BY" for Bayern, "DE" for Bundestag).
+        self._region: str = cfg.region
+        # German Wahlperiode number (Bundestag rows only; None for Landtage).
+        self._wahlperiode: Optional[int] = cfg.wahlperiode
+        # Period start date — drives the zero-polls grace window.
+        self._period_date_from: str = cfg.date_from
+
+        # Paced AW API client.
+        self._client = AWClient()
+
+        # Lazy Qdrant client for per-legislature cursor queries.
+        # Initialised on first call to _get_qdrant().
+        self._qdrant: Optional[QdrantClient] = None
+
+    # ------------------------------------------------------------------
+    # 1a. Qdrant lazy singleton (per-legislature cursor)
+    # ------------------------------------------------------------------
+
+    def _get_qdrant(self) -> QdrantClient:
+        """Return the per-instance Qdrant client, initializing on first call.
+
+        Mirrors the module-level singleton in retrieve.py (lines 52-65).
+        Kept as an instance method so tests can monkeypatch it per-connector.
+        """
+        if self._qdrant is None:
+            self._qdrant = QdrantClient(
+                url=os.getenv("QDRANT_URL", "http://localhost:6333"),
+                api_key=os.getenv("QDRANT_API_KEY"),
+            )
+        return self._qdrant
+
+    def _get_ingested_poll_ids(self) -> set[int]:
+        """Return the set of AW poll ids already ingested for this legislature.
+
+        Scrolls all vote_record chunks filtered by legislature_period_id and collects
+        their external_id (= AW poll id). Used for set-difference discovery.
+
+        This replaces a max(external_id) high-water mark, which permanently lost any
+        poll that was skipped/failed below the max on a prior run (the max advanced past
+        it and the strict ``id > cursor`` filter never re-surfaced it). Set-difference is
+        gap-free and self-healing: a poll missing from Qdrant is always re-attempted, and
+        a permanently-unprocessable poll simply stays absent without blocking newer polls.
+        """
+        from qdrant_client import models as qdrant_models
+        from src.ingestion.setup_collection import COLLECTION_NAME
+
+        qdrant = self._get_qdrant()
+        ingested: set[int] = set()
+        next_offset: Optional[qdrant_models.ExtendedPointId] = None
+        scroll_filter = qdrant_models.Filter(
+            must=[
+                qdrant_models.FieldCondition(
+                    key="source_type",
+                    match=qdrant_models.MatchValue(value="vote_record"),
+                ),
+                qdrant_models.FieldCondition(
+                    key="legislature_period_id",
+                    match=qdrant_models.MatchValue(value=self._period_id),
+                ),
+            ]
+        )
+        while True:
+            points, next_offset = qdrant.scroll(
+                collection_name=COLLECTION_NAME,
+                scroll_filter=scroll_filter,
+                limit=1000,
+                offset=next_offset,
+                with_payload=["external_id"],
+                with_vectors=False,
+            )
+            for p in points:
+                ext = p.payload.get("external_id") if p.payload else None
+                if isinstance(ext, int):
+                    ingested.add(ext)
+            if next_offset is None:
+                break
+        return ingested
+
+    # ------------------------------------------------------------------
+    # 1b. discover — scoped to one legislature, per-legislature cursor
+    # ------------------------------------------------------------------
+
+    def discover(self, since: Optional[int]) -> list[str]:
+        """Return poll ids to process for the configured legislature.
+
+        Scopes to field_legislature.  Discovers via per-legislature SET DIFFERENCE
+        against Qdrant (polls in the AW API minus polls already ingested) instead of the
+        global `since` from run_connector() — the global cursor is dominated by high-ID
+        Bundestag polls and would silently skip all lower-ID Landtag polls, and a max
+        watermark permanently loses any poll skipped below the max on an earlier run.
+
+        The global `since` argument from run_connector() is accepted (preserves
+        the ABC contract) but IGNORED — set-difference supersedes it.
+
+        Fail-fast (with grace window): zero polls from the raw API response is
+        checked BEFORE the set-difference filter (a set-difference-filtered-to-empty
+        result is normal on incremental runs). It raises ValueError ONLY when the
+        configured period's date_from is older than _ZERO_POLLS_GRACE_DAYS —
+        a legitimately NEW term (e.g. BW/RP right after their 2026 elections)
+        plausibly has zero polls for weeks; in that case a warning is logged and
+        [] is returned instead of aborting with a misleading
+        "wrong parliament_period_id" error.
+
+        Args:
+            since: Global max external_id for "vote_record" from run_connector().
+                   Accepted for ABC-contract compatibility but not used
+                   (per-legislature set-difference supersedes it).
+
+        Returns:
+            List of poll id strings sorted ascending by integer poll ID for a stable,
+            deterministic batch order across runs.
+        """
+        legislature_id = self._legislature_id
+
+        # Fetch all polls for this legislature.
+        polls = self._client.get_all("polls", {"field_legislature": legislature_id})
+
+        # Fail-fast with grace window: zero polls from the raw API response
+        # usually means a misconfigured parliament_period_id in LEGISLATURE_CONFIG.
+        # MUST check BEFORE the set-difference filter — a set-difference-filtered-
+        # to-empty result is normal on incremental runs. Exception: a legitimately
+        # NEW term (period started within _ZERO_POLLS_GRACE_DAYS) plausibly has
+        # zero polls for weeks — warn and return [] instead of aborting.
+        if not polls:
+            period_start = date_type.fromisoformat(self._period_date_from)
+            period_age_days = (date_type.today() - period_start).days
+            if period_age_days > _ZERO_POLLS_GRACE_DAYS:
+                raise ValueError(
+                    f"AW legislature {legislature_id} ({self._region}) returned zero polls "
+                    f"from the API and its period started {period_age_days} days ago "
+                    f"(> {_ZERO_POLLS_GRACE_DAYS}-day grace window). This usually means a "
+                    f"wrong parliament_period_id in LEGISLATURE_CONFIG. "
+                    f"Expected >0 polls for an established legislature."
+                )
+            logger.warning(
+                "AW legislature %s (%s) returned zero polls, but its period started "
+                "only %s days ago (<= %s-day grace window) — likely a legitimately "
+                "new term with no polls yet. Returning no work.",
+                legislature_id,
+                self._region,
+                period_age_days,
+                _ZERO_POLLS_GRACE_DAYS,
+            )
+            return []
+
+        # Drop malformed poll entries whose id is not an int (untrusted AW payload).
+        # Applied on BOTH the incremental and the AW_REFRESH path — a
+        # non-int id would crash str(p["id"]) sorting / fetch downstream.
+        polls = [p for p in polls if isinstance(p.get("id"), int)]
+
+        # Set-difference discovery: ingest polls present in the AW API but not yet in
+        # Qdrant for this legislature. Gap-free and self-healing — a poll skipped/failed
+        # on a prior run stays missing and is retried, and a permanently-unprocessable
+        # poll keeps failing harmlessly without blocking newer polls (no high-water mark
+        # to corrupt).
+        #
+        # AW_REFRESH=1 forces a full reconcile: return ALL polls so run.py's change-aware
+        # upsert can re-write any whose content_hash changed (e.g. an AW tally corrected
+        # after first ingest). Unchanged polls are skipped there without re-embedding.
+        refresh = os.getenv("AW_REFRESH", "").strip().lower() in ("1", "true", "yes")
+        if not refresh:
+            ingested_ids = self._get_ingested_poll_ids()
+            polls = [p for p in polls if p["id"] not in ingested_ids]
+
+        # Optional date floor — read inside discover() so tests can monkeypatch per-call.
+        aw_poll_since = os.getenv("AW_POLL_SINCE", "").strip()
+        if aw_poll_since:
+            # Plain string compare is valid for zero-padded YYYY-MM-DD dates.
+            # Polls with a missing/empty field_poll_date are excluded when the floor is set.
+            polls = [
+                p
+                for p in polls
+                if (p.get("field_poll_date") or "") >= aw_poll_since
+                and (p.get("field_poll_date") or "") != ""
+            ]
+
+        # Sort ASCENDING BY INTEGER POLL ID (not by field_poll_date) for a stable,
+        # deterministic batch order. run.py processes the first batch_size ids per run;
+        # on the next run those are ingested and drop out of the set-difference, so newer
+        # polls surface. Sorting by date could reorder the batch window run-to-run.
+        # (ids are guaranteed int by the isinstance filter above.)
+        polls_sorted = sorted(polls, key=lambda p: p["id"])
+        return [str(p["id"]) for p in polls_sorted]
+
+    # ------------------------------------------------------------------
+    # 2. fetch
+    # ------------------------------------------------------------------
+
+    def fetch(self, external_id: str) -> dict:
+        """Fetch raw poll + votes payload for a single poll_id.
+
+        Args:
+            external_id: String poll id (e.g., "3602").
+
+        Returns:
+            Dict with keys "poll" (single poll item) and "votes" (list of vote items).
+        """
+        poll_id = int(external_id)
+        poll_resp = self._client.get(f"polls/{poll_id}")
+        poll = poll_resp["data"]
+        votes = self._client.get_votes_for_poll(poll_id)
+        return {"poll": poll, "votes": votes}
+
+    # ------------------------------------------------------------------
+    # 3. normalize — returns list[ChunkRecord] directly
+    # ------------------------------------------------------------------
+
+    def normalize(self, raw: dict) -> list[ChunkRecord]:
+        """Build ChunkRecords directly from poll + votes payload.
+
+        No SourceItemRecord, no matcher objects, no Firestore.
+        The whole record build lives in corpus_mapper.chunk_poll(): topic
+        extraction, relevance_levels derivation, envelope stamping (external_id
+        = raw int poll_id, wahlperiode, legislature_period_id, region) and the
+        envelope-inclusive content_hash. This method owns only the connector
+        concerns: the legislature cross-check, publish_date parsing, the
+        source-item stub, and raising ValueError on unusable input.
+
+        Zero-tally guard:
+            If the poll produces zero usable fraction tallies (all votes have
+            fraction=[]), chunk_poll() returns an empty list and this method
+            raises ValueError.
+
+        Args:
+            raw: Dict with keys "poll" (poll item dict) and "votes" (list).
+
+        Returns:
+            list[ChunkRecord] — one fully-stamped chunk per poll from
+            chunk_poll(), each with external_id = poll_id (raw int).
+
+        Raises:
+            ValueError: If the poll has zero usable fraction tallies, an
+                unparseable poll date, or belongs to a different legislature
+                than this connector is configured for.
+        """
+        poll: dict = raw["poll"]
+
+        poll_id: int = poll["id"]
+
+        # Legislature cross-check: an operator error (e.g. fetching a
+        # Bundestag poll under a Bayern connector) would silently stamp the
+        # wrong region/legislature_period_id, so refuse rather than mislabel.
+        poll_legislature_id = (poll.get("field_legislature") or {}).get("id")
+        if poll_legislature_id != self._legislature_id:
+            raise ValueError(
+                f"AW poll {poll_id} belongs to legislature {poll_legislature_id!r} "
+                f"but this connector is configured for legislature "
+                f"{self._legislature_id} ({self._region}) — refusing to stamp a "
+                f"foreign-legislature poll (skipping)."
+            )
+
+        poll_date_str: str = poll.get("field_poll_date") or ""
+        try:
+            publish_date = date_type.fromisoformat(poll_date_str)
+        except (ValueError, TypeError):
+            # A missing/unparseable poll date makes publish_date non-deterministic;
+            # raise rather than fabricate date.today().
+            raise ValueError(
+                f"AW poll {poll_id} has missing or unparseable field_poll_date "
+                f"{poll_date_str!r} — skipping to avoid fabricated publish_date."
+            )
+
+        # external_id_str for UUID determinism (raw integer, no prefix)
+        external_id_str = str(poll_id)
+        source_item_id = compute_source_item_id("vote_record", external_id_str)
+
+        stub = _SourceItem(
+            source_item_id=source_item_id,
+            region=self._region,  # from LegislatureConfig
+            authority_tier=AuthorityTier.FACTUAL_RECORD,
+            source_type=SourceType.VOTE_RECORD,
+            publish_date=publish_date,
+        )
+
+        # chunk_poll produces ONE fully-stamped ChunkRecord per poll (the
+        # tallies live inside meta.vote_results, not one chunk per fraction).
+        chunks = corpus_mapper.chunk_poll(
+            stub,
+            raw,
+            wahlperiode=self._wahlperiode,  # None for Landtage
+            legislature_period_id=self._period_id,  # from LegislatureConfig
+        )
+
+        # Zero-tally guard — chunk_poll returns [] when aggregate_fraction_tallies
+        # finds no usable tallies; surface it as the runner's skip contract.
+        if not chunks:
+            raise ValueError(
+                f"AW poll {poll_id} has zero usable tallies — "
+                "all votes have fraction=[] or no votes at all. "
+                "Skipping poll."
+            )
+
+        return chunks

--- a/ai-backend/src/ingestion/connectors/abgeordnetenwatch/legislature_config.py
+++ b/ai-backend/src/ingestion/connectors/abgeordnetenwatch/legislature_config.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -245,6 +245,24 @@ LEGISLATURE_CONFIG: dict[int, LegislatureConfig] = {
 # ---------------------------------------------------------------------------
 LANDTAG_LEGISLATURE_IDS: list[int] = [
     key for key, cfg in LEGISLATURE_CONFIG.items() if cfg.region != "DE"
+]
+
+# ---------------------------------------------------------------------------
+# FEDERAL_LEGISLATURE_IDS — the Bundestag periods the default ingestion loop
+# runs: CURRENT + PRIOR (the two newest region-"DE" rows by date_from),
+# matching the Landtag depth policy. Derived from LEGISLATURE_CONFIG so the
+# Makefile loop can never drift from the config; the connector requires an
+# explicit AW_LEGISLATURE_ID, so a silent lone-default period cannot recur.
+# Older configured periods (e.g. the 19th Bundestag row, which also anchors
+# the golden test fixtures) stay runnable via an explicit AW_LEGISLATURE_ID
+# but are NOT part of the default corpus.
+# ---------------------------------------------------------------------------
+FEDERAL_LEGISLATURE_IDS: list[int] = [
+    key
+    for key, _cfg in sorted(
+        ((k, c) for k, c in LEGISLATURE_CONFIG.items() if c.region == "DE"),
+        key=lambda kv: kv[1].date_from,
+    )[-2:]
 ]
 
 

--- a/ai-backend/src/ingestion/connectors/abgeordnetenwatch/legislature_config.py
+++ b/ai-backend/src/ingestion/connectors/abgeordnetenwatch/legislature_config.py
@@ -1,0 +1,351 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Versioned configuration for all supported AW parliament periods.
+
+IDs were fetched once from the AW v2 API (2026-06-25) via:
+  GET /parliaments  → 18 parliaments (Bundestag, EU-Parlament, 16 Landtage)
+  GET /parliament-periods?parliament={id}&type=legislature
+  → selected current period (most recent end_date_period > 2026-06-25)
+
+These IDs are authoritative and never re-fetched at runtime.  To add a prior
+period or a newly created Landtag period, add a row and increment nothing else.
+
+All IDs are VERIFIED from the AW v2 public CC0 API.
+
+Key:   parliament_period_id (AW integer — the dict key used by
+       ``field_legislature`` in the polls endpoint; globally unique).
+       This is also the value stamped as ``legislature_period_id`` on every
+       vote_record ChunkRecord.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class LegislatureConfig:
+    """Static config for one AW parliament period.
+
+    Attributes:
+        parliament_period_id: AW period ID (period key; also cursor scope key).
+                              The dict key in LEGISLATURE_CONFIG.
+        region:               ISO 3166-2 code, e.g. ``"DE-BY"`` or ``"DE"`` for federal.
+        label:                AW period label, e.g. ``"Bayern 2023 - 2028"``.
+        date_from:            ISO date string of period start (start_date_period).
+        date_to:              ISO date string of period end (end_date_period), or None.
+        wahlperiode:          German Wahlperiode number for Bundestag periods
+                              (e.g. 20 for the 20th Bundestag). None for Länder —
+                              state Wahlperiode ints collide across states, so
+                              Landtag chunks never carry one.
+    """
+
+    parliament_period_id: int
+    region: str
+    label: str
+    date_from: str
+    date_to: Optional[str]
+    wahlperiode: Optional[int] = None
+
+
+# ---------------------------------------------------------------------------
+# LEGISLATURE_CONFIG — single source of truth for all supported legislatures.
+#
+# To add a prior legislature period: add a row here. No other code change needed.
+# To add a new Landtag election: add the new parliament_period row from the AW API
+# (GET /parliament-periods?parliament={parl_id}&type=legislature) and update
+# the existing row's date_to to the end_date_period of the outgoing period.
+# ---------------------------------------------------------------------------
+LEGISLATURE_CONFIG: dict[int, LegislatureConfig] = {
+    # -----------------------------------------------------------------------
+    # Bundestag — wahlperiode is the sole source of the Wahlperiode number.
+    # Verified: AW API parliament-periods/{id} (2026-06-25)
+    # -----------------------------------------------------------------------
+    111: LegislatureConfig(
+        111, "DE", "Bundestag 2017 - 2021", "2017-10-24", "2021-10-25", wahlperiode=19
+    ),
+    132: LegislatureConfig(
+        132, "DE", "Bundestag 2021 - 2025", "2021-10-26", "2025-03-24", wahlperiode=20
+    ),
+    161: LegislatureConfig(
+        161, "DE", "Bundestag 2025 - 2029", "2025-03-25", "2029-02-22", wahlperiode=21
+    ),
+    # -----------------------------------------------------------------------
+    # Landtage — current legislature period each (IDs VERIFIED from AW API, 2026-06-25).
+    # region derived via region_for_period(label) from manifestos/mappers/corpus.py.
+    # Sorted by AW parliament ID for readability.
+    # -----------------------------------------------------------------------
+    # Berlin (parliament_id=2)
+    133: LegislatureConfig(
+        133, "DE-BE", "Berlin 2021 - 2026", "2021-10-04", "2026-10-25"
+    ),
+    # Prior term. VERIFIED from AW v2 CC0 API
+    # (GET /parliament-periods?parliament=2&type=legislature) 2026-07-24.
+    107: LegislatureConfig(
+        107, "DE-BE", "Berlin 2016 - 2021", "2016-10-27", "2021-10-03"
+    ),
+    # Hamburg (parliament_id=3)
+    162: LegislatureConfig(
+        162, "DE-HH", "Hamburg 2025 - 2029", "2025-03-26", "2029-05-03"
+    ),
+    # Prior term. VERIFIED from AW v2 CC0 API
+    # (GET /parliament-periods?parliament=3&type=legislature) 2026-07-24.
+    122: LegislatureConfig(
+        122, "DE-HH", "Hamburg 2020 - 2025", "2020-03-18", "2025-03-25"
+    ),
+    # Nordrhein-Westfalen (parliament_id=4)
+    139: LegislatureConfig(
+        139, "DE-NW", "Nordrhein-Westfalen 2022 - 2027", "2022-06-01", "2027-05-30"
+    ),
+    # Prior term. VERIFIED from AW v2 CC0 API
+    # (GET /parliament-periods?parliament=4&type=legislature) 2026-07-24.
+    109: LegislatureConfig(
+        109, "DE-NW", "Nordrhein-Westfalen 2017 - 2022", "2017-06-01", "2022-05-31"
+    ),
+    # Baden-Württemberg (parliament_id=6)
+    165: LegislatureConfig(
+        165, "DE-BW", "Baden-Württemberg 2026 - 2031", "2026-05-12", "2031-05-20"
+    ),
+    # OUTGOING term: the 2021–2026 legislature whose voting record voters want
+    # around the 2026 election. Retained ALONGSIDE 165 so the two-pass split can
+    # separate them by publish_date. IDs/dates VERIFIED from AW v2 CC0 API
+    # (GET /parliament-periods?parliament=6&type=legislature) 2026-07-09.
+    126: LegislatureConfig(
+        126, "DE-BW", "Baden-Württemberg 2021 - 2026", "2021-05-11", "2026-05-11"
+    ),
+    # PRIOR term (pre-outgoing): votes here have publish_date < 2021-05-11, so they land
+    # in the HISTORIC bucket of a 2026 BW chat (the election-date "containing" tiebreak
+    # still resolves the CURRENT window to the outgoing 126 term). IDs/dates VERIFIED from
+    # AW v2 CC0 API (GET /parliament-periods?parliament=6&type=legislature) 2026-07-09.
+    105: LegislatureConfig(
+        105, "DE-BW", "Baden-Württemberg 2016 - 2021", "2016-05-11", "2021-05-10"
+    ),
+    # Rheinland-Pfalz (parliament_id=7)
+    166: LegislatureConfig(
+        166, "DE-RP", "Rheinland-Pfalz 2026 - 2031", "2026-05-18", "2031-05-31"
+    ),
+    # OUTGOING term: the 2021–2026 legislature retained for pre/around-election
+    # voting-record retrieval, alongside the post-election 166. IDs/dates VERIFIED
+    # from AW v2 CC0 API (GET /parliament-periods?parliament=7&type=legislature) 2026-07-09.
+    127: LegislatureConfig(
+        127, "DE-RP", "Rheinland-Pfalz 2021 - 2026", "2021-03-12", "2026-05-18"
+    ),
+    # Sachsen-Anhalt (parliament_id=8)
+    131: LegislatureConfig(
+        131, "DE-ST", "Sachsen-Anhalt 2021 - 2026", "2021-07-06", "2026-10-06"
+    ),
+    # Prior term. VERIFIED from AW v2 CC0 API
+    # (GET /parliament-periods?parliament=8&type=legislature) 2026-07-24.
+    114: LegislatureConfig(
+        114, "DE-ST", "Sachsen-Anhalt 2016 - 2021", "2016-04-12", "2021-07-05"
+    ),
+    # Mecklenburg-Vorpommern (parliament_id=9)
+    134: LegislatureConfig(
+        134, "DE-MV", "Mecklenburg-Vorpommern 2021 - 2026", "2021-10-26", "2026-10-25"
+    ),
+    # Prior term. VERIFIED from AW v2 CC0 API
+    # (GET /parliament-periods?parliament=9&type=legislature) 2026-07-24.
+    108: LegislatureConfig(
+        108, "DE-MV", "Mecklenburg-Vorpommern 2016 - 2021", "2016-10-04", "2021-10-25"
+    ),
+    # Bremen (parliament_id=10)
+    146: LegislatureConfig(
+        146, "DE-HB", "Bremen 2023 - 2027", "2023-06-29", "2027-06-01"
+    ),
+    # Prior term. VERIFIED from AW v2 CC0 API
+    # (GET /parliament-periods?parliament=10&type=legislature) 2026-07-24.
+    118: LegislatureConfig(
+        118, "DE-HB", "Bremen 2019 - 2023", "2019-07-03", "2023-06-28"
+    ),
+    # Hessen (parliament_id=11)
+    150: LegislatureConfig(
+        150, "DE-HE", "Hessen 2024 - 2029", "2024-01-18", "2029-01-31"
+    ),
+    # Prior term. VERIFIED from AW v2 CC0 API
+    # (GET /parliament-periods?parliament=11&type=legislature) 2026-07-24.
+    116: LegislatureConfig(
+        116, "DE-HE", "Hessen 2019 - 2024", "2019-01-18", "2024-01-17"
+    ),
+    # Niedersachsen (parliament_id=12)
+    143: LegislatureConfig(
+        143, "DE-NI", "Niedersachsen 2022 - 2027", "2022-11-08", "2027-11-18"
+    ),
+    # Prior term. VERIFIED from AW v2 CC0 API
+    # (GET /parliament-periods?parliament=12&type=legislature) 2026-07-24.
+    112: LegislatureConfig(
+        112, "DE-NI", "Niedersachsen 2017 - 2022", "2017-11-14", "2022-11-07"
+    ),
+    # Bayern (parliament_id=13) — empirical check confirmed ~149
+    149: LegislatureConfig(
+        149, "DE-BY", "Bayern 2023 - 2028", "2023-10-26", "2028-10-31"
+    ),
+    # Prior term. VERIFIED from AW v2 CC0 API
+    # (GET /parliament-periods?parliament=13&type=legislature) 2026-07-24.
+    115: LegislatureConfig(
+        115, "DE-BY", "Bayern 2018 - 2023", "2018-11-02", "2023-10-25"
+    ),
+    # Saarland (parliament_id=14)
+    137: LegislatureConfig(
+        137, "DE-SL", "Saarland 2022 - 2027", "2022-04-25", "2027-03-27"
+    ),
+    # Prior term. VERIFIED from AW v2 CC0 API
+    # (GET /parliament-periods?parliament=14&type=legislature) 2026-07-24.
+    113: LegislatureConfig(
+        113, "DE-SL", "Saarland 2017 - 2022", "2017-04-25", "2022-04-24"
+    ),
+    # Thüringen (parliament_id=15)
+    156: LegislatureConfig(
+        156, "DE-TH", "Thüringen 2024 - 2029", "2024-09-26", "2029-09-30"
+    ),
+    # Prior term. VERIFIED from AW v2 CC0 API
+    # (GET /parliament-periods?parliament=15&type=legislature) 2026-07-24.
+    121: LegislatureConfig(
+        121, "DE-TH", "Thüringen 2019 - 2024", "2019-11-26", "2024-09-26"
+    ),
+    # Brandenburg (parliament_id=16)
+    158: LegislatureConfig(
+        158, "DE-BB", "Brandenburg 2024 - 2029", "2024-10-17", "2029-10-22"
+    ),
+    # Prior term. VERIFIED from AW v2 CC0 API
+    # (GET /parliament-periods?parliament=16&type=legislature) 2026-07-24.
+    120: LegislatureConfig(
+        120, "DE-BB", "Brandenburg 2019 - 2024", "2019-09-02", "2024-10-16"
+    ),
+    # Sachsen (parliament_id=17)
+    157: LegislatureConfig(
+        157, "DE-SN", "Sachsen 2024 - 2029", "2024-10-01", "2029-09-30"
+    ),
+    # Prior term. VERIFIED from AW v2 CC0 API
+    # (GET /parliament-periods?parliament=17&type=legislature) 2026-07-24.
+    119: LegislatureConfig(
+        119, "DE-SN", "Sachsen 2019 - 2024", "2019-10-01", "2024-09-30"
+    ),
+    # Schleswig-Holstein (parliament_id=18)
+    138: LegislatureConfig(
+        138, "DE-SH", "Schleswig-Holstein 2022 - 2027", "2022-06-07", "2027-05-30"
+    ),
+    # Prior term. VERIFIED from AW v2 CC0 API
+    # (GET /parliament-periods?parliament=18&type=legislature) 2026-07-24.
+    110: LegislatureConfig(
+        110, "DE-SH", "Schleswig-Holstein 2017 - 2022", "2017-06-06", "2022-06-06"
+    ),
+}
+
+# ---------------------------------------------------------------------------
+# LANDTAG_LEGISLATURE_IDS — all Landtag parliament_period IDs.
+# Derived from LEGISLATURE_CONFIG: any entry with region != "DE" is a Landtag.
+# Includes the OUTGOING BW/RP 2021–2026 terms (126/127) alongside
+# the post-election 165/166 rows. Currently consumed by tests; an operator
+# ingesting all Landtage runs the connector once per id (AW_LEGISLATURE_ID).
+# ---------------------------------------------------------------------------
+LANDTAG_LEGISLATURE_IDS: list[int] = [
+    key for key, cfg in LEGISLATURE_CONFIG.items() if cfg.region != "DE"
+]
+
+
+# ---------------------------------------------------------------------------
+# Term-window derivation.
+#
+# The two-pass temporal retrieval needs a concrete [term_start, term_end]
+# window per chat context to split "current" (publish_date inside the window)
+# from "historic" (publish_date before it). State contexts carry a region_path
+# but NOT the window.
+#
+# WHY derive from this config instead of stamping the window on ``Context``:
+#   - ``Context`` is a broad, cross-cutting schema; adding a term window there
+#     couples every caller to a temporal concept only retrieval needs.
+#   - This module is already the single source of truth for period date ranges,
+#     so deriving here keeps one authority for "what dates does term X span".
+#   - The helper is pure (no network, no Qdrant), cheap to call per request
+#     (an in-memory scan over ~20 rows), and trivially unit-testable.
+# ---------------------------------------------------------------------------
+
+# Far-future UTC sentinel for open-ended periods (date_to is None → still current).
+# Chosen as datetime.max so any real publish_date compares as "inside the window".
+TERM_END_SENTINEL: datetime = datetime.max.replace(tzinfo=timezone.utc)
+
+
+def _to_utc_datetime(iso: Optional[str]) -> datetime:
+    """Parse an ISO date string to a tz-aware UTC datetime.
+
+    ``None`` (open-ended period) maps to :data:`TERM_END_SENTINEL`.
+    """
+    if iso is None:
+        return TERM_END_SENTINEL
+    return datetime.fromisoformat(iso).replace(tzinfo=timezone.utc)
+
+
+def _row_window(cfg: LegislatureConfig) -> tuple[datetime, datetime]:
+    """Return a row's (term_start, term_end) as tz-aware UTC datetimes."""
+    return _to_utc_datetime(cfg.date_from), _to_utc_datetime(cfg.date_to)
+
+
+def term_window_for_context(
+    region_path: Optional[list[str]],
+    legislature_period_id: Optional[int],
+    election_date: Optional[date] = None,
+) -> Optional[tuple[datetime, datetime]]:
+    """Derive the ``[term_start, term_end]`` window for a chat context.
+
+    Resolution order:
+      1. If ``legislature_period_id`` names a row in :data:`LEGISLATURE_CONFIG`,
+         use that row — unambiguous. Covers federal contexts and any context
+         that already names its term (AW vote-record precision filter).
+      2. Otherwise, if ``region_path`` is set, take the most-specific element
+         (``region_path[-1]``) and gather rows whose ``region`` equals it:
+           - none  → return ``None`` (caller falls back to single-pass).
+           - one   → use that row.
+           - many  → deterministic tiebreak (see below).
+
+    Multi-period tiebreak (e.g. DE-BW / DE-RP, where a region has both the
+    outgoing 2021–2026 term and the post-2026 term): pick the row whose
+    ``[date_from, date_to]`` **contains**
+    ``election_date``; else the **latest row ending on/before** ``election_date``;
+    else (no ``election_date`` given, or none qualifies) the **latest row by
+    date_to**. This deterministically prefers the OUTGOING term around an
+    election while never returning an arbitrary row.
+
+    Returned datetimes are tz-aware UTC; ``date_to=None`` maps to
+    :data:`TERM_END_SENTINEL`. Returns ``None`` when nothing resolves.
+
+    Pure function: no network, no Qdrant, safe to call per request.
+    """
+    # (1) Explicit period id — unambiguous when it is a known key.
+    if legislature_period_id is not None:
+        cfg = LEGISLATURE_CONFIG.get(legislature_period_id)
+        if cfg is not None:
+            return _row_window(cfg)
+        # Unknown id: fall through to region-based resolution.
+
+    # (2) Region-based resolution on the most-specific path element.
+    if not region_path:
+        return None
+    local = region_path[-1]
+    rows = [cfg for cfg in LEGISLATURE_CONFIG.values() if cfg.region == local]
+    if not rows:
+        return None
+    if len(rows) == 1:
+        return _row_window(rows[0])
+
+    # Multiple periods for this region — deterministic tiebreak.
+    def _start(cfg: LegislatureConfig) -> date:
+        return date.fromisoformat(cfg.date_from)
+
+    def _end(cfg: LegislatureConfig) -> date:
+        return date.fromisoformat(cfg.date_to) if cfg.date_to else date.max
+
+    if election_date is not None:
+        containing = [c for c in rows if _start(c) <= election_date <= _end(c)]
+        if containing:
+            return _row_window(max(containing, key=_end))
+        ended_before = [c for c in rows if _end(c) <= election_date]
+        if ended_before:
+            return _row_window(max(ended_before, key=_end))
+
+    # Final deterministic fallback: the latest term by end date.
+    return _row_window(max(rows, key=_end))

--- a/ai-backend/src/ingestion/connectors/abgeordnetenwatch/mappers/__init__.py
+++ b/ai-backend/src/ingestion/connectors/abgeordnetenwatch/mappers/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""Pure transform mappers for the Abgeordnetenwatch connector.
+
+All functions in this sub-package are I/O-free (no network, no Firestore, no
+filesystem reads) and deterministic — suitable for unit testing without mocks.
+
+Modules:
+  stance.py  — aggregate_fraction_tallies(votes) -> dict[int, FractionTally]
+               derive_stance(yes, no, abstain, no_show) -> Stance
+               fraction_to_party_slug(fraction_id, fraction_map) -> str
+               build_qsp(poll, fraction_id, tally, source_item_id, fraction_map) -> QuestionStancePair
+  corpus.py  — chunk_poll(source_item, raw) -> list[ChunkRecord]
+"""

--- a/ai-backend/src/ingestion/connectors/abgeordnetenwatch/mappers/__init__.py
+++ b/ai-backend/src/ingestion/connectors/abgeordnetenwatch/mappers/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -11,6 +11,5 @@ Modules:
   stance.py  — aggregate_fraction_tallies(votes) -> dict[int, FractionTally]
                derive_stance(yes, no, abstain, no_show) -> Stance
                fraction_to_party_slug(fraction_id, fraction_map) -> str
-               build_qsp(poll, fraction_id, tally, source_item_id, fraction_map) -> QuestionStancePair
   corpus.py  — chunk_poll(source_item, raw) -> list[ChunkRecord]
 """

--- a/ai-backend/src/ingestion/connectors/abgeordnetenwatch/mappers/corpus.py
+++ b/ai-backend/src/ingestion/connectors/abgeordnetenwatch/mappers/corpus.py
@@ -1,0 +1,377 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Pure corpus mappers for the AW connector (poll -> vote_record ChunkRecords).
+
+All functions in this module are I/O-free (no network, no Firestore, no
+wall-clock) and deterministic — suitable for unit testing without mocks.
+
+Exports:
+    chunk_poll(source_item, raw)  — produces list[ChunkRecord] per AW poll
+
+Security notes:
+    XSS-into-corpus guard: field_intro HTML is stripped via
+    BeautifulSoup.get_text() before embedding into chunk text.  No raw HTML
+    reaches the corpus or the LLM context.
+
+    DoS mitigation: no regex in this module; date parsing via
+    date.fromisoformat (stdlib) which accepts only strict ISO 8601 YYYY-MM-DD.
+
+    Pydantic extra="forbid": preserved on ChunkRecord — malformed
+    AW fields are rejected at validation, not silently dropped.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import date as date_type
+from typing import Optional, Protocol
+import uuid
+
+from bs4 import BeautifulSoup
+
+from src.ingestion.ids import make_chunk_key
+from src.ingestion.schemas import (
+    AuthorityTier,
+    ChunkRecord,
+    SourceType,
+    VoteMeta,
+    VoteResult,
+)
+from src.ingestion.connectors.abgeordnetenwatch.mappers.stance import (
+    aggregate_fraction_tallies,
+    derive_stance,
+)
+from src.ingestion.connectors.abgeordnetenwatch.topic_taxonomy_config import (
+    get_relevance_levels,
+)
+from src.ingestion.party_slugs import (
+    CANONICAL_PARTY_SLUGS,
+    PARTY_SLUG_QUARANTINE,
+    STATE_PARTY_SLUGS,
+    normalize_party_label,
+)
+
+
+# ---------------------------------------------------------------------------
+# SourceItemLike Protocol — the five attributes chunk_poll() reads from its
+# first argument.
+# ---------------------------------------------------------------------------
+
+
+class SourceItemLike(Protocol):
+    """Structural protocol for the source_item argument to chunk_poll().
+
+    Any object exposing these five attributes satisfies the protocol. Members
+    are declared as read-only properties so FROZEN dataclasses
+    (connector._SourceItem) satisfy the protocol; chunk_poll only reads them.
+    """
+
+    @property
+    def source_item_id(self) -> uuid.UUID: ...
+
+    @property
+    def region(self) -> str: ...
+
+    @property
+    def authority_tier(self) -> AuthorityTier: ...
+
+    @property
+    def source_type(self) -> SourceType: ...
+
+    @property
+    def publish_date(self) -> date_type: ...
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Party ID sentinel: a vote record belongs to no single party, so its
+# top-level party_id is "_all" (the real per-party ids live in party_ids).
+_PARTY_ID_SENTINEL = "_all"
+
+# Quarantine slug for unmapped fraction names (shared source of truth).
+_PARTY_SLUG_QUARANTINE = PARTY_SLUG_QUARANTINE
+
+# AW fraction-label → canonical slug. The shared major-party core and the
+# state/regional layer live in src/ingestion/party_slugs.py (single source of
+# truth so vote slugs tenant-align with manifesto slugs); the only AW-specific
+# additions are the "(Gruppe)" fraction-label variants below. Keys are the
+# lowercased fraction name WITHOUT the parliament-period suffix — the AW votes
+# endpoint labels fractions like "FDP (Bundestag 2017 - 2021)", so
+# _PARENS_SUFFIX_RE strips the parenthetical before lookup.
+#
+# KNOWN LIMITATION (CDU/CSU): at the Bundestag, CDU and CSU sit as one joint
+# fraction "CDU/CSU", so a federal vote's Union tally is attributed to slug
+# "cdu" only. CSU has no separate federal fraction, so a "csu" query returns no
+# federal vote records; standalone-CSU labels still map to "csu". Intentional.
+_AW_FRACTION_SLUG_MAP: dict[str, str] = {
+    **CANONICAL_PARTY_SLUGS,
+    **STATE_PARTY_SLUGS,
+    # "(Gruppe)" variants: below fraction strength a party sits as a Gruppe, and
+    # AW labels it "BSW (Gruppe)" / "Die Linke. (Gruppe)". Same tenant as the
+    # full fraction.
+    "bsw (gruppe)": "bsw",
+    "die linke. (gruppe)": "linke",
+}
+
+# Regex to strip the parliament-period parenthetical from a fraction label.
+# Example: "FDP (Bundestag 2017 - 2021)" -> "FDP"
+# Only strips text inside the LAST pair of parentheses (defensive).
+_PARENS_SUFFIX_RE = re.compile(r"\s*\([^)]*\)\s*$")
+
+# Shared normaliser (strips the U+00AD soft hyphen AW embeds in the Greens'
+# fraction name, collapses whitespace, lowercases). Aliased for back-compat.
+_normalize_fraction_label = normalize_party_label
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _canonical_party_slug(fraction_label: str) -> str:
+    """Map an AW fraction label to a canonical party slug.
+
+    The ``fraction.label`` in the votes endpoint response contains a
+    parliament-period suffix: "FDP (Bundestag 2017 - 2021)".  We strip that
+    suffix before looking up in ``_AW_FRACTION_SLUG_MAP``.
+
+    Unknown fraction labels (including after stripping) return the quarantine
+    slug ``"unbekannt"`` rather than crashing or producing an ad-hoc slug.
+
+    Args:
+        fraction_label: The ``label`` field from an AW ``fraction`` dict in
+                        a votes response, e.g. ``"FDP (Bundestag 2017 - 2021)"``.
+
+    Returns:
+        Canonical party slug string, e.g. ``"fdp"``, or ``"unbekannt"``.
+    """
+    # Strip parenthetical parliament-period suffix, then normalise away invisible
+    # formatting characters (U+00AD soft hyphen in the Greens' fraction name).
+    clean = _normalize_fraction_label(_PARENS_SUFFIX_RE.sub("", fraction_label))
+    return _AW_FRACTION_SLUG_MAP.get(clean, _PARTY_SLUG_QUARANTINE)
+
+
+def _strip_html(html: Optional[str]) -> str:
+    """Strip HTML tags from a field_intro string (XSS guard).
+
+    Args:
+        html: Raw HTML string from ``field_intro``, or ``None``.
+
+    Returns:
+        Plain text with inline whitespace collapsed, or empty string if None.
+    """
+    if not html:
+        return ""
+    return BeautifulSoup(html, "html.parser").get_text(separator=" ", strip=True)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def extract_topic_labels(poll: dict) -> list[str]:
+    """Extract the field_topics label strings from an AW poll dict.
+
+    Used for both the embed text and the relevance_levels taxonomy lookup
+    inside :func:`chunk_poll`.
+
+    isinstance check + str() cast before use (untrusted AW payload).
+    """
+    return [
+        str(t["label"])
+        for t in (poll.get("field_topics") or [])
+        if isinstance(t, dict) and t.get("label")
+    ]
+
+
+def _motion_outcome(poll: dict) -> Optional[str]:
+    """Derive the overall motion result from the poll's ``field_accepted`` flag.
+
+    Best-effort: AW exposes an explicit boolean ``field_accepted`` on the poll
+    node.  We do NOT infer pass/fail by summing fraction tallies — absent
+    parties and quorum rules make that unreliable.
+
+    Returns ``"angenommen"`` / ``"abgelehnt"`` / ``None`` (unknown).
+    """
+    accepted = poll.get("field_accepted")
+    if accepted is True:
+        return "angenommen"
+    if accepted is False:
+        return "abgelehnt"
+    return None
+
+
+def chunk_poll(
+    source_item: SourceItemLike,
+    raw: dict,
+    *,
+    wahlperiode: Optional[int] = None,
+    legislature_period_id: Optional[int] = None,
+) -> list[ChunkRecord]:
+    """Produce ONE deterministic, FULLY-STAMPED ChunkRecord per AW poll.
+
+    Design (vote-record array model + envelope/meta split):
+      - The embedded ``text`` is the *subject* of the motion only — poll label,
+        topic labels, and the HTML-stripped intro.  The tally is deliberately
+        NOT embedded (it would pollute the vector and cluster all votes together);
+        it lives in ``meta`` (a VoteMeta dict) instead.
+      - ``party_ids`` is the sorted list of every participating party's slug —
+        filterable via a non-tenant keyword array index; stays top-level (INDEXED).
+      - ``meta`` carries a VoteMeta dict with ``vote_results`` (one VoteResult per
+        fraction, sorted ascending by fraction_id for determinism) and
+        ``motion_outcome``; neither is in the envelope top-level.
+      - ``party_id`` is the ``_all`` sentinel: a vote belongs to no single party,
+        so it opts out of per-party tenant co-location and is filtered via
+        ``party_ids`` instead.
+
+    This function owns the WHOLE record build: topic extraction
+    (:func:`extract_topic_labels`), relevance_levels derivation
+    (``get_relevance_levels``; the no-topics WARNING is suppressed for
+    non-federal regions), and the envelope stamping (external_id, wahlperiode,
+    legislature_period_id, relevance_levels).
+
+    content_hash covers the correctness-bearing content AND the stamped
+    envelope fields (region, publish_date, relevance_levels, wahlperiode,
+    legislature_period_id) — so an AW_REFRESH reconcile run propagates envelope
+    corrections (e.g. a re-classified topic or a fixed region), not just
+    text/tally changes.
+
+    source_item is typed as the structural SourceItemLike Protocol — the frozen
+    stub built in connector.normalize() satisfies it.
+
+    Party slugs are resolved from the ``fraction.label`` inside each vote dict via
+    ``_canonical_party_slug()`` — no connector-level fraction_map needed.
+
+    Degenerate-input guard: votes where ``fraction`` is not a
+    dict are skipped by ``aggregate_fraction_tallies``.  A poll with zero usable
+    tallies yields an empty list here; connector.normalize() turns that into the
+    zero-tally ValueError.
+
+    Args:
+        source_item: Any SourceItemLike object with source_item_id, region,
+                     authority_tier, source_type, publish_date attributes.
+        raw:         Raw payload: ``{"poll": <poll dict>, "votes": <votes list>}``.
+        wahlperiode: German Wahlperiode number (Bundestag only; None for
+                     Landtage — state Wahlperiode ints collide across states).
+        legislature_period_id: AW parliament_period ID (globally unique period key).
+
+    Returns:
+        A list with a single fully-stamped ``ChunkRecord`` (or empty when no
+        usable tallies).
+    """
+    poll: dict = raw["poll"]
+    votes: list[dict] = raw["votes"]
+
+    poll_label: str = poll.get("label") or ""
+    field_intro: Optional[str] = poll.get("field_intro")
+    intro_text: str = _strip_html(field_intro)
+    topic_labels: list[str] = extract_topic_labels(poll)
+
+    # Aggregate per-fraction tallies (skips degenerate fraction=[] entries)
+    tallies = aggregate_fraction_tallies(votes)
+    if not tallies:
+        # Zero usable tallies — let connector.normalize() raise.
+        return []
+
+    # Merge tallies by canonical party slug. Distinct fraction_ids can map to the same
+    # slug (e.g. a transition-period Gruppe alongside the main fraction); summing prevents
+    # one tally being silently dropped when a later lookup finds only the first by party_id.
+    # Iterate fraction_ids in order so the merge itself is deterministic.
+    by_slug: dict[str, dict[str, int]] = {}
+    for _fraction_id, tally in sorted(tallies.items()):
+        party_slug = _canonical_party_slug(tally["fraction"].get("label") or "")
+        acc = by_slug.setdefault(
+            party_slug, {"yes": 0, "no": 0, "abstain": 0, "no_show": 0}
+        )
+        acc["yes"] += tally["yes"]
+        acc["no"] += tally["no"]
+        acc["abstain"] += tally["abstain"]
+        acc["no_show"] += tally["no_show"]
+
+    # One VoteResult per party, ascending by slug for determinism.
+    vote_results: list[VoteResult] = [
+        VoteResult(
+            party_id=slug,
+            stance=derive_stance(t["yes"], t["no"], t["abstain"], t["no_show"]),
+            yes=t["yes"],
+            no=t["no"],
+            abstain=t["abstain"],
+            no_show=t["no_show"],
+        )
+        for slug, t in sorted(by_slug.items())
+    ]
+    party_slugs: set[str] = set(by_slug.keys())
+
+    # Subject-only embed text — topic and tally split: tally is payload, not vector.
+    text = poll_label
+    if topic_labels:
+        text = f"{text}\n\nThemen: {', '.join(topic_labels)}"
+    if intro_text:
+        text = f"{text}\n\nKontext: {intro_text}"
+
+    chunk_key: str = make_chunk_key(source_item.source_item_id, 0)
+
+    meta = VoteMeta(
+        vote_results=vote_results,
+        motion_outcome=_motion_outcome(poll),
+    ).model_dump(mode="json", exclude_none=True)
+
+    # Relevance levels from the topic taxonomy. Landtag polls routinely carry no
+    # field_topics — suppress the per-poll no-topics WARNING for non-federal
+    # regions (unknown-label warnings stay loud everywhere).
+    relevance_levels = get_relevance_levels(
+        topic_labels, warn_on_missing_topics=(source_item.region == "DE")
+    )
+
+    # Stable hash of the correctness-bearing content (embed text + tallies/outcome
+    # + participating parties) PLUS the stamped envelope fields (region,
+    # publish_date, relevance_levels, wahlperiode, legislature_period_id) — so an
+    # AW_REFRESH reconcile run re-writes chunks whose envelope changed (e.g. a
+    # re-classified topic), not only text/tally corrections.
+    content_hash = hashlib.sha256(
+        json.dumps(
+            {
+                "text": text,
+                "meta": meta,
+                "party_ids": sorted(party_slugs),
+                "region": source_item.region,
+                "publish_date": source_item.publish_date.isoformat(),
+                "relevance_levels": relevance_levels,
+                "wahlperiode": wahlperiode,
+                "legislature_period_id": legislature_period_id,
+            },
+            sort_keys=True,
+            ensure_ascii=False,
+        ).encode("utf-8")
+    ).hexdigest()
+
+    return [
+        ChunkRecord(
+            chunk_key=chunk_key,
+            source_item_id=source_item.source_item_id,
+            chunk_index=0,
+            text=text,
+            party_id=_PARTY_ID_SENTINEL,
+            region=source_item.region,
+            authority_tier=source_item.authority_tier,
+            source_type=source_item.source_type,
+            publish_date=source_item.publish_date,
+            citation_url=poll.get("abgeordnetenwatch_url"),
+            citation_title=poll_label,
+            party_ids=sorted(party_slugs),
+            external_id=poll["id"],
+            wahlperiode=wahlperiode,
+            legislature_period_id=legislature_period_id,
+            relevance_levels=relevance_levels,
+            content_hash=content_hash,
+            meta=meta,
+        )
+    ]

--- a/ai-backend/src/ingestion/connectors/abgeordnetenwatch/mappers/corpus.py
+++ b/ai-backend/src/ingestion/connectors/abgeordnetenwatch/mappers/corpus.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -115,10 +115,36 @@ _AW_FRACTION_SLUG_MAP: dict[str, str] = {
     **STATE_PARTY_SLUGS,
     # "(Gruppe)" variants: below fraction strength a party sits as a Gruppe, and
     # AW labels it "BSW (Gruppe)" / "Die Linke. (Gruppe)". Same tenant as the
-    # full fraction.
+    # full fraction. Only the LAST parenthetical (the parliament-period suffix)
+    # is stripped before lookup, so the "(Gruppe)" part survives into the key.
     "bsw (gruppe)": "bsw",
     "die linke. (gruppe)": "linke",
+    "die linke (gruppe)": "linke",
+    "fdp (gruppe)": "fdp",
+    "fdp (parlamentarische gruppe)": "fdp",
+    "freie wähler (gruppe)": "fw",
+    # Landtag state-party names and long forms from the live AW fraction
+    # catalogue that differ from the federal labels.
+    "fdp/dvp": "fdp",  # Baden-Württemberg: the FDP's state party is FDP/DVP
+    "bvb - freie wähler": "bvb-fw",  # dash variant of "BVB/Freie Wähler"
+    "bvb - freie wähler (gruppe)": "bvb-fw",
+    "alternative für deutschland": "afd",
+    "bündnis sahra wagenknecht": "bsw",
+    "bündnis deutschland": "buendnis-deutschland",
+    "liberal-konservative reformer": "lkr",
+    "fraktionlos": "fraktionslos",  # AW catalogue carries this typo variant
+    # Landtag splinter groups without a federal parent. Distinct slugs so their
+    # tallies stay attributable instead of merging into one "unbekannt" bucket.
+    "bürger für mecklenburg-vorpommern": "buerger-fuer-mv",
+    "bürger für thüringen": "buerger-fuer-thueringen",
+    "bürger für thüringen (parlamentarische gruppe)": "buerger-fuer-thueringen",
+    "wir für brandenburg (gruppe)": "wir-fuer-brandenburg",
+    "saar-linke": "saar-linke",
 }
+
+# Landtag full_names often wrap the party in a Fraktion affix ("CDU-Fraktion",
+# "Fraktion DIE LINKE"). Stripped for a second lookup when the direct one misses.
+_FRAKTION_AFFIX_RE = re.compile(r"^fraktion\s+|-fraktion$")
 
 # Regex to strip the parliament-period parenthetical from a fraction label.
 # Example: "FDP (Bundestag 2017 - 2021)" -> "FDP"
@@ -155,7 +181,13 @@ def _canonical_party_slug(fraction_label: str) -> str:
     # Strip parenthetical parliament-period suffix, then normalise away invisible
     # formatting characters (U+00AD soft hyphen in the Greens' fraction name).
     clean = _normalize_fraction_label(_PARENS_SUFFIX_RE.sub("", fraction_label))
-    return _AW_FRACTION_SLUG_MAP.get(clean, _PARTY_SLUG_QUARANTINE)
+    slug = _AW_FRACTION_SLUG_MAP.get(clean)
+    if slug is None:
+        # Retry once with the Fraktion affix stripped ("CDU-Fraktion" → "cdu").
+        stripped = _FRAKTION_AFFIX_RE.sub("", clean)
+        if stripped != clean:
+            slug = _AW_FRACTION_SLUG_MAP.get(stripped)
+    return slug if slug is not None else _PARTY_SLUG_QUARANTINE
 
 
 def _strip_html(html: Optional[str]) -> str:
@@ -333,9 +365,11 @@ def chunk_poll(
 
     # Stable hash of the correctness-bearing content (embed text + tallies/outcome
     # + participating parties) PLUS the stamped envelope fields (region,
-    # publish_date, relevance_levels, wahlperiode, legislature_period_id) — so an
-    # AW_REFRESH reconcile run re-writes chunks whose envelope changed (e.g. a
-    # re-classified topic), not only text/tally corrections.
+    # publish_date, relevance_levels, wahlperiode, legislature_period_id) AND the
+    # displayed citation — so an AW_REFRESH reconcile run re-writes chunks whose
+    # envelope OR citation changed (e.g. a re-classified topic or a corrected
+    # abgeordnetenwatch_url), not only text/tally corrections. A field the user
+    # sees but the hash ignores could never be refreshed.
     content_hash = hashlib.sha256(
         json.dumps(
             {
@@ -347,6 +381,8 @@ def chunk_poll(
                 "relevance_levels": relevance_levels,
                 "wahlperiode": wahlperiode,
                 "legislature_period_id": legislature_period_id,
+                "citation_url": poll.get("abgeordnetenwatch_url"),
+                "citation_title": poll_label,
             },
             sort_keys=True,
             ensure_ascii=False,

--- a/ai-backend/src/ingestion/connectors/abgeordnetenwatch/mappers/stance.py
+++ b/ai-backend/src/ingestion/connectors/abgeordnetenwatch/mappers/stance.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/src/ingestion/connectors/abgeordnetenwatch/mappers/stance.py
+++ b/ai-backend/src/ingestion/connectors/abgeordnetenwatch/mappers/stance.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Pure stance-derivation and fraction-aggregation mappers for the AW connector.
+
+All functions in this module are I/O-free (no network, no Firestore, no
+filesystem) and deterministic — suitable for unit testing without mocks.
+
+Security notes:
+  Elevation of Privilege mitigation: aggregate_fraction_tallies guards
+  against the degenerate `fraction: []` case (verified poll 4539 idx 107).
+  An empty-list fraction cannot cause a crash or a tally injection.
+
+  Information disclosure: this module reads only poll/vote/fraction
+  JSON fields; no code path reads users/{uid} data.  The import surface is
+  restricted to stdlib only.
+
+  Tampering: derive_stance checks for an exact top-two tie before
+  applying stance_map, preventing Python-version-dependent sort instability.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal, TypedDict, cast
+
+from src.ingestion.schemas import Stance
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_PARTY_SLUG_QUARANTINE = "unbekannt"
+
+# The only vote tokens AW emits that contribute to a tally.  Any other token
+# (a new enum value, null, or a missing "vote" key) is skipped with a warning
+# rather than crashing the whole run.
+VoteToken = Literal["yes", "no", "abstain", "no_show"]
+_VALID_VOTE_TOKENS: tuple[VoteToken, ...] = ("yes", "no", "abstain", "no_show")
+
+
+class FractionTally(TypedDict):
+    """A single fraction's aggregated vote counts + its chosen fraction dict.
+
+    Runtime is a plain dict — the TypedDict only pins the shape for callers
+    (``corpus.py`` reads ``["yes"]``/``["fraction"]`` etc.).
+    """
+
+    yes: int
+    no: int
+    abstain: int
+    no_show: int
+    fraction: dict
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def aggregate_fraction_tallies(votes: list[dict]) -> dict[int, FractionTally]:
+    """Group per-mandate votes by fraction_id, summing yes/no/abstain/no_show.
+
+    Degenerate-input guard:
+    Votes where the ``fraction`` field is not a dict (e.g., an empty list ``[]``
+    for mandate-holders with no fraction at that time) are silently skipped.
+    They do not raise, and they do not contribute to any fraction's tally.
+
+    Args:
+        votes: List of per-mandate vote dicts from the AW ``votes`` endpoint.
+               Each item must have ``fraction`` (dict or list/None) and
+               ``vote`` (str: "yes" | "no" | "abstain" | "no_show").
+
+    Robustness guards — a single malformed vote must not abort the whole poll
+    (or crash the embedding worker at chunk time):
+    - A fraction dict missing ``id`` is skipped with a warning.
+    - A vote whose ``vote`` token is not one of the four valid tokens (a new
+      enum value, ``null``, or a missing key) is skipped with a warning instead
+      of raising ``KeyError``/``TypeError``.
+
+    Label determinism:
+    The ``fraction`` dict stored on a tally is selected deterministically — the
+    candidate with the lexicographically smallest ``label`` wins, so the chosen
+    label does not depend on payload order even when AW emits inconsistent
+    ``label`` strings across mandates of the same fraction_id (renamed Gruppen).
+
+    Returns:
+        Mapping from fraction_id (int) to a tally dict with keys
+        ``yes``, ``no``, ``abstain``, ``no_show`` (int counts) and
+        ``fraction`` (the deterministically selected fraction dict).
+    """
+    tallies: dict[int, FractionTally] = {}
+    for v in votes:
+        frac = v.get("fraction")
+        if not isinstance(frac, dict):
+            # Degenerate case: fraction=[] or None — skip without raising
+            continue
+        fid = frac.get("id")
+        if fid is None:
+            logger.warning(
+                "aggregate_fraction_tallies: fraction dict missing 'id' — "
+                "skipping vote (fraction=%r)",
+                frac,
+            )
+            continue
+
+        vote = v.get("vote")
+        if vote not in _VALID_VOTE_TOKENS:
+            logger.warning(
+                "aggregate_fraction_tallies: unexpected vote token %r for "
+                "fraction_id=%s — skipping vote (valid tokens: %s)",
+                vote,
+                fid,
+                _VALID_VOTE_TOKENS,
+            )
+            continue
+        # Membership above guarantees one of the four count keys; narrow it so the
+        # TypedDict increment below type-checks.
+        vote_token = cast(VoteToken, vote)
+
+        if fid not in tallies:
+            tallies[fid] = {
+                "yes": 0,
+                "no": 0,
+                "abstain": 0,
+                "no_show": 0,
+                "fraction": frac,
+            }
+        else:
+            # Deterministic label selection — keep the candidate fraction
+            # dict with the lexicographically smallest label so the chosen label
+            # is stable regardless of payload order.
+            stored_label = str(tallies[fid]["fraction"].get("label") or "")
+            new_label = str(frac.get("label") or "")
+            if new_label < stored_label:
+                tallies[fid]["fraction"] = frac
+
+        tallies[fid][vote_token] += 1
+    return tallies
+
+
+def derive_stance(yes: int, no: int, abstain: int, no_show: int) -> Stance:
+    """Derive the fraction's stance from its tally (locked rule).
+
+    Rule:
+    1. Find the bucket with the largest count.
+    2. If the top two buckets are tied, return ``Stance.NEUTRAL`` (tie-break
+       guard — prevents Python sort instability from making this
+       non-deterministic).
+    3. Otherwise map the winning bucket:
+       yes -> AGREE, no -> DISAGREE, abstain -> NEUTRAL, no_show -> ABSENT.
+
+    Args:
+        yes: Count of "yes" votes in the fraction.
+        no: Count of "no" votes.
+        abstain: Count of "abstain" votes.
+        no_show: Count of "no_show" votes.
+
+    Returns:
+        One of the :class:`Stance` members.
+    """
+    buckets = [
+        ("yes", yes),
+        ("no", no),
+        ("abstain", abstain),
+        ("no_show", no_show),
+    ]
+    buckets.sort(key=lambda x: x[1], reverse=True)
+
+    # Explicit tie check — do NOT rely on sort stability for tie resolution
+    if buckets[0][1] == buckets[1][1]:
+        return Stance.NEUTRAL
+
+    # Intentional collapse (do NOT "fix"):
+    # Per the locked stance rule, BOTH an exact top-two tie AND an
+    # abstain-largest plurality deliberately map to NEUTRAL. These two
+    # semantically distinct cases ("no clear majority" vs. "deliberately
+    # abstained") collapse to the same output by design — the deferred scoring
+    # engine does not (yet) need to distinguish them. This is not a bug.
+    stance_map = {
+        "yes": Stance.AGREE,
+        "no": Stance.DISAGREE,
+        "abstain": Stance.NEUTRAL,
+        "no_show": Stance.ABSENT,
+    }
+    return stance_map[buckets[0][0]]
+
+
+def fraction_to_party_slug(fraction_id: int, fraction_map: dict[int, str]) -> str:
+    """Resolve a fraction_id to a canonical party slug.
+
+    Uses a runtime map built from the AW ``/fractions`` endpoint response.
+    Unknown/unmapped fraction_ids (e.g., new Gruppen not yet in the map)
+    route to the quarantine slug ``"unbekannt"``.
+
+    Args:
+        fraction_id: AW numeric fraction ID.
+        fraction_map: Mapping of fraction_id -> canonical party slug.
+
+    Returns:
+        The party slug, or ``"unbekannt"`` if the fraction_id is not in the map.
+    """
+    return fraction_map.get(fraction_id, _PARTY_SLUG_QUARANTINE)

--- a/ai-backend/src/ingestion/connectors/abgeordnetenwatch/topic_taxonomy_config.py
+++ b/ai-backend/src/ingestion/connectors/abgeordnetenwatch/topic_taxonomy_config.py
@@ -1,0 +1,301 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Maps the 53 canonical AbgeordnetenWatch Themen to the governance levels a federal
+(Bundestag) vote on that topic is relevant to — FEDERAL, or FEDERAL + STATE — for
+the vote down-rank.
+
+The 53 ``TOPIC_TAXONOMY`` keys are the exact long-form labels verified from the AW
+v2 ``/topics`` endpoint; they are never re-fetched at runtime. The topic objects
+EMBEDDED in a poll response (``field_topics[*].label``) may instead carry a
+truncated pre-comma short form of a canonical label (verified: golden fixture
+poll 3602 carries "Öffentliche Finanzen" for the canonical "Öffentliche Finanzen,
+Steuern und Abgaben"). ``_TOPIC_ALIASES`` maps these short forms to the same
+levels as their canonical key so embedded labels resolve without the max-recall
+ALL_LEVELS fallback.
+
+Level assignment follows the Grundgesetz division of competence (verified against
+gesetze-im-internet.de/gg):
+
+  - Art. 73 (ausschließliche Bundesgesetzgebung): exclusively federal → FEDERAL,
+    unless the matter is executed by the Länder or lands on residents (e.g. Art. 73(1)
+    Verteidigung including "Schutz der Zivilbevölkerung"), which adds STATE.
+  - Art. 74 (konkurrierende Gesetzgebung) with Art. 83 ("die Länder führen die
+    Bundesgesetze als eigene Angelegenheit aus"): federal law executed by the Länder,
+    often co-funded (Art. 104a) → FEDERAL + STATE.
+  - Art. 70 (residual): matters not assigned to the Bund are Land competence. A
+    federal vote on them is FEDERAL, unless a federal funding/framework hook exists
+    (Art. 91b Wissenschaft/Forschung/Bildung, Art. 104a/104c financing), which adds STATE.
+  - Art. 23 (Länder co-decide and execute EU law) and Art. 1(3) (Grundrechte bind
+    federal and Länder authority) → FEDERAL + STATE.
+
+FEDERAL means the vote should rank below the Landtag votes in a state chat;
+FEDERAL + STATE means it stays visible there.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import FrozenSet
+
+# The governance-level constants are owned by the shared framework module
+# src/ingestion/levels.py (retrieve.py imports from there without touching a
+# connector). Re-exported here because the taxonomy dict below, the AW
+# connector, and the AW tests all reference them from this module.
+from src.ingestion.levels import (  # noqa: F401
+    ALL_LEVELS,
+    FEDERAL,
+    MUNICIPAL,
+    STATE,
+)
+
+logger = logging.getLogger(__name__)
+
+# AW injects invisible formatting characters into label strings (notably the U+00AD
+# soft hyphen inside "BÜNDNIS 90/­DIE GRÜNEN", and the same family appears in topic
+# labels). They must be stripped before the exact TOPIC_TAXONOMY lookup — otherwise an
+# affected label silently misses every key and falls back to ALL_LEVELS, which makes an
+# affected federal vote over-surface in state/municipal chats instead of being down-ranked.
+_INVISIBLE_CHARS_RE = re.compile("[\u00ad\u200b\u200c\u200d\u2060\ufeff]")
+
+
+def _normalize_topic_label(label: str) -> str:
+    """Strip invisible/zero-width formatting characters and surrounding whitespace so an
+    AW topic label matches the TOPIC_TAXONOMY keys exactly."""
+    return _INVISIBLE_CHARS_RE.sub("", label).strip()
+
+
+# ---------------------------------------------------------------------------
+# Governance level constants: re-exported from src.ingestion.levels above —
+# do NOT re-introduce local definitions (a parity test in
+# tests/ingestion/test_enum_parity.py guards this).
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# TOPIC_TAXONOMY — AW topic label → governance relevance levels (frozenset).
+#
+# Keys must match field_topics[*].label exactly. 53 entries.
+# Each value cites its governing GG article.
+#
+# No topic is tagged MUNICIPAL: AW has no municipal parliament data, so a
+# Kommunalwahl context down-ranks all federal+state votes uniformly.
+# ---------------------------------------------------------------------------
+
+TOPIC_TAXONOMY: dict[str, FrozenSet[str]] = {
+    # -----------------------------------------------------------------------
+    # FEDERAL only.
+    # -----------------------------------------------------------------------
+    # Art. 73(5) — Zoll- und Handelsgebiet, Waren- und Zahlungsverkehr mit dem Ausland.
+    "Außenwirtschaft": frozenset({FEDERAL}),
+    # Art. 73(1) — auswärtige Angelegenheiten.
+    "Entwicklungspolitik": frozenset({FEDERAL}),
+    # Art. 73(1) — auswärtige Angelegenheiten.
+    "Humanitäre Hilfe": frozenset({FEDERAL}),
+    # Bundestag advisory function (TAB) — no Land competence.
+    "Technologiefolgenabschätzung": frozenset({FEDERAL}),
+    # Art. 38-48 — the Bundestag as a federal organ.
+    "Bundestag": frozenset({FEDERAL}),
+    # Art. 40(1) — Bundestag's rules of procedure.
+    "Geschäftsordnung": frozenset({FEDERAL}),
+    # Art. 46 — immunity of Bundestag members.
+    "Immunität": frozenset({FEDERAL}),
+    # Art. 45c — Bundestag petitions committee.
+    "Petitionen": frozenset({FEDERAL}),
+    # Art. 41 — scrutiny of Bundestag elections.
+    "Wahlprüfung": frozenset({FEDERAL}),
+    # Historical federal matter — no current Land competence.
+    "Deutsche Einheit / Innerdeutsche Beziehungen (bis 1990)": frozenset({FEDERAL}),
+    # Federal Lobbyregister (Bundestag); Länder regulate their own transparency (Art. 70).
+    "Lobbyismus & Transparenz": frozenset({FEDERAL}),
+    # Art. 21(5) — "Das Nähere regeln Bundesgesetze" (party law is federal).
+    "Politisches Leben, Parteien": frozenset({FEDERAL}),
+    # Art. 32 + 73(1) — auswärtige Angelegenheiten are exclusively federal.
+    "Außenpolitik und internationale Beziehungen": frozenset({FEDERAL}),
+    # -----------------------------------------------------------------------
+    # FEDERAL + STATE.
+    # -----------------------------------------------------------------------
+    # Art. 73(1) — Verteidigung incl. "Schutz der Zivilbevölkerung", executed by the
+    # Länder (Katastrophenschutz).
+    "Verteidigung": frozenset({FEDERAL, STATE}),
+    # Art. 73(14) Kernenergie/Strahlenschutz, executed by the Länder as
+    # Bundesauftragsverwaltung (Art. 85): plant siting, evacuation planning and state
+    # environment ministries make it highly state-salient — same execution-by-Länder
+    # rationale that keeps Verteidigung FEDERAL + STATE.
+    "Reaktorsicherheit": frozenset({FEDERAL, STATE}),
+    # Art. 70 — Kulturhoheit der Länder: culture is a core Land competence, so a federal
+    # vote touching it is directly relevant to state voters (narrow federal hook: Art. 73(5a)).
+    "Kultur": frozenset({FEDERAL, STATE}),
+    # Art. 70 — tourism is residual Land competence; kept consistent with
+    # "Sport, Freizeit und Tourismus" which is also FEDERAL + STATE.
+    "Tourismus": frozenset({FEDERAL, STATE}),
+    # Art. 23 — Länder co-decide EU policy via the Bundesrat and execute EU law.
+    "Europapolitik und Europäische Union": frozenset({FEDERAL, STATE}),
+    # Art. 1(3) — Grundrechte bind Gesetzgebung, vollziehende Gewalt und Rechtsprechung
+    # at both levels.
+    "Menschenrechte": frozenset({FEDERAL, STATE}),
+    # Art. 74(12) — Arbeitsrecht und Sozialversicherung.
+    "Arbeit und Beschäftigung": frozenset({FEDERAL, STATE}),
+    # Art. 74(7) öffentliche Fürsorge, 74(12) Sozialversicherung; execution/co-funding
+    # Art. 83/104a.
+    "Soziale Sicherung": frozenset({FEDERAL, STATE}),
+    # Art. 74(19) übertragbare Krankheiten und Heilberufe, 74(19a) Krankenhäuser.
+    "Gesundheit": frozenset({FEDERAL, STATE}),
+    # Art. 105-106 — Steuergesetzgebung und Länderanteil an den Gemeinschaftsteuern.
+    "Öffentliche Finanzen, Steuern und Abgaben": frozenset({FEDERAL, STATE}),
+    # Art. 105-106.
+    "Finanzen": frozenset({FEDERAL, STATE}),
+    # Art. 109 — Haushaltswirtschaft von Bund und Ländern; Schuldenbremse.
+    "Haushalt": frozenset({FEDERAL, STATE}),
+    # Art. 74(11) — Recht der Wirtschaft.
+    "Wirtschaft": frozenset({FEDERAL, STATE}),
+    # Art. 74(11) — Energiewirtschaft (Recht der Wirtschaft).
+    "Energie": frozenset({FEDERAL, STATE}),
+    # Art. 74(24) — Luftreinhaltung; Länder execute (Art. 83).
+    "Klima": frozenset({FEDERAL, STATE}),
+    # Art. 74(24) Abfall/Luft/Lärm, 74(29) Naturschutz, 74(32) Wasserhaushalt.
+    "Umwelt": frozenset({FEDERAL, STATE}),
+    # Art. 74(29) — Naturschutz und Landschaftspflege.
+    "Naturschutz": frozenset({FEDERAL, STATE}),
+    # Art. 74(22) Straßenverkehr und Fernstraßen, 74(23) Schienenbahnen; Art. 73(6/6a)
+    # Luftverkehr/Bundeseisenbahnen.
+    "Verkehr": frozenset({FEDERAL, STATE}),
+    # Art. 91b (Bund-Länder education co-funding), Art. 104c (school infrastructure),
+    # Art. 74(33) Hochschulzulassung.
+    "Bildung und Erziehung": frozenset({FEDERAL, STATE}),
+    # Art. 74(18) Bodenrecht/Wohnungswesen/Siedlungswesen, 74(31) Raumordnung.
+    "Raumordnung, Bau- und Wohnungswesen": frozenset({FEDERAL, STATE}),
+    # Art. 74(17) landwirtschaftliche Erzeugung und Ernährungssicherung, 74(20) Lebensmittelrecht.
+    "Landwirtschaft und Ernährung": frozenset({FEDERAL, STATE}),
+    # Art. 74(4) Aufenthalts- und Niederlassungsrecht der Ausländer, 74(6) Flüchtlinge;
+    # Länder execute (Art. 83/104a).
+    "Migration und Aufenthaltsrecht": frozenset({FEDERAL, STATE}),
+    # Art. 74(1) Strafrecht, Art. 73(9a/10) BKA und Bundespolizei; general policing is
+    # residual Land competence (Art. 70).
+    "Innere Sicherheit": frozenset({FEDERAL, STATE}),
+    # Art. 74(3) Vereinsrecht, Art. 73(3) Melde- und Ausweiswesen.
+    "Innere Angelegenheiten": frozenset({FEDERAL, STATE}),
+    # Art. 83-85 (Länder execute federal law), Art. 74(27) Beamtenstatusrecht.
+    "Staat und Verwaltung": frozenset({FEDERAL, STATE}),
+    # Art. 74(1) — bürgerliches Recht, Strafrecht, Gerichtsverfassung; Länder execute
+    # (Art. 83/92).
+    "Recht": frozenset({FEDERAL, STATE}),
+    # Art. 74(7) — öffentliche Fürsorge.
+    "Gesellschaftspolitik, soziale Gruppen": frozenset({FEDERAL, STATE}),
+    # Art. 74(7) öffentliche Fürsorge, Art. 6 Schutz der Familie; Länder execute and
+    # co-fund (Art. 104a).
+    "Familie": frozenset({FEDERAL, STATE}),
+    # Art. 3(2) Gleichberechtigung (binds both), Art. 74(7) öffentliche Fürsorge.
+    "Frauen": frozenset({FEDERAL, STATE}),
+    # Art. 74(7) — öffentliche Fürsorge (Kinder- und Jugendhilfe).
+    "Jugend": frozenset({FEDERAL, STATE}),
+    # Art. 74(12) Sozialversicherung, 74(7) öffentliche Fürsorge.
+    "Senioren": frozenset({FEDERAL, STATE}),
+    # Art. 73(7) Telekommunikation, Art. 91c (Bund-Länder IT-Systeme).
+    "Digitale Agenda": frozenset({FEDERAL, STATE}),
+    # Art. 73(7), Art. 87f — Telekommunikation.
+    "digitale Infrastruktur": frozenset({FEDERAL, STATE}),
+    # Art. 73(7) Telekommunikation (federal); Rundfunk is Land competence (Art. 70).
+    "Medien, Kommunikation und Informationstechnik": frozenset({FEDERAL, STATE}),
+    # Art. 73(7) Telekommunikation; Rundfunkhoheit der Länder (Art. 70).
+    "Medien": frozenset({FEDERAL, STATE}),
+    # Art. 74(1) — Anti-Doping-Gesetz (Strafrecht); otherwise residual Land competence (Art. 70).
+    "Sport": frozenset({FEDERAL, STATE}),
+    # Art. 74(1) doping/Strafrecht for Sport; Freizeit and Tourismus are residual Länder (Art. 70).
+    "Sport, Freizeit und Tourismus": frozenset({FEDERAL, STATE}),
+    # Art. 74(11) Recht der Wirtschaft, 74(1) bürgerliches Recht.
+    "Verbraucherschutz": frozenset({FEDERAL, STATE}),
+    # Art. 74(13) Forschungsförderung, Art. 91b (Bund-Länder co-funding).
+    "Forschung": frozenset({FEDERAL, STATE}),
+    # Art. 91b, Art. 74(13), 74(33) Hochschulzulassung.
+    "Wissenschaft, Forschung und Technologie": frozenset({FEDERAL, STATE}),
+}
+
+
+# ---------------------------------------------------------------------------
+# _TOPIC_ALIASES — short-form labels observed in EMBEDDED poll field_topics.
+#
+# The AW /topics endpoint returns the long canonical labels keyed in
+# TOPIC_TAXONOMY above, but the topic objects embedded in a poll response may
+# carry a truncated pre-comma short form (verified: golden fixture poll 3602,
+# topic 22, carries "Öffentliche Finanzen"). Each alias maps to the SAME levels
+# as its canonical key.
+#
+# Conservative scope: only pre-comma truncations of comma-containing canonical
+# keys are aliased — that is the one attested truncation mechanism. Pre-comma
+# prefixes that are already canonical keys with identical levels ("Medien" for
+# "Medien, Kommunikation und Informationstechnik", "Sport" for "Sport, Freizeit
+# und Tourismus") need no alias. "und"-joined keys without a comma have no
+# attested short form and are deliberately NOT aliased.
+# ---------------------------------------------------------------------------
+
+_TOPIC_ALIASES: dict[str, FrozenSet[str]] = {
+    # Verified from the repo's own golden fixture (poll 3602).
+    "Öffentliche Finanzen": TOPIC_TAXONOMY["Öffentliche Finanzen, Steuern und Abgaben"],
+    # Same pre-comma truncation mechanism for the remaining comma-containing keys.
+    "Raumordnung": TOPIC_TAXONOMY["Raumordnung, Bau- und Wohnungswesen"],
+    "Gesellschaftspolitik": TOPIC_TAXONOMY["Gesellschaftspolitik, soziale Gruppen"],
+    "Politisches Leben": TOPIC_TAXONOMY["Politisches Leben, Parteien"],
+    "Wissenschaft": TOPIC_TAXONOMY["Wissenschaft, Forschung und Technologie"],
+}
+
+
+def get_relevance_levels(
+    topic_labels: list[str],
+    *,
+    warn_on_missing_topics: bool = True,
+) -> list[str]:
+    """Return the sorted union of governance levels for the given topic labels.
+
+    Unknown labels or empty input default to all levels (max recall). Unknown
+    labels ALWAYS log a warning (an unmapped label is actionable everywhere).
+    Empty input logs a warning only when ``warn_on_missing_topics`` is True —
+    Landtag polls routinely carry no field_topics, so callers pass False for
+    non-federal legislatures to avoid one noise WARNING per poll burying
+    actionable warnings (federal polls keep the loud default).
+
+    Args:
+        topic_labels: List of AW field_topics[*].label strings for a poll. Labels are
+            cast to str before lookup (untrusted AW payload; used only as dict keys).
+        warn_on_missing_topics: Emit the no-field_topics WARNING on empty input
+            (True, default — federal polls); False logs at DEBUG instead
+            (non-federal legislatures where missing topics are the norm).
+
+    Returns:
+        Sorted list of governance level strings, e.g. ['federal', 'state'].
+        Returns sorted(ALL_LEVELS) for unknown labels or empty input.
+    """
+    if not topic_labels:
+        if warn_on_missing_topics:
+            logger.warning(
+                "AW poll has no field_topics — defaulting to all levels. "
+                "This vote will surface across all election level contexts."
+            )
+        else:
+            logger.debug(
+                "AW poll has no field_topics — defaulting to all levels "
+                "(expected for this legislature; suppressing per-poll warning)."
+            )
+        return sorted(ALL_LEVELS)
+
+    result: set[str] = set()
+    for label in topic_labels:
+        safe_label = _normalize_topic_label(str(label))
+        mapped = TOPIC_TAXONOMY.get(safe_label)
+        if mapped is None:
+            # Embedded poll payloads may carry the pre-comma short form.
+            mapped = _TOPIC_ALIASES.get(safe_label)
+        if mapped is None:
+            logger.warning(
+                "AW Thema %r is not in TOPIC_TAXONOMY — defaulting to all levels. "
+                "Add it to topic_taxonomy_config.py.",
+                safe_label,
+            )
+            result.update(ALL_LEVELS)
+        else:
+            result.update(mapped)
+
+    return sorted(result)

--- a/ai-backend/src/ingestion/connectors/abgeordnetenwatch/topic_taxonomy_config.py
+++ b/ai-backend/src/ingestion/connectors/abgeordnetenwatch/topic_taxonomy_config.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -42,10 +42,10 @@ import re
 from typing import FrozenSet
 
 # The governance-level constants are owned by the shared framework module
-# src/ingestion/levels.py (retrieve.py imports from there without touching a
+# src/ingestion/governance_levels.py (retrieve.py imports from there without touching a
 # connector). Re-exported here because the taxonomy dict below, the AW
 # connector, and the AW tests all reference them from this module.
-from src.ingestion.levels import (  # noqa: F401
+from src.ingestion.governance_levels import (  # noqa: F401
     ALL_LEVELS,
     FEDERAL,
     MUNICIPAL,
@@ -69,7 +69,7 @@ def _normalize_topic_label(label: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Governance level constants: re-exported from src.ingestion.levels above —
+# Governance level constants: re-exported from src.ingestion.governance_levels above —
 # do NOT re-introduce local definitions (a parity test in
 # tests/ingestion/test_enum_parity.py guards this).
 # ---------------------------------------------------------------------------

--- a/ai-backend/src/ingestion/run.py
+++ b/ai-backend/src/ingestion/run.py
@@ -500,6 +500,12 @@ def run_connector(
     # store predates fingerprints or the client cannot read points).
     check_fingerprint(qdrant, collection_name)
 
+    # One run, one store contract: store-aware discovery must read the same
+    # client/collection this runner upserts into. hasattr-guarded so bare test
+    # stubs that don't subclass BaseConnector keep working.
+    if hasattr(connector, "bind_store"):
+        connector.bind_store(qdrant, collection_name)
+
     since = (
         since_override
         if since_override is not None

--- a/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/conftest.py
+++ b/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/conftest.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Shared pytest fixtures for the Abgeordnetenwatch connector test suite.
+
+Provides:
+  - aw_poll_3602_poll: the poll metadata fixture (poll 3602 from the AW API)
+  - aw_poll_3602_votes: the 710-vote fixture including the empty-fraction edge case
+
+The golden fixtures (aw_poll_3602_poll.json, aw_poll_3602_votes.json) contain
+data verified from the live AW API (poll 3602 "Corona-Maßnahmen zum Schutz der
+Bevölkerung", parliament period 111, date 2020-05-14).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# Golden fixture loaders (no I/O guard needed — pure JSON reads)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def aw_poll_3602_poll() -> dict:
+    """Load the aw_poll_3602_poll.json golden fixture.
+
+    Shape: single poll item (data: {...}) for poll id=3602.
+    Used by: test_stance.py golden-record assertion.
+    """
+    return json.loads((_FIXTURES_DIR / "aw_poll_3602_poll.json").read_text())
+
+
+@pytest.fixture()
+def aw_poll_3602_votes() -> dict:
+    """Load the aw_poll_3602_votes.json golden fixture.
+
+    Shape: 710 per-mandate vote items (data: [...]) including one vote
+    with fraction=[] to exercise the degenerate-input guard.
+    Used by: test_stance.py golden-record assertion.
+    """
+    return json.loads((_FIXTURES_DIR / "aw_poll_3602_votes.json").read_text())

--- a/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/conftest.py
+++ b/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/conftest.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/fixtures/aw_poll_3602_poll.json
+++ b/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/fixtures/aw_poll_3602_poll.json
@@ -1,0 +1,58 @@
+{
+  "meta": {
+    "abgeordnetenwatch_api": {
+      "version": "2.9.0",
+      "licence": "CC0 1.0",
+      "documentation": "https://www.abgeordnetenwatch.de/api/entitaeten/poll"
+    },
+    "status": "ok",
+    "status_message": "",
+    "result": {
+      "count": 1,
+      "total": 1,
+      "range_start": 0,
+      "range_end": 1
+    }
+  },
+  "data": {
+    "id": 3602,
+    "entity_type": "node",
+    "label": "Corona-Maßnahmen zum Schutz der Bevölkerung",
+    "api_url": "https://www.abgeordnetenwatch.de/api/v2/polls/3602",
+    "abgeordnetenwatch_url": "https://www.abgeordnetenwatch.de/bundestag/19/abstimmungen/corona-massnahmen-zum-schutz-der-bevoelkerung",
+    "field_legislature": {
+      "id": 111,
+      "entity_type": "parliament_period",
+      "label": "Bundestag 2017 - 2021",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/parliament-periods/111"
+    },
+    "field_topics": [
+      {
+        "id": 28,
+        "entity_type": "taxonomy_term",
+        "label": "Gesundheit",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/topics/28",
+        "abgeordnetenwatch_url": "https://www.abgeordnetenwatch.de/themen-dip21/gesundheit"
+      },
+      {
+        "id": 23,
+        "entity_type": "taxonomy_term",
+        "label": "Innere Sicherheit",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/topics/23",
+        "abgeordnetenwatch_url": "https://www.abgeordnetenwatch.de/themen-dip21/innere-sicherheit"
+      },
+      {
+        "id": 22,
+        "entity_type": "taxonomy_term",
+        "label": "Öffentliche Finanzen",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/topics/22",
+        "abgeordnetenwatch_url": "https://www.abgeordnetenwatch.de/themen-dip21/oeffentliche-finanzen-steuern-und-abgaben"
+      }
+    ],
+    "field_accepted": true,
+    "field_committees": null,
+    "field_intro": "<p>Am 14. Mai 2020 haben die Abgeordneten des Deutschen Bundestages über Corona-Maßnahmen zum Schutz der Bevölkerung abgestimmt.</p>",
+    "field_poll_date": "2020-05-14",
+    "field_related_links": []
+  }
+}

--- a/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/fixtures/aw_poll_3602_votes.json
+++ b/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/fixtures/aw_poll_3602_votes.json
@@ -1,0 +1,18474 @@
+{
+  "meta": {
+    "abgeordnetenwatch_api": {
+      "version": "2.9.0",
+      "licence": "CC0 1.0",
+      "documentation": "https://www.abgeordnetenwatch.de/api/entitaeten/vote"
+    },
+    "status": "ok",
+    "status_message": "",
+    "result": {
+      "count": 710,
+      "total": 710,
+      "range_start": 0,
+      "range_end": 800
+    }
+  },
+  "data": [
+    {
+      "id": 357600,
+      "entity_type": "vote",
+      "label": "Mandate 46500 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357600",
+      "mandate": {
+        "id": 46500,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46500 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46500"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357601,
+      "entity_type": "vote",
+      "label": "Mandate 46501 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357601",
+      "mandate": {
+        "id": 46501,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46501 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46501"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357602,
+      "entity_type": "vote",
+      "label": "Mandate 46502 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357602",
+      "mandate": {
+        "id": 46502,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46502 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46502"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357603,
+      "entity_type": "vote",
+      "label": "Mandate 46503 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357603",
+      "mandate": {
+        "id": 46503,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46503 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46503"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357604,
+      "entity_type": "vote",
+      "label": "Mandate 46504 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357604",
+      "mandate": {
+        "id": 46504,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46504 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46504"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357605,
+      "entity_type": "vote",
+      "label": "Mandate 46505 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357605",
+      "mandate": {
+        "id": 46505,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46505 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46505"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357606,
+      "entity_type": "vote",
+      "label": "Mandate 46506 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357606",
+      "mandate": {
+        "id": 46506,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46506 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46506"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357607,
+      "entity_type": "vote",
+      "label": "Mandate 46507 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357607",
+      "mandate": {
+        "id": 46507,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46507 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46507"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357608,
+      "entity_type": "vote",
+      "label": "Mandate 46508 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357608",
+      "mandate": {
+        "id": 46508,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46508 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46508"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357609,
+      "entity_type": "vote",
+      "label": "Mandate 46509 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357609",
+      "mandate": {
+        "id": 46509,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46509 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46509"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357610,
+      "entity_type": "vote",
+      "label": "Mandate 46510 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357610",
+      "mandate": {
+        "id": 46510,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46510 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46510"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357611,
+      "entity_type": "vote",
+      "label": "Mandate 46511 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357611",
+      "mandate": {
+        "id": 46511,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46511 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46511"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357612,
+      "entity_type": "vote",
+      "label": "Mandate 46512 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357612",
+      "mandate": {
+        "id": 46512,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46512 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46512"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357613,
+      "entity_type": "vote",
+      "label": "Mandate 46513 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357613",
+      "mandate": {
+        "id": 46513,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46513 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46513"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357614,
+      "entity_type": "vote",
+      "label": "Mandate 46514 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357614",
+      "mandate": {
+        "id": 46514,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46514 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46514"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357615,
+      "entity_type": "vote",
+      "label": "Mandate 46515 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357615",
+      "mandate": {
+        "id": 46515,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46515 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46515"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357616,
+      "entity_type": "vote",
+      "label": "Mandate 46516 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357616",
+      "mandate": {
+        "id": 46516,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46516 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46516"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357617,
+      "entity_type": "vote",
+      "label": "Mandate 46517 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357617",
+      "mandate": {
+        "id": 46517,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46517 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46517"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357618,
+      "entity_type": "vote",
+      "label": "Mandate 46518 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357618",
+      "mandate": {
+        "id": 46518,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46518 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46518"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357619,
+      "entity_type": "vote",
+      "label": "Mandate 46519 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357619",
+      "mandate": {
+        "id": 46519,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46519 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46519"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357620,
+      "entity_type": "vote",
+      "label": "Mandate 46520 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357620",
+      "mandate": {
+        "id": 46520,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46520 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46520"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357621,
+      "entity_type": "vote",
+      "label": "Mandate 46521 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357621",
+      "mandate": {
+        "id": 46521,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46521 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46521"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357622,
+      "entity_type": "vote",
+      "label": "Mandate 46522 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357622",
+      "mandate": {
+        "id": 46522,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46522 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46522"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357623,
+      "entity_type": "vote",
+      "label": "Mandate 46523 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357623",
+      "mandate": {
+        "id": 46523,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46523 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46523"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357624,
+      "entity_type": "vote",
+      "label": "Mandate 46524 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357624",
+      "mandate": {
+        "id": 46524,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46524 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46524"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357625,
+      "entity_type": "vote",
+      "label": "Mandate 46525 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357625",
+      "mandate": {
+        "id": 46525,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46525 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46525"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357626,
+      "entity_type": "vote",
+      "label": "Mandate 46526 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357626",
+      "mandate": {
+        "id": 46526,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46526 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46526"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357627,
+      "entity_type": "vote",
+      "label": "Mandate 46527 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357627",
+      "mandate": {
+        "id": 46527,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46527 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46527"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357628,
+      "entity_type": "vote",
+      "label": "Mandate 46528 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357628",
+      "mandate": {
+        "id": 46528,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46528 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46528"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357629,
+      "entity_type": "vote",
+      "label": "Mandate 46529 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357629",
+      "mandate": {
+        "id": 46529,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46529 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46529"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357630,
+      "entity_type": "vote",
+      "label": "Mandate 46530 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357630",
+      "mandate": {
+        "id": 46530,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46530 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46530"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357631,
+      "entity_type": "vote",
+      "label": "Mandate 46531 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357631",
+      "mandate": {
+        "id": 46531,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46531 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46531"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357632,
+      "entity_type": "vote",
+      "label": "Mandate 46532 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357632",
+      "mandate": {
+        "id": 46532,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46532 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46532"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357633,
+      "entity_type": "vote",
+      "label": "Mandate 46533 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357633",
+      "mandate": {
+        "id": 46533,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46533 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46533"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357634,
+      "entity_type": "vote",
+      "label": "Mandate 46534 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357634",
+      "mandate": {
+        "id": 46534,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46534 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46534"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357635,
+      "entity_type": "vote",
+      "label": "Mandate 46535 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357635",
+      "mandate": {
+        "id": 46535,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46535 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46535"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357636,
+      "entity_type": "vote",
+      "label": "Mandate 46536 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357636",
+      "mandate": {
+        "id": 46536,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46536 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46536"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357637,
+      "entity_type": "vote",
+      "label": "Mandate 46537 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357637",
+      "mandate": {
+        "id": 46537,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46537 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46537"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357638,
+      "entity_type": "vote",
+      "label": "Mandate 46538 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357638",
+      "mandate": {
+        "id": 46538,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46538 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46538"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357639,
+      "entity_type": "vote",
+      "label": "Mandate 46539 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357639",
+      "mandate": {
+        "id": 46539,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46539 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46539"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357640,
+      "entity_type": "vote",
+      "label": "Mandate 46540 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357640",
+      "mandate": {
+        "id": 46540,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46540 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46540"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357641,
+      "entity_type": "vote",
+      "label": "Mandate 46541 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357641",
+      "mandate": {
+        "id": 46541,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46541 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46541"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357642,
+      "entity_type": "vote",
+      "label": "Mandate 46542 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357642",
+      "mandate": {
+        "id": 46542,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46542 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46542"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357643,
+      "entity_type": "vote",
+      "label": "Mandate 46543 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357643",
+      "mandate": {
+        "id": 46543,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46543 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46543"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357644,
+      "entity_type": "vote",
+      "label": "Mandate 46544 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357644",
+      "mandate": {
+        "id": 46544,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46544 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46544"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357645,
+      "entity_type": "vote",
+      "label": "Mandate 46545 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357645",
+      "mandate": {
+        "id": 46545,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46545 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46545"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357646,
+      "entity_type": "vote",
+      "label": "Mandate 46546 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357646",
+      "mandate": {
+        "id": 46546,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46546 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46546"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357647,
+      "entity_type": "vote",
+      "label": "Mandate 46547 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357647",
+      "mandate": {
+        "id": 46547,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46547 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46547"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357648,
+      "entity_type": "vote",
+      "label": "Mandate 46548 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357648",
+      "mandate": {
+        "id": 46548,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46548 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46548"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357649,
+      "entity_type": "vote",
+      "label": "Mandate 46549 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357649",
+      "mandate": {
+        "id": 46549,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46549 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46549"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357650,
+      "entity_type": "vote",
+      "label": "Mandate 46550 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357650",
+      "mandate": {
+        "id": 46550,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46550 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46550"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357651,
+      "entity_type": "vote",
+      "label": "Mandate 46551 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357651",
+      "mandate": {
+        "id": 46551,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46551 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46551"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357652,
+      "entity_type": "vote",
+      "label": "Mandate 46552 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357652",
+      "mandate": {
+        "id": 46552,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46552 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46552"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357653,
+      "entity_type": "vote",
+      "label": "Mandate 46553 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357653",
+      "mandate": {
+        "id": 46553,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46553 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46553"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357654,
+      "entity_type": "vote",
+      "label": "Mandate 46554 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357654",
+      "mandate": {
+        "id": 46554,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46554 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46554"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357655,
+      "entity_type": "vote",
+      "label": "Mandate 46555 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357655",
+      "mandate": {
+        "id": 46555,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46555 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46555"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357656,
+      "entity_type": "vote",
+      "label": "Mandate 46556 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357656",
+      "mandate": {
+        "id": 46556,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46556 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46556"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357657,
+      "entity_type": "vote",
+      "label": "Mandate 46557 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357657",
+      "mandate": {
+        "id": 46557,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46557 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46557"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357658,
+      "entity_type": "vote",
+      "label": "Mandate 46558 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357658",
+      "mandate": {
+        "id": 46558,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46558 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46558"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357659,
+      "entity_type": "vote",
+      "label": "Mandate 46559 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357659",
+      "mandate": {
+        "id": 46559,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46559 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46559"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357660,
+      "entity_type": "vote",
+      "label": "Mandate 46560 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357660",
+      "mandate": {
+        "id": 46560,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46560 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46560"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357661,
+      "entity_type": "vote",
+      "label": "Mandate 46561 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357661",
+      "mandate": {
+        "id": 46561,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46561 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46561"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357662,
+      "entity_type": "vote",
+      "label": "Mandate 46562 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357662",
+      "mandate": {
+        "id": 46562,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46562 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46562"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357663,
+      "entity_type": "vote",
+      "label": "Mandate 46563 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357663",
+      "mandate": {
+        "id": 46563,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46563 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46563"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357664,
+      "entity_type": "vote",
+      "label": "Mandate 46564 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357664",
+      "mandate": {
+        "id": 46564,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46564 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46564"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357665,
+      "entity_type": "vote",
+      "label": "Mandate 46565 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357665",
+      "mandate": {
+        "id": 46565,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46565 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46565"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357666,
+      "entity_type": "vote",
+      "label": "Mandate 46566 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357666",
+      "mandate": {
+        "id": 46566,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46566 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46566"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357667,
+      "entity_type": "vote",
+      "label": "Mandate 46567 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357667",
+      "mandate": {
+        "id": 46567,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46567 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46567"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357668,
+      "entity_type": "vote",
+      "label": "Mandate 46568 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357668",
+      "mandate": {
+        "id": 46568,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46568 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46568"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357669,
+      "entity_type": "vote",
+      "label": "Mandate 46569 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357669",
+      "mandate": {
+        "id": 46569,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46569 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46569"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357670,
+      "entity_type": "vote",
+      "label": "Mandate 46570 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357670",
+      "mandate": {
+        "id": 46570,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46570 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46570"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357671,
+      "entity_type": "vote",
+      "label": "Mandate 46571 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357671",
+      "mandate": {
+        "id": 46571,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46571 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46571"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357672,
+      "entity_type": "vote",
+      "label": "Mandate 46572 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357672",
+      "mandate": {
+        "id": 46572,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46572 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46572"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357673,
+      "entity_type": "vote",
+      "label": "Mandate 46573 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357673",
+      "mandate": {
+        "id": 46573,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46573 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46573"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357674,
+      "entity_type": "vote",
+      "label": "Mandate 46574 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357674",
+      "mandate": {
+        "id": 46574,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46574 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46574"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357675,
+      "entity_type": "vote",
+      "label": "Mandate 46575 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357675",
+      "mandate": {
+        "id": 46575,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46575 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46575"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357676,
+      "entity_type": "vote",
+      "label": "Mandate 46576 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357676",
+      "mandate": {
+        "id": 46576,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46576 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46576"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357677,
+      "entity_type": "vote",
+      "label": "Mandate 46577 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357677",
+      "mandate": {
+        "id": 46577,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46577 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46577"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357678,
+      "entity_type": "vote",
+      "label": "Mandate 46578 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357678",
+      "mandate": {
+        "id": 46578,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46578 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46578"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357679,
+      "entity_type": "vote",
+      "label": "Mandate 46579 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357679",
+      "mandate": {
+        "id": 46579,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46579 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46579"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 14,
+        "entity_type": "fraction",
+        "label": "FDP (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/14"
+      }
+    },
+    {
+      "id": 357680,
+      "entity_type": "vote",
+      "label": "Mandate 46580 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357680",
+      "mandate": {
+        "id": 46580,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46580 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46580"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357681,
+      "entity_type": "vote",
+      "label": "Mandate 46581 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357681",
+      "mandate": {
+        "id": 46581,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46581 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46581"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357682,
+      "entity_type": "vote",
+      "label": "Mandate 46582 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357682",
+      "mandate": {
+        "id": 46582,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46582 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46582"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357683,
+      "entity_type": "vote",
+      "label": "Mandate 46583 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357683",
+      "mandate": {
+        "id": 46583,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46583 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46583"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357684,
+      "entity_type": "vote",
+      "label": "Mandate 46584 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357684",
+      "mandate": {
+        "id": 46584,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46584 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46584"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357685,
+      "entity_type": "vote",
+      "label": "Mandate 46585 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357685",
+      "mandate": {
+        "id": 46585,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46585 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46585"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357686,
+      "entity_type": "vote",
+      "label": "Mandate 46586 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357686",
+      "mandate": {
+        "id": 46586,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46586 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46586"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357687,
+      "entity_type": "vote",
+      "label": "Mandate 46587 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357687",
+      "mandate": {
+        "id": 46587,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46587 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46587"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357688,
+      "entity_type": "vote",
+      "label": "Mandate 46588 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357688",
+      "mandate": {
+        "id": 46588,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46588 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46588"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357689,
+      "entity_type": "vote",
+      "label": "Mandate 46589 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357689",
+      "mandate": {
+        "id": 46589,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46589 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46589"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357690,
+      "entity_type": "vote",
+      "label": "Mandate 46590 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357690",
+      "mandate": {
+        "id": 46590,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46590 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46590"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357691,
+      "entity_type": "vote",
+      "label": "Mandate 46591 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357691",
+      "mandate": {
+        "id": 46591,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46591 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46591"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357692,
+      "entity_type": "vote",
+      "label": "Mandate 46592 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357692",
+      "mandate": {
+        "id": 46592,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46592 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46592"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357693,
+      "entity_type": "vote",
+      "label": "Mandate 46593 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357693",
+      "mandate": {
+        "id": 46593,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46593 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46593"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357694,
+      "entity_type": "vote",
+      "label": "Mandate 46594 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357694",
+      "mandate": {
+        "id": 46594,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46594 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46594"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357695,
+      "entity_type": "vote",
+      "label": "Mandate 46595 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357695",
+      "mandate": {
+        "id": 46595,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46595 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46595"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357696,
+      "entity_type": "vote",
+      "label": "Mandate 46596 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357696",
+      "mandate": {
+        "id": 46596,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46596 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46596"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357697,
+      "entity_type": "vote",
+      "label": "Mandate 46597 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357697",
+      "mandate": {
+        "id": 46597,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46597 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46597"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357698,
+      "entity_type": "vote",
+      "label": "Mandate 46598 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357698",
+      "mandate": {
+        "id": 46598,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46598 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46598"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357699,
+      "entity_type": "vote",
+      "label": "Mandate 46599 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357699",
+      "mandate": {
+        "id": 46599,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46599 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46599"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357700,
+      "entity_type": "vote",
+      "label": "Mandate 46600 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357700",
+      "mandate": {
+        "id": 46600,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46600 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46600"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357701,
+      "entity_type": "vote",
+      "label": "Mandate 46601 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357701",
+      "mandate": {
+        "id": 46601,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46601 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46601"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357702,
+      "entity_type": "vote",
+      "label": "Mandate 46602 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357702",
+      "mandate": {
+        "id": 46602,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46602 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46602"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357703,
+      "entity_type": "vote",
+      "label": "Mandate 46603 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357703",
+      "mandate": {
+        "id": 46603,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46603 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46603"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357704,
+      "entity_type": "vote",
+      "label": "Mandate 46604 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357704",
+      "mandate": {
+        "id": 46604,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46604 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46604"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357705,
+      "entity_type": "vote",
+      "label": "Mandate 46605 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357705",
+      "mandate": {
+        "id": 46605,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46605 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46605"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357706,
+      "entity_type": "vote",
+      "label": "Mandate 46606 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357706",
+      "mandate": {
+        "id": 46606,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46606 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46606"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357707,
+      "entity_type": "vote",
+      "label": "Mandate 46607 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357707",
+      "mandate": {
+        "id": 46607,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46607 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46607"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357708,
+      "entity_type": "vote",
+      "label": "Mandate 46608 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357708",
+      "mandate": {
+        "id": 46608,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46608 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46608"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357709,
+      "entity_type": "vote",
+      "label": "Mandate 46609 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357709",
+      "mandate": {
+        "id": 46609,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46609 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46609"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357710,
+      "entity_type": "vote",
+      "label": "Mandate 46610 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357710",
+      "mandate": {
+        "id": 46610,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46610 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46610"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357711,
+      "entity_type": "vote",
+      "label": "Mandate 46611 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357711",
+      "mandate": {
+        "id": 46611,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46611 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46611"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357712,
+      "entity_type": "vote",
+      "label": "Mandate 46612 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357712",
+      "mandate": {
+        "id": 46612,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46612 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46612"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357713,
+      "entity_type": "vote",
+      "label": "Mandate 46613 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357713",
+      "mandate": {
+        "id": 46613,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46613 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46613"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357714,
+      "entity_type": "vote",
+      "label": "Mandate 46614 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357714",
+      "mandate": {
+        "id": 46614,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46614 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46614"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357715,
+      "entity_type": "vote",
+      "label": "Mandate 46615 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357715",
+      "mandate": {
+        "id": 46615,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46615 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46615"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357716,
+      "entity_type": "vote",
+      "label": "Mandate 46616 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357716",
+      "mandate": {
+        "id": 46616,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46616 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46616"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357717,
+      "entity_type": "vote",
+      "label": "Mandate 46617 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357717",
+      "mandate": {
+        "id": 46617,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46617 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46617"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357718,
+      "entity_type": "vote",
+      "label": "Mandate 46618 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357718",
+      "mandate": {
+        "id": 46618,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46618 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46618"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357719,
+      "entity_type": "vote",
+      "label": "Mandate 46619 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357719",
+      "mandate": {
+        "id": 46619,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46619 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46619"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357720,
+      "entity_type": "vote",
+      "label": "Mandate 46620 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357720",
+      "mandate": {
+        "id": 46620,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46620 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46620"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357721,
+      "entity_type": "vote",
+      "label": "Mandate 46621 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357721",
+      "mandate": {
+        "id": 46621,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46621 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46621"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357722,
+      "entity_type": "vote",
+      "label": "Mandate 46622 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357722",
+      "mandate": {
+        "id": 46622,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46622 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46622"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357723,
+      "entity_type": "vote",
+      "label": "Mandate 46623 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357723",
+      "mandate": {
+        "id": 46623,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46623 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46623"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357724,
+      "entity_type": "vote",
+      "label": "Mandate 46624 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357724",
+      "mandate": {
+        "id": 46624,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46624 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46624"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357725,
+      "entity_type": "vote",
+      "label": "Mandate 46625 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357725",
+      "mandate": {
+        "id": 46625,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46625 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46625"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357726,
+      "entity_type": "vote",
+      "label": "Mandate 46626 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357726",
+      "mandate": {
+        "id": 46626,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46626 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46626"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357727,
+      "entity_type": "vote",
+      "label": "Mandate 46627 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357727",
+      "mandate": {
+        "id": 46627,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46627 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46627"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357728,
+      "entity_type": "vote",
+      "label": "Mandate 46628 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357728",
+      "mandate": {
+        "id": 46628,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46628 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46628"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357729,
+      "entity_type": "vote",
+      "label": "Mandate 46629 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357729",
+      "mandate": {
+        "id": 46629,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46629 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46629"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357730,
+      "entity_type": "vote",
+      "label": "Mandate 46630 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357730",
+      "mandate": {
+        "id": 46630,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46630 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46630"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357731,
+      "entity_type": "vote",
+      "label": "Mandate 46631 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357731",
+      "mandate": {
+        "id": 46631,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46631 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46631"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357732,
+      "entity_type": "vote",
+      "label": "Mandate 46632 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357732",
+      "mandate": {
+        "id": 46632,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46632 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46632"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357733,
+      "entity_type": "vote",
+      "label": "Mandate 46633 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357733",
+      "mandate": {
+        "id": 46633,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46633 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46633"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357734,
+      "entity_type": "vote",
+      "label": "Mandate 46634 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357734",
+      "mandate": {
+        "id": 46634,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46634 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46634"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357735,
+      "entity_type": "vote",
+      "label": "Mandate 46635 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357735",
+      "mandate": {
+        "id": 46635,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46635 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46635"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357736,
+      "entity_type": "vote",
+      "label": "Mandate 46636 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357736",
+      "mandate": {
+        "id": 46636,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46636 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46636"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357737,
+      "entity_type": "vote",
+      "label": "Mandate 46637 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357737",
+      "mandate": {
+        "id": 46637,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46637 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46637"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357738,
+      "entity_type": "vote",
+      "label": "Mandate 46638 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357738",
+      "mandate": {
+        "id": 46638,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46638 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46638"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357739,
+      "entity_type": "vote",
+      "label": "Mandate 46639 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357739",
+      "mandate": {
+        "id": 46639,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46639 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46639"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357740,
+      "entity_type": "vote",
+      "label": "Mandate 46640 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357740",
+      "mandate": {
+        "id": 46640,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46640 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46640"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357741,
+      "entity_type": "vote",
+      "label": "Mandate 46641 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357741",
+      "mandate": {
+        "id": 46641,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46641 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46641"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357742,
+      "entity_type": "vote",
+      "label": "Mandate 46642 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357742",
+      "mandate": {
+        "id": 46642,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46642 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46642"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357743,
+      "entity_type": "vote",
+      "label": "Mandate 46643 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357743",
+      "mandate": {
+        "id": 46643,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46643 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46643"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357744,
+      "entity_type": "vote",
+      "label": "Mandate 46644 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357744",
+      "mandate": {
+        "id": 46644,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46644 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46644"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357745,
+      "entity_type": "vote",
+      "label": "Mandate 46645 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357745",
+      "mandate": {
+        "id": 46645,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46645 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46645"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357746,
+      "entity_type": "vote",
+      "label": "Mandate 46646 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357746",
+      "mandate": {
+        "id": 46646,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46646 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46646"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357747,
+      "entity_type": "vote",
+      "label": "Mandate 46647 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357747",
+      "mandate": {
+        "id": 46647,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46647 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46647"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357748,
+      "entity_type": "vote",
+      "label": "Mandate 46648 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357748",
+      "mandate": {
+        "id": 46648,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46648 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46648"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357749,
+      "entity_type": "vote",
+      "label": "Mandate 46649 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357749",
+      "mandate": {
+        "id": 46649,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46649 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46649"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357750,
+      "entity_type": "vote",
+      "label": "Mandate 46650 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357750",
+      "mandate": {
+        "id": 46650,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46650 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46650"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357751,
+      "entity_type": "vote",
+      "label": "Mandate 46651 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357751",
+      "mandate": {
+        "id": 46651,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46651 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46651"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357752,
+      "entity_type": "vote",
+      "label": "Mandate 46652 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357752",
+      "mandate": {
+        "id": 46652,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46652 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46652"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357753,
+      "entity_type": "vote",
+      "label": "Mandate 46653 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357753",
+      "mandate": {
+        "id": 46653,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46653 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46653"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357754,
+      "entity_type": "vote",
+      "label": "Mandate 46654 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357754",
+      "mandate": {
+        "id": 46654,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46654 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46654"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357755,
+      "entity_type": "vote",
+      "label": "Mandate 46655 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357755",
+      "mandate": {
+        "id": 46655,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46655 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46655"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357756,
+      "entity_type": "vote",
+      "label": "Mandate 46656 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357756",
+      "mandate": {
+        "id": 46656,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46656 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46656"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357757,
+      "entity_type": "vote",
+      "label": "Mandate 46657 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357757",
+      "mandate": {
+        "id": 46657,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46657 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46657"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357758,
+      "entity_type": "vote",
+      "label": "Mandate 46658 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357758",
+      "mandate": {
+        "id": 46658,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46658 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46658"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357759,
+      "entity_type": "vote",
+      "label": "Mandate 46659 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357759",
+      "mandate": {
+        "id": 46659,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46659 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46659"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357760,
+      "entity_type": "vote",
+      "label": "Mandate 46660 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357760",
+      "mandate": {
+        "id": 46660,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46660 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46660"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357761,
+      "entity_type": "vote",
+      "label": "Mandate 46661 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357761",
+      "mandate": {
+        "id": 46661,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46661 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46661"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357762,
+      "entity_type": "vote",
+      "label": "Mandate 46662 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357762",
+      "mandate": {
+        "id": 46662,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46662 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46662"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357763,
+      "entity_type": "vote",
+      "label": "Mandate 46663 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357763",
+      "mandate": {
+        "id": 46663,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46663 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46663"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357764,
+      "entity_type": "vote",
+      "label": "Mandate 46664 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357764",
+      "mandate": {
+        "id": 46664,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46664 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46664"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357765,
+      "entity_type": "vote",
+      "label": "Mandate 46665 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357765",
+      "mandate": {
+        "id": 46665,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46665 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46665"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357766,
+      "entity_type": "vote",
+      "label": "Mandate 46666 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357766",
+      "mandate": {
+        "id": 46666,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46666 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46666"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357767,
+      "entity_type": "vote",
+      "label": "Mandate 46667 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357767",
+      "mandate": {
+        "id": 46667,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46667 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46667"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357768,
+      "entity_type": "vote",
+      "label": "Mandate 46668 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357768",
+      "mandate": {
+        "id": 46668,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46668 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46668"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357769,
+      "entity_type": "vote",
+      "label": "Mandate 46669 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357769",
+      "mandate": {
+        "id": 46669,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46669 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46669"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357770,
+      "entity_type": "vote",
+      "label": "Mandate 46670 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357770",
+      "mandate": {
+        "id": 46670,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46670 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46670"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357771,
+      "entity_type": "vote",
+      "label": "Mandate 46671 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357771",
+      "mandate": {
+        "id": 46671,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46671 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46671"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357772,
+      "entity_type": "vote",
+      "label": "Mandate 46672 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357772",
+      "mandate": {
+        "id": 46672,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46672 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46672"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357773,
+      "entity_type": "vote",
+      "label": "Mandate 46673 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357773",
+      "mandate": {
+        "id": 46673,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46673 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46673"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357774,
+      "entity_type": "vote",
+      "label": "Mandate 46674 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357774",
+      "mandate": {
+        "id": 46674,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46674 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46674"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357775,
+      "entity_type": "vote",
+      "label": "Mandate 46675 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357775",
+      "mandate": {
+        "id": 46675,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46675 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46675"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357776,
+      "entity_type": "vote",
+      "label": "Mandate 46676 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357776",
+      "mandate": {
+        "id": 46676,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46676 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46676"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357777,
+      "entity_type": "vote",
+      "label": "Mandate 46677 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357777",
+      "mandate": {
+        "id": 46677,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46677 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46677"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357778,
+      "entity_type": "vote",
+      "label": "Mandate 46678 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357778",
+      "mandate": {
+        "id": 46678,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46678 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46678"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357779,
+      "entity_type": "vote",
+      "label": "Mandate 46679 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357779",
+      "mandate": {
+        "id": 46679,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46679 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46679"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357780,
+      "entity_type": "vote",
+      "label": "Mandate 46680 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357780",
+      "mandate": {
+        "id": 46680,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46680 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46680"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357781,
+      "entity_type": "vote",
+      "label": "Mandate 46681 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357781",
+      "mandate": {
+        "id": 46681,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46681 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46681"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357782,
+      "entity_type": "vote",
+      "label": "Mandate 46682 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357782",
+      "mandate": {
+        "id": 46682,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46682 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46682"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357783,
+      "entity_type": "vote",
+      "label": "Mandate 46683 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357783",
+      "mandate": {
+        "id": 46683,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46683 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46683"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357784,
+      "entity_type": "vote",
+      "label": "Mandate 46684 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357784",
+      "mandate": {
+        "id": 46684,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46684 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46684"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357785,
+      "entity_type": "vote",
+      "label": "Mandate 46685 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357785",
+      "mandate": {
+        "id": 46685,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46685 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46685"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357786,
+      "entity_type": "vote",
+      "label": "Mandate 46686 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357786",
+      "mandate": {
+        "id": 46686,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46686 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46686"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357787,
+      "entity_type": "vote",
+      "label": "Mandate 46687 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357787",
+      "mandate": {
+        "id": 46687,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46687 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46687"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357788,
+      "entity_type": "vote",
+      "label": "Mandate 46688 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357788",
+      "mandate": {
+        "id": 46688,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46688 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46688"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357789,
+      "entity_type": "vote",
+      "label": "Mandate 46689 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357789",
+      "mandate": {
+        "id": 46689,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46689 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46689"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357790,
+      "entity_type": "vote",
+      "label": "Mandate 46690 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357790",
+      "mandate": {
+        "id": 46690,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46690 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46690"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357791,
+      "entity_type": "vote",
+      "label": "Mandate 46691 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357791",
+      "mandate": {
+        "id": 46691,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46691 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46691"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357792,
+      "entity_type": "vote",
+      "label": "Mandate 46692 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357792",
+      "mandate": {
+        "id": 46692,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46692 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46692"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357793,
+      "entity_type": "vote",
+      "label": "Mandate 46693 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357793",
+      "mandate": {
+        "id": 46693,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46693 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46693"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357794,
+      "entity_type": "vote",
+      "label": "Mandate 46694 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357794",
+      "mandate": {
+        "id": 46694,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46694 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46694"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357795,
+      "entity_type": "vote",
+      "label": "Mandate 46695 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357795",
+      "mandate": {
+        "id": 46695,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46695 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46695"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357796,
+      "entity_type": "vote",
+      "label": "Mandate 46696 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357796",
+      "mandate": {
+        "id": 46696,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46696 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46696"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357797,
+      "entity_type": "vote",
+      "label": "Mandate 46697 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357797",
+      "mandate": {
+        "id": 46697,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46697 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46697"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357798,
+      "entity_type": "vote",
+      "label": "Mandate 46698 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357798",
+      "mandate": {
+        "id": 46698,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46698 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46698"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357799,
+      "entity_type": "vote",
+      "label": "Mandate 46699 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357799",
+      "mandate": {
+        "id": 46699,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46699 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46699"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357800,
+      "entity_type": "vote",
+      "label": "Mandate 46700 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357800",
+      "mandate": {
+        "id": 46700,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46700 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46700"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357801,
+      "entity_type": "vote",
+      "label": "Mandate 46701 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357801",
+      "mandate": {
+        "id": 46701,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46701 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46701"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357802,
+      "entity_type": "vote",
+      "label": "Mandate 46702 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357802",
+      "mandate": {
+        "id": 46702,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46702 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46702"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357803,
+      "entity_type": "vote",
+      "label": "Mandate 46703 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357803",
+      "mandate": {
+        "id": 46703,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46703 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46703"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357804,
+      "entity_type": "vote",
+      "label": "Mandate 46704 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357804",
+      "mandate": {
+        "id": 46704,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46704 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46704"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357805,
+      "entity_type": "vote",
+      "label": "Mandate 46705 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357805",
+      "mandate": {
+        "id": 46705,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46705 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46705"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357806,
+      "entity_type": "vote",
+      "label": "Mandate 46706 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357806",
+      "mandate": {
+        "id": 46706,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46706 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46706"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357807,
+      "entity_type": "vote",
+      "label": "Mandate 46707 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357807",
+      "mandate": {
+        "id": 46707,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46707 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46707"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357808,
+      "entity_type": "vote",
+      "label": "Mandate 46708 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357808",
+      "mandate": {
+        "id": 46708,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46708 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46708"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357809,
+      "entity_type": "vote",
+      "label": "Mandate 46709 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357809",
+      "mandate": {
+        "id": 46709,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46709 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46709"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357810,
+      "entity_type": "vote",
+      "label": "Mandate 46710 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357810",
+      "mandate": {
+        "id": 46710,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46710 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46710"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357811,
+      "entity_type": "vote",
+      "label": "Mandate 46711 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357811",
+      "mandate": {
+        "id": 46711,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46711 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46711"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357812,
+      "entity_type": "vote",
+      "label": "Mandate 46712 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357812",
+      "mandate": {
+        "id": 46712,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46712 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46712"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357813,
+      "entity_type": "vote",
+      "label": "Mandate 46713 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357813",
+      "mandate": {
+        "id": 46713,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46713 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46713"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357814,
+      "entity_type": "vote",
+      "label": "Mandate 46714 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357814",
+      "mandate": {
+        "id": 46714,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46714 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46714"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357815,
+      "entity_type": "vote",
+      "label": "Mandate 46715 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357815",
+      "mandate": {
+        "id": 46715,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46715 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46715"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357816,
+      "entity_type": "vote",
+      "label": "Mandate 46716 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357816",
+      "mandate": {
+        "id": 46716,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46716 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46716"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357817,
+      "entity_type": "vote",
+      "label": "Mandate 46717 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357817",
+      "mandate": {
+        "id": 46717,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46717 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46717"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357818,
+      "entity_type": "vote",
+      "label": "Mandate 46718 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357818",
+      "mandate": {
+        "id": 46718,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46718 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46718"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357819,
+      "entity_type": "vote",
+      "label": "Mandate 46719 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357819",
+      "mandate": {
+        "id": 46719,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46719 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46719"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357820,
+      "entity_type": "vote",
+      "label": "Mandate 46720 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357820",
+      "mandate": {
+        "id": 46720,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46720 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46720"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357821,
+      "entity_type": "vote",
+      "label": "Mandate 46721 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357821",
+      "mandate": {
+        "id": 46721,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46721 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46721"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357822,
+      "entity_type": "vote",
+      "label": "Mandate 46722 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357822",
+      "mandate": {
+        "id": 46722,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46722 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46722"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357823,
+      "entity_type": "vote",
+      "label": "Mandate 46723 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357823",
+      "mandate": {
+        "id": 46723,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46723 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46723"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357824,
+      "entity_type": "vote",
+      "label": "Mandate 46724 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357824",
+      "mandate": {
+        "id": 46724,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46724 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46724"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357825,
+      "entity_type": "vote",
+      "label": "Mandate 46725 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357825",
+      "mandate": {
+        "id": 46725,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46725 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46725"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357826,
+      "entity_type": "vote",
+      "label": "Mandate 46726 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357826",
+      "mandate": {
+        "id": 46726,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46726 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46726"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357827,
+      "entity_type": "vote",
+      "label": "Mandate 46727 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357827",
+      "mandate": {
+        "id": 46727,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46727 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46727"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357828,
+      "entity_type": "vote",
+      "label": "Mandate 46728 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357828",
+      "mandate": {
+        "id": 46728,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46728 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46728"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357829,
+      "entity_type": "vote",
+      "label": "Mandate 46729 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357829",
+      "mandate": {
+        "id": 46729,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46729 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46729"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357830,
+      "entity_type": "vote",
+      "label": "Mandate 46730 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357830",
+      "mandate": {
+        "id": 46730,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46730 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46730"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357831,
+      "entity_type": "vote",
+      "label": "Mandate 46731 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357831",
+      "mandate": {
+        "id": 46731,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46731 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46731"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 22,
+        "entity_type": "fraction",
+        "label": "SPD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/22"
+      }
+    },
+    {
+      "id": 357832,
+      "entity_type": "vote",
+      "label": "Mandate 46732 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357832",
+      "mandate": {
+        "id": 46732,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46732 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46732"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357833,
+      "entity_type": "vote",
+      "label": "Mandate 46733 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357833",
+      "mandate": {
+        "id": 46733,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46733 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46733"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357834,
+      "entity_type": "vote",
+      "label": "Mandate 46734 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357834",
+      "mandate": {
+        "id": 46734,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46734 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46734"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357835,
+      "entity_type": "vote",
+      "label": "Mandate 46735 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357835",
+      "mandate": {
+        "id": 46735,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46735 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46735"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357836,
+      "entity_type": "vote",
+      "label": "Mandate 46736 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357836",
+      "mandate": {
+        "id": 46736,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46736 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46736"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357837,
+      "entity_type": "vote",
+      "label": "Mandate 46737 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357837",
+      "mandate": {
+        "id": 46737,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46737 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46737"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357838,
+      "entity_type": "vote",
+      "label": "Mandate 46738 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357838",
+      "mandate": {
+        "id": 46738,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46738 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46738"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357839,
+      "entity_type": "vote",
+      "label": "Mandate 46739 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357839",
+      "mandate": {
+        "id": 46739,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46739 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46739"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357840,
+      "entity_type": "vote",
+      "label": "Mandate 46740 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357840",
+      "mandate": {
+        "id": 46740,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46740 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46740"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357841,
+      "entity_type": "vote",
+      "label": "Mandate 46741 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357841",
+      "mandate": {
+        "id": 46741,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46741 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46741"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357842,
+      "entity_type": "vote",
+      "label": "Mandate 46742 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357842",
+      "mandate": {
+        "id": 46742,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46742 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46742"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357843,
+      "entity_type": "vote",
+      "label": "Mandate 46743 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357843",
+      "mandate": {
+        "id": 46743,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46743 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46743"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357844,
+      "entity_type": "vote",
+      "label": "Mandate 46744 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357844",
+      "mandate": {
+        "id": 46744,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46744 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46744"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357845,
+      "entity_type": "vote",
+      "label": "Mandate 46745 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357845",
+      "mandate": {
+        "id": 46745,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46745 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46745"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357846,
+      "entity_type": "vote",
+      "label": "Mandate 46746 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357846",
+      "mandate": {
+        "id": 46746,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46746 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46746"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357847,
+      "entity_type": "vote",
+      "label": "Mandate 46747 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357847",
+      "mandate": {
+        "id": 46747,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46747 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46747"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357848,
+      "entity_type": "vote",
+      "label": "Mandate 46748 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357848",
+      "mandate": {
+        "id": 46748,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46748 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46748"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357849,
+      "entity_type": "vote",
+      "label": "Mandate 46749 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357849",
+      "mandate": {
+        "id": 46749,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46749 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46749"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357850,
+      "entity_type": "vote",
+      "label": "Mandate 46750 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357850",
+      "mandate": {
+        "id": 46750,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46750 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46750"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357851,
+      "entity_type": "vote",
+      "label": "Mandate 46751 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357851",
+      "mandate": {
+        "id": 46751,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46751 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46751"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357852,
+      "entity_type": "vote",
+      "label": "Mandate 46752 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357852",
+      "mandate": {
+        "id": 46752,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46752 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46752"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357853,
+      "entity_type": "vote",
+      "label": "Mandate 46753 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357853",
+      "mandate": {
+        "id": 46753,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46753 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46753"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357854,
+      "entity_type": "vote",
+      "label": "Mandate 46754 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357854",
+      "mandate": {
+        "id": 46754,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46754 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46754"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357855,
+      "entity_type": "vote",
+      "label": "Mandate 46755 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357855",
+      "mandate": {
+        "id": 46755,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46755 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46755"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357856,
+      "entity_type": "vote",
+      "label": "Mandate 46756 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357856",
+      "mandate": {
+        "id": 46756,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46756 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46756"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357857,
+      "entity_type": "vote",
+      "label": "Mandate 46757 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357857",
+      "mandate": {
+        "id": 46757,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46757 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46757"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357858,
+      "entity_type": "vote",
+      "label": "Mandate 46758 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357858",
+      "mandate": {
+        "id": 46758,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46758 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46758"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357859,
+      "entity_type": "vote",
+      "label": "Mandate 46759 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357859",
+      "mandate": {
+        "id": 46759,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46759 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46759"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357860,
+      "entity_type": "vote",
+      "label": "Mandate 46760 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357860",
+      "mandate": {
+        "id": 46760,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46760 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46760"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357861,
+      "entity_type": "vote",
+      "label": "Mandate 46761 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357861",
+      "mandate": {
+        "id": 46761,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46761 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46761"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357862,
+      "entity_type": "vote",
+      "label": "Mandate 46762 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357862",
+      "mandate": {
+        "id": 46762,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46762 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46762"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357863,
+      "entity_type": "vote",
+      "label": "Mandate 46763 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357863",
+      "mandate": {
+        "id": 46763,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46763 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46763"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357864,
+      "entity_type": "vote",
+      "label": "Mandate 46764 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357864",
+      "mandate": {
+        "id": 46764,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46764 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46764"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357865,
+      "entity_type": "vote",
+      "label": "Mandate 46765 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357865",
+      "mandate": {
+        "id": 46765,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46765 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46765"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357866,
+      "entity_type": "vote",
+      "label": "Mandate 46766 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357866",
+      "mandate": {
+        "id": 46766,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46766 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46766"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357867,
+      "entity_type": "vote",
+      "label": "Mandate 46767 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357867",
+      "mandate": {
+        "id": 46767,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46767 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46767"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357868,
+      "entity_type": "vote",
+      "label": "Mandate 46768 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357868",
+      "mandate": {
+        "id": 46768,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46768 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46768"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357869,
+      "entity_type": "vote",
+      "label": "Mandate 46769 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357869",
+      "mandate": {
+        "id": 46769,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46769 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46769"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357870,
+      "entity_type": "vote",
+      "label": "Mandate 46770 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357870",
+      "mandate": {
+        "id": 46770,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46770 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46770"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357871,
+      "entity_type": "vote",
+      "label": "Mandate 46771 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357871",
+      "mandate": {
+        "id": 46771,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46771 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46771"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357872,
+      "entity_type": "vote",
+      "label": "Mandate 46772 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357872",
+      "mandate": {
+        "id": 46772,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46772 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46772"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357873,
+      "entity_type": "vote",
+      "label": "Mandate 46773 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357873",
+      "mandate": {
+        "id": 46773,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46773 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46773"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357874,
+      "entity_type": "vote",
+      "label": "Mandate 46774 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357874",
+      "mandate": {
+        "id": 46774,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46774 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46774"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357875,
+      "entity_type": "vote",
+      "label": "Mandate 46775 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357875",
+      "mandate": {
+        "id": 46775,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46775 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46775"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357876,
+      "entity_type": "vote",
+      "label": "Mandate 46776 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357876",
+      "mandate": {
+        "id": 46776,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46776 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46776"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357877,
+      "entity_type": "vote",
+      "label": "Mandate 46777 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357877",
+      "mandate": {
+        "id": 46777,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46777 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46777"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357878,
+      "entity_type": "vote",
+      "label": "Mandate 46778 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357878",
+      "mandate": {
+        "id": 46778,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46778 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46778"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357879,
+      "entity_type": "vote",
+      "label": "Mandate 46779 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357879",
+      "mandate": {
+        "id": 46779,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46779 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46779"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357880,
+      "entity_type": "vote",
+      "label": "Mandate 46780 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357880",
+      "mandate": {
+        "id": 46780,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46780 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46780"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357881,
+      "entity_type": "vote",
+      "label": "Mandate 46781 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357881",
+      "mandate": {
+        "id": 46781,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46781 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46781"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357882,
+      "entity_type": "vote",
+      "label": "Mandate 46782 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357882",
+      "mandate": {
+        "id": 46782,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46782 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46782"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357883,
+      "entity_type": "vote",
+      "label": "Mandate 46783 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357883",
+      "mandate": {
+        "id": 46783,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46783 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46783"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357884,
+      "entity_type": "vote",
+      "label": "Mandate 46784 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357884",
+      "mandate": {
+        "id": 46784,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46784 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46784"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357885,
+      "entity_type": "vote",
+      "label": "Mandate 46785 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357885",
+      "mandate": {
+        "id": 46785,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46785 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46785"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357886,
+      "entity_type": "vote",
+      "label": "Mandate 46786 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357886",
+      "mandate": {
+        "id": 46786,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46786 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46786"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357887,
+      "entity_type": "vote",
+      "label": "Mandate 46787 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357887",
+      "mandate": {
+        "id": 46787,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46787 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46787"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357888,
+      "entity_type": "vote",
+      "label": "Mandate 46788 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357888",
+      "mandate": {
+        "id": 46788,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46788 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46788"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357889,
+      "entity_type": "vote",
+      "label": "Mandate 46789 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357889",
+      "mandate": {
+        "id": 46789,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46789 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46789"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357890,
+      "entity_type": "vote",
+      "label": "Mandate 46790 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357890",
+      "mandate": {
+        "id": 46790,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46790 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46790"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357891,
+      "entity_type": "vote",
+      "label": "Mandate 46791 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357891",
+      "mandate": {
+        "id": 46791,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46791 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46791"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357892,
+      "entity_type": "vote",
+      "label": "Mandate 46792 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357892",
+      "mandate": {
+        "id": 46792,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46792 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46792"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357893,
+      "entity_type": "vote",
+      "label": "Mandate 46793 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357893",
+      "mandate": {
+        "id": 46793,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46793 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46793"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357894,
+      "entity_type": "vote",
+      "label": "Mandate 46794 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357894",
+      "mandate": {
+        "id": 46794,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46794 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46794"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357895,
+      "entity_type": "vote",
+      "label": "Mandate 46795 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357895",
+      "mandate": {
+        "id": 46795,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46795 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46795"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357896,
+      "entity_type": "vote",
+      "label": "Mandate 46796 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357896",
+      "mandate": {
+        "id": 46796,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46796 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46796"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357897,
+      "entity_type": "vote",
+      "label": "Mandate 46797 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357897",
+      "mandate": {
+        "id": 46797,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46797 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46797"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357898,
+      "entity_type": "vote",
+      "label": "Mandate 46798 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357898",
+      "mandate": {
+        "id": 46798,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46798 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46798"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357899,
+      "entity_type": "vote",
+      "label": "Mandate 46799 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357899",
+      "mandate": {
+        "id": 46799,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46799 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46799"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357900,
+      "entity_type": "vote",
+      "label": "Mandate 46800 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357900",
+      "mandate": {
+        "id": 46800,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46800 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46800"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 41,
+        "entity_type": "fraction",
+        "label": "DIE LINKE (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/41"
+      }
+    },
+    {
+      "id": 357901,
+      "entity_type": "vote",
+      "label": "Mandate 46801 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357901",
+      "mandate": {
+        "id": 46801,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46801 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46801"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357902,
+      "entity_type": "vote",
+      "label": "Mandate 46802 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357902",
+      "mandate": {
+        "id": 46802,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46802 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46802"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357903,
+      "entity_type": "vote",
+      "label": "Mandate 46803 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357903",
+      "mandate": {
+        "id": 46803,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46803 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46803"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357904,
+      "entity_type": "vote",
+      "label": "Mandate 46804 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357904",
+      "mandate": {
+        "id": 46804,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46804 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46804"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357905,
+      "entity_type": "vote",
+      "label": "Mandate 46805 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357905",
+      "mandate": {
+        "id": 46805,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46805 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46805"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357906,
+      "entity_type": "vote",
+      "label": "Mandate 46806 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357906",
+      "mandate": {
+        "id": 46806,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46806 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46806"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357907,
+      "entity_type": "vote",
+      "label": "Mandate 46807 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357907",
+      "mandate": {
+        "id": 46807,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46807 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46807"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357908,
+      "entity_type": "vote",
+      "label": "Mandate 46808 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357908",
+      "mandate": {
+        "id": 46808,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46808 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46808"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357909,
+      "entity_type": "vote",
+      "label": "Mandate 46809 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357909",
+      "mandate": {
+        "id": 46809,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46809 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46809"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357910,
+      "entity_type": "vote",
+      "label": "Mandate 46810 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357910",
+      "mandate": {
+        "id": 46810,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46810 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46810"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357911,
+      "entity_type": "vote",
+      "label": "Mandate 46811 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357911",
+      "mandate": {
+        "id": 46811,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46811 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46811"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357912,
+      "entity_type": "vote",
+      "label": "Mandate 46812 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357912",
+      "mandate": {
+        "id": 46812,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46812 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46812"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357913,
+      "entity_type": "vote",
+      "label": "Mandate 46813 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357913",
+      "mandate": {
+        "id": 46813,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46813 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46813"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357914,
+      "entity_type": "vote",
+      "label": "Mandate 46814 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357914",
+      "mandate": {
+        "id": 46814,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46814 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46814"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357915,
+      "entity_type": "vote",
+      "label": "Mandate 46815 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357915",
+      "mandate": {
+        "id": 46815,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46815 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46815"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357916,
+      "entity_type": "vote",
+      "label": "Mandate 46816 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357916",
+      "mandate": {
+        "id": 46816,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46816 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46816"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357917,
+      "entity_type": "vote",
+      "label": "Mandate 46817 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357917",
+      "mandate": {
+        "id": 46817,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46817 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46817"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357918,
+      "entity_type": "vote",
+      "label": "Mandate 46818 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357918",
+      "mandate": {
+        "id": 46818,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46818 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46818"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357919,
+      "entity_type": "vote",
+      "label": "Mandate 46819 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357919",
+      "mandate": {
+        "id": 46819,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46819 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46819"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357920,
+      "entity_type": "vote",
+      "label": "Mandate 46820 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357920",
+      "mandate": {
+        "id": 46820,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46820 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46820"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357921,
+      "entity_type": "vote",
+      "label": "Mandate 46821 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357921",
+      "mandate": {
+        "id": 46821,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46821 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46821"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357922,
+      "entity_type": "vote",
+      "label": "Mandate 46822 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357922",
+      "mandate": {
+        "id": 46822,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46822 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46822"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357923,
+      "entity_type": "vote",
+      "label": "Mandate 46823 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357923",
+      "mandate": {
+        "id": 46823,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46823 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46823"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357924,
+      "entity_type": "vote",
+      "label": "Mandate 46824 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357924",
+      "mandate": {
+        "id": 46824,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46824 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46824"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357925,
+      "entity_type": "vote",
+      "label": "Mandate 46825 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357925",
+      "mandate": {
+        "id": 46825,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46825 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46825"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357926,
+      "entity_type": "vote",
+      "label": "Mandate 46826 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357926",
+      "mandate": {
+        "id": 46826,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46826 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46826"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357927,
+      "entity_type": "vote",
+      "label": "Mandate 46827 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357927",
+      "mandate": {
+        "id": 46827,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46827 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46827"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357928,
+      "entity_type": "vote",
+      "label": "Mandate 46828 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357928",
+      "mandate": {
+        "id": 46828,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46828 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46828"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357929,
+      "entity_type": "vote",
+      "label": "Mandate 46829 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357929",
+      "mandate": {
+        "id": 46829,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46829 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46829"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357930,
+      "entity_type": "vote",
+      "label": "Mandate 46830 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357930",
+      "mandate": {
+        "id": 46830,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46830 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46830"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357931,
+      "entity_type": "vote",
+      "label": "Mandate 46831 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357931",
+      "mandate": {
+        "id": 46831,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46831 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46831"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357932,
+      "entity_type": "vote",
+      "label": "Mandate 46832 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357932",
+      "mandate": {
+        "id": 46832,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46832 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46832"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357933,
+      "entity_type": "vote",
+      "label": "Mandate 46833 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357933",
+      "mandate": {
+        "id": 46833,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46833 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46833"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357934,
+      "entity_type": "vote",
+      "label": "Mandate 46834 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357934",
+      "mandate": {
+        "id": 46834,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46834 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46834"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357935,
+      "entity_type": "vote",
+      "label": "Mandate 46835 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357935",
+      "mandate": {
+        "id": 46835,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46835 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46835"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357936,
+      "entity_type": "vote",
+      "label": "Mandate 46836 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357936",
+      "mandate": {
+        "id": 46836,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46836 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46836"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357937,
+      "entity_type": "vote",
+      "label": "Mandate 46837 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357937",
+      "mandate": {
+        "id": 46837,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46837 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46837"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357938,
+      "entity_type": "vote",
+      "label": "Mandate 46838 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357938",
+      "mandate": {
+        "id": 46838,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46838 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46838"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357939,
+      "entity_type": "vote",
+      "label": "Mandate 46839 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357939",
+      "mandate": {
+        "id": 46839,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46839 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46839"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357940,
+      "entity_type": "vote",
+      "label": "Mandate 46840 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357940",
+      "mandate": {
+        "id": 46840,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46840 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46840"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357941,
+      "entity_type": "vote",
+      "label": "Mandate 46841 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357941",
+      "mandate": {
+        "id": 46841,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46841 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46841"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357942,
+      "entity_type": "vote",
+      "label": "Mandate 46842 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357942",
+      "mandate": {
+        "id": 46842,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46842 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46842"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357943,
+      "entity_type": "vote",
+      "label": "Mandate 46843 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357943",
+      "mandate": {
+        "id": 46843,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46843 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46843"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357944,
+      "entity_type": "vote",
+      "label": "Mandate 46844 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357944",
+      "mandate": {
+        "id": 46844,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46844 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46844"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357945,
+      "entity_type": "vote",
+      "label": "Mandate 46845 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357945",
+      "mandate": {
+        "id": 46845,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46845 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46845"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357946,
+      "entity_type": "vote",
+      "label": "Mandate 46846 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357946",
+      "mandate": {
+        "id": 46846,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46846 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46846"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357947,
+      "entity_type": "vote",
+      "label": "Mandate 46847 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357947",
+      "mandate": {
+        "id": 46847,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46847 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46847"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357948,
+      "entity_type": "vote",
+      "label": "Mandate 46848 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357948",
+      "mandate": {
+        "id": 46848,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46848 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46848"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357949,
+      "entity_type": "vote",
+      "label": "Mandate 46849 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357949",
+      "mandate": {
+        "id": 46849,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46849 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46849"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357950,
+      "entity_type": "vote",
+      "label": "Mandate 46850 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357950",
+      "mandate": {
+        "id": 46850,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46850 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46850"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357951,
+      "entity_type": "vote",
+      "label": "Mandate 46851 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357951",
+      "mandate": {
+        "id": 46851,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46851 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46851"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357952,
+      "entity_type": "vote",
+      "label": "Mandate 46852 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357952",
+      "mandate": {
+        "id": 46852,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46852 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46852"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357953,
+      "entity_type": "vote",
+      "label": "Mandate 46853 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357953",
+      "mandate": {
+        "id": 46853,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46853 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46853"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357954,
+      "entity_type": "vote",
+      "label": "Mandate 46854 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357954",
+      "mandate": {
+        "id": 46854,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46854 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46854"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357955,
+      "entity_type": "vote",
+      "label": "Mandate 46855 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357955",
+      "mandate": {
+        "id": 46855,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46855 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46855"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357956,
+      "entity_type": "vote",
+      "label": "Mandate 46856 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357956",
+      "mandate": {
+        "id": 46856,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46856 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46856"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357957,
+      "entity_type": "vote",
+      "label": "Mandate 46857 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357957",
+      "mandate": {
+        "id": 46857,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46857 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46857"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357958,
+      "entity_type": "vote",
+      "label": "Mandate 46858 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357958",
+      "mandate": {
+        "id": 46858,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46858 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46858"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357959,
+      "entity_type": "vote",
+      "label": "Mandate 46859 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357959",
+      "mandate": {
+        "id": 46859,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46859 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46859"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357960,
+      "entity_type": "vote",
+      "label": "Mandate 46860 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357960",
+      "mandate": {
+        "id": 46860,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46860 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46860"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357961,
+      "entity_type": "vote",
+      "label": "Mandate 46861 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357961",
+      "mandate": {
+        "id": 46861,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46861 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46861"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357962,
+      "entity_type": "vote",
+      "label": "Mandate 46862 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357962",
+      "mandate": {
+        "id": 46862,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46862 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46862"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357963,
+      "entity_type": "vote",
+      "label": "Mandate 46863 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357963",
+      "mandate": {
+        "id": 46863,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46863 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46863"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357964,
+      "entity_type": "vote",
+      "label": "Mandate 46864 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357964",
+      "mandate": {
+        "id": 46864,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46864 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46864"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357965,
+      "entity_type": "vote",
+      "label": "Mandate 46865 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357965",
+      "mandate": {
+        "id": 46865,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46865 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46865"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357966,
+      "entity_type": "vote",
+      "label": "Mandate 46866 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357966",
+      "mandate": {
+        "id": 46866,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46866 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46866"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357967,
+      "entity_type": "vote",
+      "label": "Mandate 46867 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357967",
+      "mandate": {
+        "id": 46867,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46867 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46867"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357968,
+      "entity_type": "vote",
+      "label": "Mandate 46868 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357968",
+      "mandate": {
+        "id": 46868,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46868 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46868"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357969,
+      "entity_type": "vote",
+      "label": "Mandate 46869 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357969",
+      "mandate": {
+        "id": 46869,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46869 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46869"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357970,
+      "entity_type": "vote",
+      "label": "Mandate 46870 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357970",
+      "mandate": {
+        "id": 46870,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46870 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46870"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357971,
+      "entity_type": "vote",
+      "label": "Mandate 46871 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357971",
+      "mandate": {
+        "id": 46871,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46871 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46871"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357972,
+      "entity_type": "vote",
+      "label": "Mandate 46872 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357972",
+      "mandate": {
+        "id": 46872,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46872 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46872"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357973,
+      "entity_type": "vote",
+      "label": "Mandate 46873 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357973",
+      "mandate": {
+        "id": 46873,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46873 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46873"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357974,
+      "entity_type": "vote",
+      "label": "Mandate 46874 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357974",
+      "mandate": {
+        "id": 46874,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46874 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46874"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357975,
+      "entity_type": "vote",
+      "label": "Mandate 46875 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357975",
+      "mandate": {
+        "id": 46875,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46875 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46875"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357976,
+      "entity_type": "vote",
+      "label": "Mandate 46876 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357976",
+      "mandate": {
+        "id": 46876,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46876 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46876"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357977,
+      "entity_type": "vote",
+      "label": "Mandate 46877 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357977",
+      "mandate": {
+        "id": 46877,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46877 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46877"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357978,
+      "entity_type": "vote",
+      "label": "Mandate 46878 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357978",
+      "mandate": {
+        "id": 46878,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46878 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46878"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357979,
+      "entity_type": "vote",
+      "label": "Mandate 46879 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357979",
+      "mandate": {
+        "id": 46879,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46879 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46879"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357980,
+      "entity_type": "vote",
+      "label": "Mandate 46880 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357980",
+      "mandate": {
+        "id": 46880,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46880 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46880"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357981,
+      "entity_type": "vote",
+      "label": "Mandate 46881 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357981",
+      "mandate": {
+        "id": 46881,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46881 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46881"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357982,
+      "entity_type": "vote",
+      "label": "Mandate 46882 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357982",
+      "mandate": {
+        "id": 46882,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46882 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46882"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357983,
+      "entity_type": "vote",
+      "label": "Mandate 46883 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357983",
+      "mandate": {
+        "id": 46883,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46883 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46883"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357984,
+      "entity_type": "vote",
+      "label": "Mandate 46884 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357984",
+      "mandate": {
+        "id": 46884,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46884 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46884"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357985,
+      "entity_type": "vote",
+      "label": "Mandate 46885 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357985",
+      "mandate": {
+        "id": 46885,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46885 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46885"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357986,
+      "entity_type": "vote",
+      "label": "Mandate 46886 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357986",
+      "mandate": {
+        "id": 46886,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46886 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46886"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357987,
+      "entity_type": "vote",
+      "label": "Mandate 46887 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357987",
+      "mandate": {
+        "id": 46887,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46887 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46887"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357988,
+      "entity_type": "vote",
+      "label": "Mandate 46888 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357988",
+      "mandate": {
+        "id": 46888,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46888 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46888"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357989,
+      "entity_type": "vote",
+      "label": "Mandate 46889 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357989",
+      "mandate": {
+        "id": 46889,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46889 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46889"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 56,
+        "entity_type": "fraction",
+        "label": "AfD (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/56"
+      }
+    },
+    {
+      "id": 357990,
+      "entity_type": "vote",
+      "label": "Mandate 46890 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357990",
+      "mandate": {
+        "id": 46890,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46890 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46890"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 357991,
+      "entity_type": "vote",
+      "label": "Mandate 46891 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357991",
+      "mandate": {
+        "id": 46891,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46891 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46891"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 357992,
+      "entity_type": "vote",
+      "label": "Mandate 46892 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357992",
+      "mandate": {
+        "id": 46892,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46892 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46892"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 357993,
+      "entity_type": "vote",
+      "label": "Mandate 46893 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357993",
+      "mandate": {
+        "id": 46893,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46893 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46893"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 357994,
+      "entity_type": "vote",
+      "label": "Mandate 46894 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357994",
+      "mandate": {
+        "id": 46894,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46894 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46894"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 357995,
+      "entity_type": "vote",
+      "label": "Mandate 46895 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357995",
+      "mandate": {
+        "id": 46895,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46895 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46895"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 357996,
+      "entity_type": "vote",
+      "label": "Mandate 46896 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357996",
+      "mandate": {
+        "id": 46896,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46896 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46896"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 357997,
+      "entity_type": "vote",
+      "label": "Mandate 46897 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357997",
+      "mandate": {
+        "id": 46897,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46897 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46897"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 357998,
+      "entity_type": "vote",
+      "label": "Mandate 46898 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357998",
+      "mandate": {
+        "id": 46898,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46898 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46898"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 357999,
+      "entity_type": "vote",
+      "label": "Mandate 46899 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/357999",
+      "mandate": {
+        "id": 46899,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46899 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46899"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358000,
+      "entity_type": "vote",
+      "label": "Mandate 46900 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358000",
+      "mandate": {
+        "id": 46900,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46900 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46900"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358001,
+      "entity_type": "vote",
+      "label": "Mandate 46901 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358001",
+      "mandate": {
+        "id": 46901,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46901 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46901"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358002,
+      "entity_type": "vote",
+      "label": "Mandate 46902 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358002",
+      "mandate": {
+        "id": 46902,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46902 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46902"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358003,
+      "entity_type": "vote",
+      "label": "Mandate 46903 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358003",
+      "mandate": {
+        "id": 46903,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46903 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46903"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358004,
+      "entity_type": "vote",
+      "label": "Mandate 46904 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358004",
+      "mandate": {
+        "id": 46904,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46904 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46904"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358005,
+      "entity_type": "vote",
+      "label": "Mandate 46905 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358005",
+      "mandate": {
+        "id": 46905,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46905 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46905"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358006,
+      "entity_type": "vote",
+      "label": "Mandate 46906 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358006",
+      "mandate": {
+        "id": 46906,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46906 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46906"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358007,
+      "entity_type": "vote",
+      "label": "Mandate 46907 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358007",
+      "mandate": {
+        "id": 46907,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46907 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46907"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358008,
+      "entity_type": "vote",
+      "label": "Mandate 46908 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358008",
+      "mandate": {
+        "id": 46908,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46908 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46908"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358009,
+      "entity_type": "vote",
+      "label": "Mandate 46909 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358009",
+      "mandate": {
+        "id": 46909,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46909 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46909"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358010,
+      "entity_type": "vote",
+      "label": "Mandate 46910 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358010",
+      "mandate": {
+        "id": 46910,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46910 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46910"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358011,
+      "entity_type": "vote",
+      "label": "Mandate 46911 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358011",
+      "mandate": {
+        "id": 46911,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46911 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46911"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358012,
+      "entity_type": "vote",
+      "label": "Mandate 46912 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358012",
+      "mandate": {
+        "id": 46912,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46912 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46912"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358013,
+      "entity_type": "vote",
+      "label": "Mandate 46913 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358013",
+      "mandate": {
+        "id": 46913,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46913 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46913"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358014,
+      "entity_type": "vote",
+      "label": "Mandate 46914 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358014",
+      "mandate": {
+        "id": 46914,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46914 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46914"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358015,
+      "entity_type": "vote",
+      "label": "Mandate 46915 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358015",
+      "mandate": {
+        "id": 46915,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46915 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46915"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358016,
+      "entity_type": "vote",
+      "label": "Mandate 46916 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358016",
+      "mandate": {
+        "id": 46916,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46916 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46916"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358017,
+      "entity_type": "vote",
+      "label": "Mandate 46917 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358017",
+      "mandate": {
+        "id": 46917,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46917 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46917"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358018,
+      "entity_type": "vote",
+      "label": "Mandate 46918 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358018",
+      "mandate": {
+        "id": 46918,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46918 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46918"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358019,
+      "entity_type": "vote",
+      "label": "Mandate 46919 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358019",
+      "mandate": {
+        "id": 46919,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46919 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46919"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358020,
+      "entity_type": "vote",
+      "label": "Mandate 46920 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358020",
+      "mandate": {
+        "id": 46920,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46920 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46920"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358021,
+      "entity_type": "vote",
+      "label": "Mandate 46921 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358021",
+      "mandate": {
+        "id": 46921,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46921 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46921"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358022,
+      "entity_type": "vote",
+      "label": "Mandate 46922 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358022",
+      "mandate": {
+        "id": 46922,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46922 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46922"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358023,
+      "entity_type": "vote",
+      "label": "Mandate 46923 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358023",
+      "mandate": {
+        "id": 46923,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46923 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46923"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358024,
+      "entity_type": "vote",
+      "label": "Mandate 46924 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358024",
+      "mandate": {
+        "id": 46924,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46924 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46924"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358025,
+      "entity_type": "vote",
+      "label": "Mandate 46925 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358025",
+      "mandate": {
+        "id": 46925,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46925 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46925"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358026,
+      "entity_type": "vote",
+      "label": "Mandate 46926 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358026",
+      "mandate": {
+        "id": 46926,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46926 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46926"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358027,
+      "entity_type": "vote",
+      "label": "Mandate 46927 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358027",
+      "mandate": {
+        "id": 46927,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46927 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46927"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358028,
+      "entity_type": "vote",
+      "label": "Mandate 46928 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358028",
+      "mandate": {
+        "id": 46928,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46928 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46928"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358029,
+      "entity_type": "vote",
+      "label": "Mandate 46929 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358029",
+      "mandate": {
+        "id": 46929,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46929 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46929"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358030,
+      "entity_type": "vote",
+      "label": "Mandate 46930 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358030",
+      "mandate": {
+        "id": 46930,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46930 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46930"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358031,
+      "entity_type": "vote",
+      "label": "Mandate 46931 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358031",
+      "mandate": {
+        "id": 46931,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46931 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46931"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358032,
+      "entity_type": "vote",
+      "label": "Mandate 46932 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358032",
+      "mandate": {
+        "id": 46932,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46932 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46932"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358033,
+      "entity_type": "vote",
+      "label": "Mandate 46933 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358033",
+      "mandate": {
+        "id": 46933,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46933 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46933"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358034,
+      "entity_type": "vote",
+      "label": "Mandate 46934 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358034",
+      "mandate": {
+        "id": 46934,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46934 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46934"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358035,
+      "entity_type": "vote",
+      "label": "Mandate 46935 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358035",
+      "mandate": {
+        "id": 46935,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46935 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46935"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358036,
+      "entity_type": "vote",
+      "label": "Mandate 46936 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358036",
+      "mandate": {
+        "id": 46936,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46936 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46936"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358037,
+      "entity_type": "vote",
+      "label": "Mandate 46937 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358037",
+      "mandate": {
+        "id": 46937,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46937 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46937"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358038,
+      "entity_type": "vote",
+      "label": "Mandate 46938 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358038",
+      "mandate": {
+        "id": 46938,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46938 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46938"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358039,
+      "entity_type": "vote",
+      "label": "Mandate 46939 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358039",
+      "mandate": {
+        "id": 46939,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46939 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46939"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358040,
+      "entity_type": "vote",
+      "label": "Mandate 46940 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358040",
+      "mandate": {
+        "id": 46940,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46940 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46940"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358041,
+      "entity_type": "vote",
+      "label": "Mandate 46941 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358041",
+      "mandate": {
+        "id": 46941,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46941 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46941"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358042,
+      "entity_type": "vote",
+      "label": "Mandate 46942 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358042",
+      "mandate": {
+        "id": 46942,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46942 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46942"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358043,
+      "entity_type": "vote",
+      "label": "Mandate 46943 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358043",
+      "mandate": {
+        "id": 46943,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46943 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46943"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358044,
+      "entity_type": "vote",
+      "label": "Mandate 46944 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358044",
+      "mandate": {
+        "id": 46944,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46944 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46944"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358045,
+      "entity_type": "vote",
+      "label": "Mandate 46945 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358045",
+      "mandate": {
+        "id": 46945,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46945 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46945"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358046,
+      "entity_type": "vote",
+      "label": "Mandate 46946 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358046",
+      "mandate": {
+        "id": 46946,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46946 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46946"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358047,
+      "entity_type": "vote",
+      "label": "Mandate 46947 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358047",
+      "mandate": {
+        "id": 46947,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46947 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46947"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358048,
+      "entity_type": "vote",
+      "label": "Mandate 46948 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358048",
+      "mandate": {
+        "id": 46948,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46948 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46948"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358049,
+      "entity_type": "vote",
+      "label": "Mandate 46949 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358049",
+      "mandate": {
+        "id": 46949,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46949 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46949"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358050,
+      "entity_type": "vote",
+      "label": "Mandate 46950 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358050",
+      "mandate": {
+        "id": 46950,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46950 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46950"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358051,
+      "entity_type": "vote",
+      "label": "Mandate 46951 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358051",
+      "mandate": {
+        "id": 46951,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46951 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46951"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358052,
+      "entity_type": "vote",
+      "label": "Mandate 46952 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358052",
+      "mandate": {
+        "id": 46952,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46952 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46952"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358053,
+      "entity_type": "vote",
+      "label": "Mandate 46953 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358053",
+      "mandate": {
+        "id": 46953,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46953 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46953"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358054,
+      "entity_type": "vote",
+      "label": "Mandate 46954 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358054",
+      "mandate": {
+        "id": 46954,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46954 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46954"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358055,
+      "entity_type": "vote",
+      "label": "Mandate 46955 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358055",
+      "mandate": {
+        "id": 46955,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46955 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46955"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358056,
+      "entity_type": "vote",
+      "label": "Mandate 46956 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358056",
+      "mandate": {
+        "id": 46956,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46956 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46956"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358057,
+      "entity_type": "vote",
+      "label": "Mandate 46957 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358057",
+      "mandate": {
+        "id": 46957,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46957 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46957"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358058,
+      "entity_type": "vote",
+      "label": "Mandate 46958 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358058",
+      "mandate": {
+        "id": 46958,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46958 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46958"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358059,
+      "entity_type": "vote",
+      "label": "Mandate 46959 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358059",
+      "mandate": {
+        "id": 46959,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46959 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46959"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358060,
+      "entity_type": "vote",
+      "label": "Mandate 46960 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358060",
+      "mandate": {
+        "id": 46960,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46960 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46960"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358061,
+      "entity_type": "vote",
+      "label": "Mandate 46961 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358061",
+      "mandate": {
+        "id": 46961,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46961 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46961"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358062,
+      "entity_type": "vote",
+      "label": "Mandate 46962 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358062",
+      "mandate": {
+        "id": 46962,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46962 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46962"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358063,
+      "entity_type": "vote",
+      "label": "Mandate 46963 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358063",
+      "mandate": {
+        "id": 46963,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46963 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46963"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358064,
+      "entity_type": "vote",
+      "label": "Mandate 46964 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358064",
+      "mandate": {
+        "id": 46964,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46964 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46964"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358065,
+      "entity_type": "vote",
+      "label": "Mandate 46965 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358065",
+      "mandate": {
+        "id": 46965,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46965 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46965"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358066,
+      "entity_type": "vote",
+      "label": "Mandate 46966 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358066",
+      "mandate": {
+        "id": 46966,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46966 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46966"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358067,
+      "entity_type": "vote",
+      "label": "Mandate 46967 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358067",
+      "mandate": {
+        "id": 46967,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46967 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46967"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358068,
+      "entity_type": "vote",
+      "label": "Mandate 46968 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358068",
+      "mandate": {
+        "id": 46968,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46968 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46968"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358069,
+      "entity_type": "vote",
+      "label": "Mandate 46969 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358069",
+      "mandate": {
+        "id": 46969,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46969 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46969"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358070,
+      "entity_type": "vote",
+      "label": "Mandate 46970 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358070",
+      "mandate": {
+        "id": 46970,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46970 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46970"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358071,
+      "entity_type": "vote",
+      "label": "Mandate 46971 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358071",
+      "mandate": {
+        "id": 46971,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46971 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46971"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358072,
+      "entity_type": "vote",
+      "label": "Mandate 46972 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358072",
+      "mandate": {
+        "id": 46972,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46972 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46972"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358073,
+      "entity_type": "vote",
+      "label": "Mandate 46973 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358073",
+      "mandate": {
+        "id": 46973,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46973 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46973"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358074,
+      "entity_type": "vote",
+      "label": "Mandate 46974 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358074",
+      "mandate": {
+        "id": 46974,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46974 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46974"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358075,
+      "entity_type": "vote",
+      "label": "Mandate 46975 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358075",
+      "mandate": {
+        "id": 46975,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46975 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46975"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358076,
+      "entity_type": "vote",
+      "label": "Mandate 46976 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358076",
+      "mandate": {
+        "id": 46976,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46976 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46976"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358077,
+      "entity_type": "vote",
+      "label": "Mandate 46977 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358077",
+      "mandate": {
+        "id": 46977,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46977 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46977"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358078,
+      "entity_type": "vote",
+      "label": "Mandate 46978 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358078",
+      "mandate": {
+        "id": 46978,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46978 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46978"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358079,
+      "entity_type": "vote",
+      "label": "Mandate 46979 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358079",
+      "mandate": {
+        "id": 46979,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46979 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46979"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358080,
+      "entity_type": "vote",
+      "label": "Mandate 46980 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358080",
+      "mandate": {
+        "id": 46980,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46980 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46980"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358081,
+      "entity_type": "vote",
+      "label": "Mandate 46981 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358081",
+      "mandate": {
+        "id": 46981,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46981 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46981"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358082,
+      "entity_type": "vote",
+      "label": "Mandate 46982 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358082",
+      "mandate": {
+        "id": 46982,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46982 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46982"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358083,
+      "entity_type": "vote",
+      "label": "Mandate 46983 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358083",
+      "mandate": {
+        "id": 46983,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46983 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46983"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358084,
+      "entity_type": "vote",
+      "label": "Mandate 46984 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358084",
+      "mandate": {
+        "id": 46984,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46984 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46984"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358085,
+      "entity_type": "vote",
+      "label": "Mandate 46985 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358085",
+      "mandate": {
+        "id": 46985,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46985 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46985"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358086,
+      "entity_type": "vote",
+      "label": "Mandate 46986 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358086",
+      "mandate": {
+        "id": 46986,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46986 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46986"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358087,
+      "entity_type": "vote",
+      "label": "Mandate 46987 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358087",
+      "mandate": {
+        "id": 46987,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46987 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46987"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358088,
+      "entity_type": "vote",
+      "label": "Mandate 46988 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358088",
+      "mandate": {
+        "id": 46988,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46988 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46988"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358089,
+      "entity_type": "vote",
+      "label": "Mandate 46989 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358089",
+      "mandate": {
+        "id": 46989,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46989 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46989"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358090,
+      "entity_type": "vote",
+      "label": "Mandate 46990 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358090",
+      "mandate": {
+        "id": 46990,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46990 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46990"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358091,
+      "entity_type": "vote",
+      "label": "Mandate 46991 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358091",
+      "mandate": {
+        "id": 46991,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46991 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46991"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358092,
+      "entity_type": "vote",
+      "label": "Mandate 46992 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358092",
+      "mandate": {
+        "id": 46992,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46992 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46992"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358093,
+      "entity_type": "vote",
+      "label": "Mandate 46993 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358093",
+      "mandate": {
+        "id": 46993,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46993 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46993"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358094,
+      "entity_type": "vote",
+      "label": "Mandate 46994 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358094",
+      "mandate": {
+        "id": 46994,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46994 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46994"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358095,
+      "entity_type": "vote",
+      "label": "Mandate 46995 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358095",
+      "mandate": {
+        "id": 46995,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46995 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46995"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358096,
+      "entity_type": "vote",
+      "label": "Mandate 46996 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358096",
+      "mandate": {
+        "id": 46996,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46996 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46996"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358097,
+      "entity_type": "vote",
+      "label": "Mandate 46997 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358097",
+      "mandate": {
+        "id": 46997,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46997 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46997"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358098,
+      "entity_type": "vote",
+      "label": "Mandate 46998 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358098",
+      "mandate": {
+        "id": 46998,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46998 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46998"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358099,
+      "entity_type": "vote",
+      "label": "Mandate 46999 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358099",
+      "mandate": {
+        "id": 46999,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 46999 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/46999"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358100,
+      "entity_type": "vote",
+      "label": "Mandate 47000 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358100",
+      "mandate": {
+        "id": 47000,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47000 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47000"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358101,
+      "entity_type": "vote",
+      "label": "Mandate 47001 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358101",
+      "mandate": {
+        "id": 47001,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47001 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47001"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358102,
+      "entity_type": "vote",
+      "label": "Mandate 47002 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358102",
+      "mandate": {
+        "id": 47002,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47002 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47002"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358103,
+      "entity_type": "vote",
+      "label": "Mandate 47003 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358103",
+      "mandate": {
+        "id": 47003,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47003 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47003"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358104,
+      "entity_type": "vote",
+      "label": "Mandate 47004 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358104",
+      "mandate": {
+        "id": 47004,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47004 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47004"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358105,
+      "entity_type": "vote",
+      "label": "Mandate 47005 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358105",
+      "mandate": {
+        "id": 47005,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47005 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47005"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358106,
+      "entity_type": "vote",
+      "label": "Mandate 47006 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358106",
+      "mandate": {
+        "id": 47006,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47006 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47006"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358107,
+      "entity_type": "vote",
+      "label": "Mandate 47007 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358107",
+      "mandate": {
+        "id": 47007,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47007 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47007"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358108,
+      "entity_type": "vote",
+      "label": "Mandate 47008 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358108",
+      "mandate": {
+        "id": 47008,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47008 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47008"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358109,
+      "entity_type": "vote",
+      "label": "Mandate 47009 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358109",
+      "mandate": {
+        "id": 47009,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47009 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47009"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358110,
+      "entity_type": "vote",
+      "label": "Mandate 47010 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358110",
+      "mandate": {
+        "id": 47010,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47010 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47010"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358111,
+      "entity_type": "vote",
+      "label": "Mandate 47011 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358111",
+      "mandate": {
+        "id": 47011,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47011 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47011"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358112,
+      "entity_type": "vote",
+      "label": "Mandate 47012 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358112",
+      "mandate": {
+        "id": 47012,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47012 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47012"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358113,
+      "entity_type": "vote",
+      "label": "Mandate 47013 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358113",
+      "mandate": {
+        "id": 47013,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47013 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47013"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358114,
+      "entity_type": "vote",
+      "label": "Mandate 47014 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358114",
+      "mandate": {
+        "id": 47014,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47014 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47014"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358115,
+      "entity_type": "vote",
+      "label": "Mandate 47015 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358115",
+      "mandate": {
+        "id": 47015,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47015 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47015"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358116,
+      "entity_type": "vote",
+      "label": "Mandate 47016 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358116",
+      "mandate": {
+        "id": 47016,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47016 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47016"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358117,
+      "entity_type": "vote",
+      "label": "Mandate 47017 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358117",
+      "mandate": {
+        "id": 47017,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47017 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47017"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358118,
+      "entity_type": "vote",
+      "label": "Mandate 47018 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358118",
+      "mandate": {
+        "id": 47018,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47018 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47018"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358119,
+      "entity_type": "vote",
+      "label": "Mandate 47019 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358119",
+      "mandate": {
+        "id": 47019,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47019 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47019"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358120,
+      "entity_type": "vote",
+      "label": "Mandate 47020 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358120",
+      "mandate": {
+        "id": 47020,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47020 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47020"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358121,
+      "entity_type": "vote",
+      "label": "Mandate 47021 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358121",
+      "mandate": {
+        "id": 47021,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47021 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47021"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358122,
+      "entity_type": "vote",
+      "label": "Mandate 47022 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358122",
+      "mandate": {
+        "id": 47022,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47022 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47022"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358123,
+      "entity_type": "vote",
+      "label": "Mandate 47023 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358123",
+      "mandate": {
+        "id": 47023,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47023 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47023"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358124,
+      "entity_type": "vote",
+      "label": "Mandate 47024 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358124",
+      "mandate": {
+        "id": 47024,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47024 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47024"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358125,
+      "entity_type": "vote",
+      "label": "Mandate 47025 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358125",
+      "mandate": {
+        "id": 47025,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47025 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47025"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358126,
+      "entity_type": "vote",
+      "label": "Mandate 47026 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358126",
+      "mandate": {
+        "id": 47026,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47026 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47026"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358127,
+      "entity_type": "vote",
+      "label": "Mandate 47027 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358127",
+      "mandate": {
+        "id": 47027,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47027 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47027"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358128,
+      "entity_type": "vote",
+      "label": "Mandate 47028 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358128",
+      "mandate": {
+        "id": 47028,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47028 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47028"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358129,
+      "entity_type": "vote",
+      "label": "Mandate 47029 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358129",
+      "mandate": {
+        "id": 47029,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47029 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47029"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358130,
+      "entity_type": "vote",
+      "label": "Mandate 47030 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358130",
+      "mandate": {
+        "id": 47030,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47030 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47030"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358131,
+      "entity_type": "vote",
+      "label": "Mandate 47031 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358131",
+      "mandate": {
+        "id": 47031,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47031 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47031"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358132,
+      "entity_type": "vote",
+      "label": "Mandate 47032 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358132",
+      "mandate": {
+        "id": 47032,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47032 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47032"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358133,
+      "entity_type": "vote",
+      "label": "Mandate 47033 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358133",
+      "mandate": {
+        "id": 47033,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47033 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47033"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358134,
+      "entity_type": "vote",
+      "label": "Mandate 47034 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358134",
+      "mandate": {
+        "id": 47034,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47034 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47034"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358135,
+      "entity_type": "vote",
+      "label": "Mandate 47035 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358135",
+      "mandate": {
+        "id": 47035,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47035 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47035"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358136,
+      "entity_type": "vote",
+      "label": "Mandate 47036 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358136",
+      "mandate": {
+        "id": 47036,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47036 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47036"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358137,
+      "entity_type": "vote",
+      "label": "Mandate 47037 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358137",
+      "mandate": {
+        "id": 47037,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47037 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47037"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358138,
+      "entity_type": "vote",
+      "label": "Mandate 47038 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358138",
+      "mandate": {
+        "id": 47038,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47038 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47038"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358139,
+      "entity_type": "vote",
+      "label": "Mandate 47039 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358139",
+      "mandate": {
+        "id": 47039,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47039 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47039"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358140,
+      "entity_type": "vote",
+      "label": "Mandate 47040 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358140",
+      "mandate": {
+        "id": 47040,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47040 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47040"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358141,
+      "entity_type": "vote",
+      "label": "Mandate 47041 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358141",
+      "mandate": {
+        "id": 47041,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47041 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47041"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358142,
+      "entity_type": "vote",
+      "label": "Mandate 47042 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358142",
+      "mandate": {
+        "id": 47042,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47042 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47042"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358143,
+      "entity_type": "vote",
+      "label": "Mandate 47043 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358143",
+      "mandate": {
+        "id": 47043,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47043 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47043"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358144,
+      "entity_type": "vote",
+      "label": "Mandate 47044 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358144",
+      "mandate": {
+        "id": 47044,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47044 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47044"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358145,
+      "entity_type": "vote",
+      "label": "Mandate 47045 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358145",
+      "mandate": {
+        "id": 47045,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47045 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47045"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358146,
+      "entity_type": "vote",
+      "label": "Mandate 47046 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358146",
+      "mandate": {
+        "id": 47046,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47046 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47046"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358147,
+      "entity_type": "vote",
+      "label": "Mandate 47047 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358147",
+      "mandate": {
+        "id": 47047,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47047 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47047"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358148,
+      "entity_type": "vote",
+      "label": "Mandate 47048 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358148",
+      "mandate": {
+        "id": 47048,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47048 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47048"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358149,
+      "entity_type": "vote",
+      "label": "Mandate 47049 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358149",
+      "mandate": {
+        "id": 47049,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47049 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47049"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358150,
+      "entity_type": "vote",
+      "label": "Mandate 47050 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358150",
+      "mandate": {
+        "id": 47050,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47050 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47050"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358151,
+      "entity_type": "vote",
+      "label": "Mandate 47051 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358151",
+      "mandate": {
+        "id": 47051,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47051 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47051"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358152,
+      "entity_type": "vote",
+      "label": "Mandate 47052 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358152",
+      "mandate": {
+        "id": 47052,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47052 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47052"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358153,
+      "entity_type": "vote",
+      "label": "Mandate 47053 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358153",
+      "mandate": {
+        "id": 47053,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47053 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47053"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358154,
+      "entity_type": "vote",
+      "label": "Mandate 47054 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358154",
+      "mandate": {
+        "id": 47054,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47054 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47054"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358155,
+      "entity_type": "vote",
+      "label": "Mandate 47055 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358155",
+      "mandate": {
+        "id": 47055,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47055 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47055"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358156,
+      "entity_type": "vote",
+      "label": "Mandate 47056 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358156",
+      "mandate": {
+        "id": 47056,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47056 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47056"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358157,
+      "entity_type": "vote",
+      "label": "Mandate 47057 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358157",
+      "mandate": {
+        "id": 47057,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47057 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47057"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358158,
+      "entity_type": "vote",
+      "label": "Mandate 47058 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358158",
+      "mandate": {
+        "id": 47058,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47058 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47058"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358159,
+      "entity_type": "vote",
+      "label": "Mandate 47059 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358159",
+      "mandate": {
+        "id": 47059,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47059 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47059"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358160,
+      "entity_type": "vote",
+      "label": "Mandate 47060 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358160",
+      "mandate": {
+        "id": 47060,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47060 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47060"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358161,
+      "entity_type": "vote",
+      "label": "Mandate 47061 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358161",
+      "mandate": {
+        "id": 47061,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47061 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47061"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358162,
+      "entity_type": "vote",
+      "label": "Mandate 47062 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358162",
+      "mandate": {
+        "id": 47062,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47062 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47062"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358163,
+      "entity_type": "vote",
+      "label": "Mandate 47063 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358163",
+      "mandate": {
+        "id": 47063,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47063 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47063"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358164,
+      "entity_type": "vote",
+      "label": "Mandate 47064 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358164",
+      "mandate": {
+        "id": 47064,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47064 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47064"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358165,
+      "entity_type": "vote",
+      "label": "Mandate 47065 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358165",
+      "mandate": {
+        "id": 47065,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47065 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47065"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358166,
+      "entity_type": "vote",
+      "label": "Mandate 47066 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358166",
+      "mandate": {
+        "id": 47066,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47066 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47066"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358167,
+      "entity_type": "vote",
+      "label": "Mandate 47067 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358167",
+      "mandate": {
+        "id": 47067,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47067 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47067"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358168,
+      "entity_type": "vote",
+      "label": "Mandate 47068 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358168",
+      "mandate": {
+        "id": 47068,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47068 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47068"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358169,
+      "entity_type": "vote",
+      "label": "Mandate 47069 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358169",
+      "mandate": {
+        "id": 47069,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47069 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47069"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358170,
+      "entity_type": "vote",
+      "label": "Mandate 47070 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358170",
+      "mandate": {
+        "id": 47070,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47070 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47070"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358171,
+      "entity_type": "vote",
+      "label": "Mandate 47071 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358171",
+      "mandate": {
+        "id": 47071,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47071 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47071"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358172,
+      "entity_type": "vote",
+      "label": "Mandate 47072 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358172",
+      "mandate": {
+        "id": 47072,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47072 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47072"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358173,
+      "entity_type": "vote",
+      "label": "Mandate 47073 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358173",
+      "mandate": {
+        "id": 47073,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47073 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47073"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358174,
+      "entity_type": "vote",
+      "label": "Mandate 47074 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358174",
+      "mandate": {
+        "id": 47074,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47074 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47074"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358175,
+      "entity_type": "vote",
+      "label": "Mandate 47075 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358175",
+      "mandate": {
+        "id": 47075,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47075 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47075"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358176,
+      "entity_type": "vote",
+      "label": "Mandate 47076 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358176",
+      "mandate": {
+        "id": 47076,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47076 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47076"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358177,
+      "entity_type": "vote",
+      "label": "Mandate 47077 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358177",
+      "mandate": {
+        "id": 47077,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47077 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47077"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358178,
+      "entity_type": "vote",
+      "label": "Mandate 47078 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358178",
+      "mandate": {
+        "id": 47078,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47078 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47078"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358179,
+      "entity_type": "vote",
+      "label": "Mandate 47079 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358179",
+      "mandate": {
+        "id": 47079,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47079 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47079"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358180,
+      "entity_type": "vote",
+      "label": "Mandate 47080 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358180",
+      "mandate": {
+        "id": 47080,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47080 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47080"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358181,
+      "entity_type": "vote",
+      "label": "Mandate 47081 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358181",
+      "mandate": {
+        "id": 47081,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47081 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47081"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358182,
+      "entity_type": "vote",
+      "label": "Mandate 47082 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358182",
+      "mandate": {
+        "id": 47082,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47082 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47082"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358183,
+      "entity_type": "vote",
+      "label": "Mandate 47083 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358183",
+      "mandate": {
+        "id": 47083,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47083 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47083"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358184,
+      "entity_type": "vote",
+      "label": "Mandate 47084 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358184",
+      "mandate": {
+        "id": 47084,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47084 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47084"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358185,
+      "entity_type": "vote",
+      "label": "Mandate 47085 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358185",
+      "mandate": {
+        "id": 47085,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47085 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47085"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358186,
+      "entity_type": "vote",
+      "label": "Mandate 47086 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358186",
+      "mandate": {
+        "id": 47086,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47086 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47086"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358187,
+      "entity_type": "vote",
+      "label": "Mandate 47087 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358187",
+      "mandate": {
+        "id": 47087,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47087 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47087"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358188,
+      "entity_type": "vote",
+      "label": "Mandate 47088 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358188",
+      "mandate": {
+        "id": 47088,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47088 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47088"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358189,
+      "entity_type": "vote",
+      "label": "Mandate 47089 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358189",
+      "mandate": {
+        "id": 47089,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47089 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47089"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358190,
+      "entity_type": "vote",
+      "label": "Mandate 47090 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358190",
+      "mandate": {
+        "id": 47090,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47090 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47090"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358191,
+      "entity_type": "vote",
+      "label": "Mandate 47091 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358191",
+      "mandate": {
+        "id": 47091,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47091 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47091"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358192,
+      "entity_type": "vote",
+      "label": "Mandate 47092 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358192",
+      "mandate": {
+        "id": 47092,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47092 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47092"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358193,
+      "entity_type": "vote",
+      "label": "Mandate 47093 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358193",
+      "mandate": {
+        "id": 47093,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47093 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47093"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358194,
+      "entity_type": "vote",
+      "label": "Mandate 47094 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358194",
+      "mandate": {
+        "id": 47094,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47094 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47094"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358195,
+      "entity_type": "vote",
+      "label": "Mandate 47095 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358195",
+      "mandate": {
+        "id": 47095,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47095 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47095"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358196,
+      "entity_type": "vote",
+      "label": "Mandate 47096 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358196",
+      "mandate": {
+        "id": 47096,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47096 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47096"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358197,
+      "entity_type": "vote",
+      "label": "Mandate 47097 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358197",
+      "mandate": {
+        "id": 47097,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47097 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47097"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358198,
+      "entity_type": "vote",
+      "label": "Mandate 47098 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358198",
+      "mandate": {
+        "id": 47098,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47098 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47098"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358199,
+      "entity_type": "vote",
+      "label": "Mandate 47099 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358199",
+      "mandate": {
+        "id": 47099,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47099 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47099"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358200,
+      "entity_type": "vote",
+      "label": "Mandate 47100 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358200",
+      "mandate": {
+        "id": 47100,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47100 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47100"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358201,
+      "entity_type": "vote",
+      "label": "Mandate 47101 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358201",
+      "mandate": {
+        "id": 47101,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47101 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47101"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358202,
+      "entity_type": "vote",
+      "label": "Mandate 47102 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358202",
+      "mandate": {
+        "id": 47102,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47102 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47102"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358203,
+      "entity_type": "vote",
+      "label": "Mandate 47103 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358203",
+      "mandate": {
+        "id": 47103,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47103 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47103"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358204,
+      "entity_type": "vote",
+      "label": "Mandate 47104 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358204",
+      "mandate": {
+        "id": 47104,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47104 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47104"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358205,
+      "entity_type": "vote",
+      "label": "Mandate 47105 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358205",
+      "mandate": {
+        "id": 47105,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47105 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47105"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358206,
+      "entity_type": "vote",
+      "label": "Mandate 47106 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358206",
+      "mandate": {
+        "id": 47106,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47106 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47106"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358207,
+      "entity_type": "vote",
+      "label": "Mandate 47107 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358207",
+      "mandate": {
+        "id": 47107,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47107 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47107"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358208,
+      "entity_type": "vote",
+      "label": "Mandate 47108 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358208",
+      "mandate": {
+        "id": 47108,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47108 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47108"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358209,
+      "entity_type": "vote",
+      "label": "Mandate 47109 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358209",
+      "mandate": {
+        "id": 47109,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47109 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47109"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358210,
+      "entity_type": "vote",
+      "label": "Mandate 47110 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358210",
+      "mandate": {
+        "id": 47110,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47110 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47110"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358211,
+      "entity_type": "vote",
+      "label": "Mandate 47111 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358211",
+      "mandate": {
+        "id": 47111,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47111 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47111"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358212,
+      "entity_type": "vote",
+      "label": "Mandate 47112 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358212",
+      "mandate": {
+        "id": 47112,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47112 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47112"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358213,
+      "entity_type": "vote",
+      "label": "Mandate 47113 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358213",
+      "mandate": {
+        "id": 47113,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47113 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47113"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358214,
+      "entity_type": "vote",
+      "label": "Mandate 47114 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358214",
+      "mandate": {
+        "id": 47114,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47114 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47114"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "yes",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358215,
+      "entity_type": "vote",
+      "label": "Mandate 47115 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358215",
+      "mandate": {
+        "id": 47115,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47115 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47115"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358216,
+      "entity_type": "vote",
+      "label": "Mandate 47116 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358216",
+      "mandate": {
+        "id": 47116,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47116 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47116"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358217,
+      "entity_type": "vote",
+      "label": "Mandate 47117 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358217",
+      "mandate": {
+        "id": 47117,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47117 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47117"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358218,
+      "entity_type": "vote",
+      "label": "Mandate 47118 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358218",
+      "mandate": {
+        "id": 47118,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47118 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47118"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358219,
+      "entity_type": "vote",
+      "label": "Mandate 47119 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358219",
+      "mandate": {
+        "id": 47119,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47119 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47119"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358220,
+      "entity_type": "vote",
+      "label": "Mandate 47120 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358220",
+      "mandate": {
+        "id": 47120,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47120 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47120"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358221,
+      "entity_type": "vote",
+      "label": "Mandate 47121 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358221",
+      "mandate": {
+        "id": 47121,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47121 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47121"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358222,
+      "entity_type": "vote",
+      "label": "Mandate 47122 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358222",
+      "mandate": {
+        "id": 47122,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47122 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47122"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358223,
+      "entity_type": "vote",
+      "label": "Mandate 47123 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358223",
+      "mandate": {
+        "id": 47123,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47123 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47123"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358224,
+      "entity_type": "vote",
+      "label": "Mandate 47124 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358224",
+      "mandate": {
+        "id": 47124,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47124 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47124"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358225,
+      "entity_type": "vote",
+      "label": "Mandate 47125 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358225",
+      "mandate": {
+        "id": 47125,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47125 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47125"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358226,
+      "entity_type": "vote",
+      "label": "Mandate 47126 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358226",
+      "mandate": {
+        "id": 47126,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47126 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47126"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358227,
+      "entity_type": "vote",
+      "label": "Mandate 47127 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358227",
+      "mandate": {
+        "id": 47127,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47127 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47127"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358228,
+      "entity_type": "vote",
+      "label": "Mandate 47128 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358228",
+      "mandate": {
+        "id": 47128,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47128 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47128"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358229,
+      "entity_type": "vote",
+      "label": "Mandate 47129 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358229",
+      "mandate": {
+        "id": 47129,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47129 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47129"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358230,
+      "entity_type": "vote",
+      "label": "Mandate 47130 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358230",
+      "mandate": {
+        "id": 47130,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47130 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47130"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358231,
+      "entity_type": "vote",
+      "label": "Mandate 47131 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358231",
+      "mandate": {
+        "id": 47131,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47131 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47131"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358232,
+      "entity_type": "vote",
+      "label": "Mandate 47132 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358232",
+      "mandate": {
+        "id": 47132,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47132 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47132"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358233,
+      "entity_type": "vote",
+      "label": "Mandate 47133 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358233",
+      "mandate": {
+        "id": 47133,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47133 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47133"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358234,
+      "entity_type": "vote",
+      "label": "Mandate 47134 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358234",
+      "mandate": {
+        "id": 47134,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47134 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47134"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358235,
+      "entity_type": "vote",
+      "label": "Mandate 47135 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358235",
+      "mandate": {
+        "id": 47135,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47135 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47135"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 81,
+        "entity_type": "fraction",
+        "label": "CDU/CSU (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/81"
+      }
+    },
+    {
+      "id": 358236,
+      "entity_type": "vote",
+      "label": "Mandate 47136 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358236",
+      "mandate": {
+        "id": 47136,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47136 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47136"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358237,
+      "entity_type": "vote",
+      "label": "Mandate 47137 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358237",
+      "mandate": {
+        "id": 47137,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47137 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47137"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358238,
+      "entity_type": "vote",
+      "label": "Mandate 47138 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358238",
+      "mandate": {
+        "id": 47138,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47138 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47138"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358239,
+      "entity_type": "vote",
+      "label": "Mandate 47139 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358239",
+      "mandate": {
+        "id": 47139,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47139 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47139"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358240,
+      "entity_type": "vote",
+      "label": "Mandate 47140 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358240",
+      "mandate": {
+        "id": 47140,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47140 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47140"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358241,
+      "entity_type": "vote",
+      "label": "Mandate 47141 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358241",
+      "mandate": {
+        "id": 47141,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47141 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47141"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358242,
+      "entity_type": "vote",
+      "label": "Mandate 47142 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358242",
+      "mandate": {
+        "id": 47142,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47142 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47142"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358243,
+      "entity_type": "vote",
+      "label": "Mandate 47143 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358243",
+      "mandate": {
+        "id": 47143,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47143 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47143"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358244,
+      "entity_type": "vote",
+      "label": "Mandate 47144 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358244",
+      "mandate": {
+        "id": 47144,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47144 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47144"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358245,
+      "entity_type": "vote",
+      "label": "Mandate 47145 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358245",
+      "mandate": {
+        "id": 47145,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47145 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47145"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358246,
+      "entity_type": "vote",
+      "label": "Mandate 47146 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358246",
+      "mandate": {
+        "id": 47146,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47146 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47146"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358247,
+      "entity_type": "vote",
+      "label": "Mandate 47147 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358247",
+      "mandate": {
+        "id": 47147,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47147 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47147"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358248,
+      "entity_type": "vote",
+      "label": "Mandate 47148 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358248",
+      "mandate": {
+        "id": 47148,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47148 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47148"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358249,
+      "entity_type": "vote",
+      "label": "Mandate 47149 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358249",
+      "mandate": {
+        "id": 47149,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47149 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47149"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358250,
+      "entity_type": "vote",
+      "label": "Mandate 47150 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358250",
+      "mandate": {
+        "id": 47150,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47150 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47150"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358251,
+      "entity_type": "vote",
+      "label": "Mandate 47151 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358251",
+      "mandate": {
+        "id": 47151,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47151 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47151"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358252,
+      "entity_type": "vote",
+      "label": "Mandate 47152 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358252",
+      "mandate": {
+        "id": 47152,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47152 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47152"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358253,
+      "entity_type": "vote",
+      "label": "Mandate 47153 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358253",
+      "mandate": {
+        "id": 47153,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47153 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47153"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358254,
+      "entity_type": "vote",
+      "label": "Mandate 47154 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358254",
+      "mandate": {
+        "id": 47154,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47154 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47154"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358255,
+      "entity_type": "vote",
+      "label": "Mandate 47155 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358255",
+      "mandate": {
+        "id": 47155,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47155 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47155"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358256,
+      "entity_type": "vote",
+      "label": "Mandate 47156 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358256",
+      "mandate": {
+        "id": 47156,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47156 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47156"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358257,
+      "entity_type": "vote",
+      "label": "Mandate 47157 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358257",
+      "mandate": {
+        "id": 47157,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47157 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47157"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358258,
+      "entity_type": "vote",
+      "label": "Mandate 47158 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358258",
+      "mandate": {
+        "id": 47158,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47158 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47158"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358259,
+      "entity_type": "vote",
+      "label": "Mandate 47159 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358259",
+      "mandate": {
+        "id": 47159,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47159 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47159"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358260,
+      "entity_type": "vote",
+      "label": "Mandate 47160 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358260",
+      "mandate": {
+        "id": 47160,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47160 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47160"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358261,
+      "entity_type": "vote",
+      "label": "Mandate 47161 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358261",
+      "mandate": {
+        "id": 47161,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47161 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47161"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358262,
+      "entity_type": "vote",
+      "label": "Mandate 47162 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358262",
+      "mandate": {
+        "id": 47162,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47162 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47162"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358263,
+      "entity_type": "vote",
+      "label": "Mandate 47163 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358263",
+      "mandate": {
+        "id": 47163,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47163 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47163"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358264,
+      "entity_type": "vote",
+      "label": "Mandate 47164 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358264",
+      "mandate": {
+        "id": 47164,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47164 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47164"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358265,
+      "entity_type": "vote",
+      "label": "Mandate 47165 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358265",
+      "mandate": {
+        "id": 47165,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47165 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47165"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358266,
+      "entity_type": "vote",
+      "label": "Mandate 47166 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358266",
+      "mandate": {
+        "id": 47166,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47166 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47166"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358267,
+      "entity_type": "vote",
+      "label": "Mandate 47167 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358267",
+      "mandate": {
+        "id": 47167,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47167 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47167"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358268,
+      "entity_type": "vote",
+      "label": "Mandate 47168 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358268",
+      "mandate": {
+        "id": 47168,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47168 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47168"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358269,
+      "entity_type": "vote",
+      "label": "Mandate 47169 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358269",
+      "mandate": {
+        "id": 47169,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47169 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47169"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358270,
+      "entity_type": "vote",
+      "label": "Mandate 47170 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358270",
+      "mandate": {
+        "id": 47170,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47170 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47170"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358271,
+      "entity_type": "vote",
+      "label": "Mandate 47171 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358271",
+      "mandate": {
+        "id": 47171,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47171 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47171"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358272,
+      "entity_type": "vote",
+      "label": "Mandate 47172 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358272",
+      "mandate": {
+        "id": 47172,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47172 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47172"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358273,
+      "entity_type": "vote",
+      "label": "Mandate 47173 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358273",
+      "mandate": {
+        "id": 47173,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47173 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47173"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358274,
+      "entity_type": "vote",
+      "label": "Mandate 47174 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358274",
+      "mandate": {
+        "id": 47174,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47174 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47174"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358275,
+      "entity_type": "vote",
+      "label": "Mandate 47175 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358275",
+      "mandate": {
+        "id": 47175,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47175 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47175"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358276,
+      "entity_type": "vote",
+      "label": "Mandate 47176 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358276",
+      "mandate": {
+        "id": 47176,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47176 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47176"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358277,
+      "entity_type": "vote",
+      "label": "Mandate 47177 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358277",
+      "mandate": {
+        "id": 47177,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47177 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47177"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358278,
+      "entity_type": "vote",
+      "label": "Mandate 47178 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358278",
+      "mandate": {
+        "id": 47178,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47178 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47178"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358279,
+      "entity_type": "vote",
+      "label": "Mandate 47179 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358279",
+      "mandate": {
+        "id": 47179,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47179 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47179"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358280,
+      "entity_type": "vote",
+      "label": "Mandate 47180 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358280",
+      "mandate": {
+        "id": 47180,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47180 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47180"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358281,
+      "entity_type": "vote",
+      "label": "Mandate 47181 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358281",
+      "mandate": {
+        "id": 47181,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47181 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47181"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358282,
+      "entity_type": "vote",
+      "label": "Mandate 47182 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358282",
+      "mandate": {
+        "id": 47182,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47182 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47182"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358283,
+      "entity_type": "vote",
+      "label": "Mandate 47183 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358283",
+      "mandate": {
+        "id": 47183,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47183 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47183"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358284,
+      "entity_type": "vote",
+      "label": "Mandate 47184 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358284",
+      "mandate": {
+        "id": 47184,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47184 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47184"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358285,
+      "entity_type": "vote",
+      "label": "Mandate 47185 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358285",
+      "mandate": {
+        "id": 47185,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47185 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47185"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358286,
+      "entity_type": "vote",
+      "label": "Mandate 47186 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358286",
+      "mandate": {
+        "id": 47186,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47186 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47186"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358287,
+      "entity_type": "vote",
+      "label": "Mandate 47187 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358287",
+      "mandate": {
+        "id": 47187,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47187 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47187"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358288,
+      "entity_type": "vote",
+      "label": "Mandate 47188 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358288",
+      "mandate": {
+        "id": 47188,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47188 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47188"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358289,
+      "entity_type": "vote",
+      "label": "Mandate 47189 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358289",
+      "mandate": {
+        "id": 47189,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47189 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47189"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358290,
+      "entity_type": "vote",
+      "label": "Mandate 47190 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358290",
+      "mandate": {
+        "id": 47190,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47190 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47190"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358291,
+      "entity_type": "vote",
+      "label": "Mandate 47191 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358291",
+      "mandate": {
+        "id": 47191,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47191 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47191"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358292,
+      "entity_type": "vote",
+      "label": "Mandate 47192 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358292",
+      "mandate": {
+        "id": 47192,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47192 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47192"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358293,
+      "entity_type": "vote",
+      "label": "Mandate 47193 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358293",
+      "mandate": {
+        "id": 47193,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47193 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47193"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358294,
+      "entity_type": "vote",
+      "label": "Mandate 47194 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358294",
+      "mandate": {
+        "id": 47194,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47194 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47194"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358295,
+      "entity_type": "vote",
+      "label": "Mandate 47195 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358295",
+      "mandate": {
+        "id": 47195,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47195 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47195"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "abstain",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358296,
+      "entity_type": "vote",
+      "label": "Mandate 47196 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358296",
+      "mandate": {
+        "id": 47196,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47196 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47196"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358297,
+      "entity_type": "vote",
+      "label": "Mandate 47197 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358297",
+      "mandate": {
+        "id": 47197,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47197 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47197"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358298,
+      "entity_type": "vote",
+      "label": "Mandate 47198 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358298",
+      "mandate": {
+        "id": 47198,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47198 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47198"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358299,
+      "entity_type": "vote",
+      "label": "Mandate 47199 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358299",
+      "mandate": {
+        "id": 47199,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47199 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47199"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358300,
+      "entity_type": "vote",
+      "label": "Mandate 47200 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358300",
+      "mandate": {
+        "id": 47200,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47200 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47200"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358301,
+      "entity_type": "vote",
+      "label": "Mandate 47201 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358301",
+      "mandate": {
+        "id": 47201,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47201 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47201"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358302,
+      "entity_type": "vote",
+      "label": "Mandate 47202 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358302",
+      "mandate": {
+        "id": 47202,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47202 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47202"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 153,
+        "entity_type": "fraction",
+        "label": "DIE GRÜNEN (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/153"
+      }
+    },
+    {
+      "id": 358303,
+      "entity_type": "vote",
+      "label": "Mandate 47203 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358303",
+      "mandate": {
+        "id": 47203,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47203 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47203"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 231,
+        "entity_type": "fraction",
+        "label": "fraktionslos (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/231"
+      }
+    },
+    {
+      "id": 358304,
+      "entity_type": "vote",
+      "label": "Mandate 47204 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358304",
+      "mandate": {
+        "id": 47204,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47204 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47204"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 231,
+        "entity_type": "fraction",
+        "label": "fraktionslos (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/231"
+      }
+    },
+    {
+      "id": 358305,
+      "entity_type": "vote",
+      "label": "Mandate 47205 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358305",
+      "mandate": {
+        "id": 47205,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47205 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47205"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 231,
+        "entity_type": "fraction",
+        "label": "fraktionslos (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/231"
+      }
+    },
+    {
+      "id": 358306,
+      "entity_type": "vote",
+      "label": "Mandate 47206 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358306",
+      "mandate": {
+        "id": 47206,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47206 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47206"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 231,
+        "entity_type": "fraction",
+        "label": "fraktionslos (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/231"
+      }
+    },
+    {
+      "id": 358307,
+      "entity_type": "vote",
+      "label": "Mandate 47207 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358307",
+      "mandate": {
+        "id": 47207,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47207 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47207"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 231,
+        "entity_type": "fraction",
+        "label": "fraktionslos (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/231"
+      }
+    },
+    {
+      "id": 358308,
+      "entity_type": "vote",
+      "label": "Mandate 47208 - Corona-Maßnahmen",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358308",
+      "mandate": {
+        "id": 47208,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47208 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47208"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": {
+        "id": 231,
+        "entity_type": "fraction",
+        "label": "fraktionslos (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/fractions/231"
+      }
+    },
+    {
+      "id": 358309,
+      "entity_type": "vote",
+      "label": "Mandate 47209 - Corona-Maßnahmen (empty fraction)",
+      "api_url": "https://www.abgeordnetenwatch.de/api/v2/votes/358309",
+      "mandate": {
+        "id": 47209,
+        "entity_type": "candidacy_mandate",
+        "label": "Mandate 47209 (Bundestag 2017 - 2021)",
+        "api_url": "https://www.abgeordnetenwatch.de/api/v2/candidacies-mandates/47209"
+      },
+      "poll": {
+        "id": 3602,
+        "entity_type": "node",
+        "label": "Corona-Maßnahmen zum Schutz der Bevölkerung"
+      },
+      "vote": "no_show",
+      "reason_no_show": null,
+      "reason_no_show_other": null,
+      "fraction": []
+    }
+  ]
+}

--- a/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_client.py
+++ b/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_client.py
@@ -1,0 +1,603 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Unit tests for AWClient — covers the rate ceiling and core invariants.
+
+Tests defined here:
+  - test_get_sleeps_before_request: get() sleeps >=2s before each call
+  - test_get_raises_on_bad_meta_status: meta.status != "ok" -> ValueError
+  - test_paginates_by_row_count_without_overlap: get_all treats range_end as a
+    row count and advances range_start by the delivered count (no page overlap)
+  - test_get_all_stops_at_total: get_all stops when start >= total (no infinite loop)
+  - test_rate_ceiling_30_per_60s: 30 sequential get() calls accumulate >=58s of
+    mocked sleep (<=30 req/60s ceiling)
+  - test_base_url_is_pinned_constant: _AW_BASE is the expected literal constant
+  - test_get_votes_for_poll_uses_range_800: votes endpoint uses range_end=800
+
+All tests mock time.sleep and requests.Session — NO live network calls.
+The mocked-clock assertion for the rate ceiling (test_rate_ceiling_30_per_60s)
+accumulates sleep calls to verify the timing contract without actually waiting.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.ingestion.connectors.abgeordnetenwatch.client import AWClient, _AW_BASE
+
+
+# ---------------------------------------------------------------------------
+# Helpers — mock HTTP response factories
+# ---------------------------------------------------------------------------
+
+
+def _make_ok_response(data: Any, total: int = 1, count: int = 1) -> MagicMock:
+    """Build a mock requests.Response that returns meta.status='ok'."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "meta": {
+            "status": "ok",
+            "status_message": "",
+            "result": {
+                "count": count,
+                "total": total,
+                "range_start": 0,
+                "range_end": count,
+            },
+        },
+        "data": data,
+    }
+    return resp
+
+
+def _make_error_response() -> MagicMock:
+    """Build a mock requests.Response with meta.status='error'."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "meta": {
+            "status": "error",
+            "status_message": "The following parameter(s) are not valid: parliament_period",
+            "result": {"count": 0, "total": 0, "range_start": 0, "range_end": 0},
+        },
+        "data": [],
+    }
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Base URL constant — SSRF guard
+# ---------------------------------------------------------------------------
+
+
+class TestBaseUrlConstant:
+    def test_aw_base_is_pinned(self) -> None:
+        """_AW_BASE must be the exact pinned AW v2 URL (SSRF guard)."""
+        assert _AW_BASE == "https://www.abgeordnetenwatch.de/api/v2"
+
+    def test_aw_base_contains_abgeordnetenwatch(self) -> None:
+        """_AW_BASE contains the expected domain fragment."""
+        assert "abgeordnetenwatch.de/api/v2" in _AW_BASE
+
+
+# ---------------------------------------------------------------------------
+# get() — pacing + meta.status guard
+# ---------------------------------------------------------------------------
+
+
+class TestGet:
+    def test_get_sleeps_before_request(self) -> None:
+        """get() must call time.sleep() before each request (pacing)."""
+        mock_resp = _make_ok_response({"id": 3602}, total=1, count=1)
+        with (
+            patch("time.sleep") as mock_sleep,
+            patch("requests.Session.get", return_value=mock_resp),
+        ):
+            c = AWClient()
+            c.get("polls/3602")
+            assert mock_sleep.called, "time.sleep must be called before each get() call"
+            # call_args_list entries are call(args, kwargs); first positional arg is [0][0]
+            sleep_seconds = mock_sleep.call_args_list[0][0][0]
+            assert sleep_seconds >= 2.0, f"sleep must be >=2s, got {sleep_seconds}"
+
+    def test_get_returns_parsed_dict(self) -> None:
+        """get() returns the full parsed JSON response dict."""
+        mock_resp = _make_ok_response({"id": 3602}, total=1, count=1)
+        with patch("time.sleep"), patch("requests.Session.get", return_value=mock_resp):
+            c = AWClient()
+            result = c.get("polls/3602")
+        assert isinstance(result, dict)
+        assert result["meta"]["status"] == "ok"
+        assert result["data"] == {"id": 3602}
+
+    def test_get_raises_on_error_status(self) -> None:
+        """get() raises ValueError when meta.status != 'ok' (API error envelope guard)."""
+        mock_resp = _make_error_response()
+        with patch("time.sleep"), patch("requests.Session.get", return_value=mock_resp):
+            c = AWClient()
+            with pytest.raises(ValueError, match="AW API error"):
+                c.get("polls", params={"parliament_period": 132})
+
+    def test_get_uses_pinned_base_url(self) -> None:
+        """get() constructs the URL from _AW_BASE + path, never from a caller-supplied host."""
+        mock_resp = _make_ok_response([], total=0, count=0)
+        captured_urls = []
+
+        def capture_get(url: str, **kwargs: Any) -> MagicMock:
+            captured_urls.append(url)
+            mock_resp.raise_for_status = MagicMock()
+            return mock_resp
+
+        with (
+            patch("time.sleep"),
+            patch("requests.Session.get", side_effect=capture_get),
+        ):
+            c = AWClient()
+            c.get("polls/3602")
+
+        assert len(captured_urls) == 1
+        assert captured_urls[0].startswith(_AW_BASE), (
+            f"URL must start with pinned _AW_BASE, got: {captured_urls[0]}"
+        )
+        assert captured_urls[0] == f"{_AW_BASE}/polls/3602"
+
+
+# ---------------------------------------------------------------------------
+# get_all() — row-count pagination
+# ---------------------------------------------------------------------------
+
+
+class TestGetAll:
+    def test_paginates_by_row_count_without_overlap(self) -> None:
+        """get_all() must treat range_end as a ROW COUNT (live AW contract).
+
+        The mock mimics the live API — a request at range_start=N for
+        range_end=K returns rows N..N+K-1 — so the old ``range_end=start+100``
+        (absolute-index) assumption would re-fetch rows and duplicate them.
+        get_all must request a fixed _PAGE_SIZE window and advance by the
+        delivered count, so each row appears exactly once, in order.
+        """
+        from src.ingestion.connectors.abgeordnetenwatch.client import _PAGE_SIZE
+
+        total = 250
+        universe = [{"id": i} for i in range(total)]
+        seen: list[tuple[int, int]] = []
+
+        def fake_get(path: str, params: dict | None = None) -> dict:
+            params = params or {}
+            rs = params.get("range_start", 0)
+            row_count = params.get("range_end")
+            seen.append((rs, row_count))
+            rows = universe[rs : rs + row_count] if row_count else universe[rs:]
+            return {
+                "meta": {
+                    "status": "ok",
+                    "status_message": "",
+                    "result": {
+                        "count": len(rows),
+                        "total": total,
+                        "range_start": rs,
+                        "range_end": row_count,
+                    },
+                },
+                "data": rows,
+            }
+
+        c = AWClient()
+        with patch.object(c, "get", side_effect=fake_get):
+            result = c.get_all("polls", {"field_legislature": 111})
+
+        ids = [r["id"] for r in result]
+        assert ids == list(range(total)), "each row exactly once, in order"
+        assert len(ids) == len(set(ids)), "no duplicates (no page overlap)"
+        # range_end must be the constant page size (a row count), never start+size.
+        assert all(rc == _PAGE_SIZE for _, rc in seen), (
+            f"range_end must equal _PAGE_SIZE={_PAGE_SIZE}, saw {seen}"
+        )
+        # range_start advances by the delivered count: 0 -> 100 -> 200.
+        assert [rs for rs, _ in seen] == [0, 100, 200], seen
+
+    def test_stops_at_total(self) -> None:
+        """get_all() stops when all items have been fetched (no infinite loop)."""
+        data = [{"id": i} for i in range(50)]
+
+        call_count = 0
+
+        def fake_get(path: str, params: dict | None = None) -> dict:
+            nonlocal call_count
+            call_count += 1
+            if call_count > 5:
+                raise RuntimeError(
+                    "get_all made too many calls — infinite loop detected"
+                )
+            return {
+                "meta": {
+                    "status": "ok",
+                    "status_message": "",
+                    "result": {
+                        "count": 50,
+                        "total": 50,
+                        "range_start": 0,
+                        "range_end": 50,
+                    },
+                },
+                "data": data,
+            }
+
+        c = AWClient()
+        with patch.object(c, "get", side_effect=fake_get):
+            result = c.get_all("polls", {"field_legislature": 111})
+
+        assert result == data
+        assert call_count == 1, f"Expected 1 call for 50-item result, got {call_count}"
+
+    def test_page_cap_breaks_infinite_loop(self) -> None:
+        """get_all stops at _MAX_PAGES even if total is absurdly large."""
+        from src.ingestion.connectors.abgeordnetenwatch.client import _MAX_PAGES
+
+        call_count = 0
+
+        def fake_get(path: str, params: dict | None = None) -> dict:
+            nonlocal call_count
+            call_count += 1
+            rs = (params or {}).get("range_start", 0)
+            # Advertise a huge total that would never be reached.
+            return {
+                "meta": {
+                    "status": "ok",
+                    "status_message": "",
+                    "result": {
+                        "count": 100,
+                        "total": 10_000_000,
+                        "range_start": rs,
+                        "range_end": rs + 100,
+                    },
+                },
+                "data": [{"id": rs + i} for i in range(100)],
+            }
+
+        c = AWClient()
+        with patch.object(c, "get", side_effect=fake_get):
+            result = c.get_all("polls", {"field_legislature": 111})
+
+        assert call_count == _MAX_PAGES, (
+            f"get_all must stop at _MAX_PAGES={_MAX_PAGES}, made {call_count} calls"
+        )
+        assert len(result) == _MAX_PAGES * 100
+
+    def test_missing_meta_result_raises_value_error(self) -> None:
+        """A 200-OK envelope missing meta.result.total raises ValueError, not KeyError."""
+
+        def fake_get(path: str, params: dict | None = None) -> dict:
+            return {"meta": {"status": "ok"}, "data": []}  # no result
+
+        c = AWClient()
+        with patch.object(c, "get", side_effect=fake_get):
+            with pytest.raises(ValueError, match="missing meta.result.total"):
+                c.get_all("polls", {"field_legislature": 111})
+
+    def test_missing_data_raises_value_error(self) -> None:
+        """A 200-OK envelope missing 'data' raises ValueError, not KeyError."""
+
+        def fake_get(path: str, params: dict | None = None) -> dict:
+            return {
+                "meta": {
+                    "status": "ok",
+                    "result": {
+                        "count": 0,
+                        "total": 0,
+                        "range_start": 0,
+                        "range_end": 100,
+                    },
+                }
+            }  # no data key
+
+        c = AWClient()
+        with patch.object(c, "get", side_effect=fake_get):
+            with pytest.raises(ValueError, match="missing or non-list 'data'"):
+                c.get_all("polls", {"field_legislature": 111})
+
+    def test_get_all_uses_field_legislature_param(self) -> None:
+        """get_all() passes field_legislature (not parliament_period) guard."""
+        received_params = []
+
+        def fake_get(path: str, params: dict | None = None) -> dict:
+            received_params.append(dict(params or {}))
+            return {
+                "meta": {
+                    "status": "ok",
+                    "status_message": "",
+                    "result": {
+                        "count": 0,
+                        "total": 0,
+                        "range_start": 0,
+                        "range_end": 100,
+                    },
+                },
+                "data": [],
+            }
+
+        c = AWClient()
+        with patch.object(c, "get", side_effect=fake_get):
+            c.get_all("polls", {"field_legislature": 111})
+
+        assert received_params[0].get("field_legislature") == 111, (
+            "get_all must pass field_legislature (not parliament_period)"
+        )
+
+    def test_under_delivered_page_advances_by_delivered_count(self) -> None:
+        """A server that caps a page below the requested window must NOT be
+        skipped or raise: because get_all advances range_start by the count
+        actually delivered, the extra pages collect every row (no gap, no
+        duplicate) rather than striding past the tail.
+        """
+        total = 150
+        universe = [{"id": i} for i in range(total)]
+        cap = 60  # server delivers at most 60 rows per page (below _PAGE_SIZE)
+
+        def fake_get(path: str, params: dict | None = None) -> dict:
+            params = params or {}
+            rs = params.get("range_start", 0)
+            requested = params.get("range_end") or cap
+            rows = universe[rs : rs + min(cap, requested)]
+            return {
+                "meta": {
+                    "status": "ok",
+                    "status_message": "",
+                    "result": {
+                        "count": len(rows),
+                        "total": total,
+                        "range_start": rs,
+                        "range_end": requested,
+                    },
+                },
+                "data": rows,
+            }
+
+        c = AWClient()
+        with patch.object(c, "get", side_effect=fake_get):
+            result = c.get_all("polls", {"field_legislature": 111})
+
+        ids = [r["id"] for r in result]
+        assert ids == list(range(total)), "all rows collected once despite the cap"
+        assert len(ids) == len(set(ids)), "no duplicates"
+
+    def test_short_final_page_is_not_under_delivery(self) -> None:
+        """The last page legitimately delivers total - start items (< _PAGE_SIZE)."""
+        page1 = [{"id": i} for i in range(100)]
+        page2 = [{"id": i} for i in range(100, 130)]  # 30 items — the true tail
+
+        def fake_get(path: str, params: dict | None = None) -> dict:
+            rs = (params or {}).get("range_start", 0)
+            data = page1 if rs == 0 else page2
+            return {
+                "meta": {
+                    "status": "ok",
+                    "status_message": "",
+                    "result": {
+                        "count": len(data),
+                        "total": 130,
+                        "range_start": rs,
+                        "range_end": rs + 100,
+                    },
+                },
+                "data": data,
+            }
+
+        c = AWClient()
+        with patch.object(c, "get", side_effect=fake_get):
+            result = c.get_all("polls", {"field_legislature": 111})
+        assert len(result) == 130
+
+
+# ---------------------------------------------------------------------------
+# get_votes_for_poll() — single call with range_end=800
+# ---------------------------------------------------------------------------
+
+
+class TestGetVotesForPoll:
+    def test_uses_range_end_800(self) -> None:
+        """get_votes_for_poll() fetches all votes in one call with range_end=800."""
+        captured_params = []
+
+        def fake_get(path: str, params: dict | None = None) -> dict:
+            captured_params.append(dict(params or {}))
+            return {
+                "meta": {
+                    "status": "ok",
+                    "status_message": "",
+                    "result": {
+                        "count": 709,
+                        "total": 709,
+                        "range_start": 0,
+                        "range_end": 800,
+                    },
+                },
+                "data": [
+                    {"id": i, "vote": "yes", "fraction": {"id": 22}} for i in range(709)
+                ],
+            }
+
+        c = AWClient()
+        with patch.object(c, "get", side_effect=fake_get):
+            result = c.get_votes_for_poll(3602)
+
+        assert len(result) == 709
+        assert captured_params[0].get("poll") == 3602
+        assert captured_params[0].get("range_start") == 0
+        assert captured_params[0].get("range_end") == 800
+
+    def test_returns_only_data_list(self) -> None:
+        """get_votes_for_poll() returns the data list, not the full response envelope."""
+        vote_data = [{"id": 1, "vote": "yes", "fraction": {"id": 22}}]
+
+        def fake_get(path: str, params: dict | None = None) -> dict:
+            return {
+                "meta": {
+                    "status": "ok",
+                    "status_message": "",
+                    "result": {
+                        "count": 1,
+                        "total": 1,
+                        "range_start": 0,
+                        "range_end": 800,
+                    },
+                },
+                "data": vote_data,
+            }
+
+        c = AWClient()
+        with patch.object(c, "get", side_effect=fake_get):
+            result = c.get_votes_for_poll(3602)
+
+        assert result == vote_data
+
+    def test_raises_when_total_exceeds_window(self) -> None:
+        """A poll with >800 total votes raises instead of silently truncating."""
+
+        def fake_get(path: str, params: dict | None = None) -> dict:
+            return {
+                "meta": {
+                    "status": "ok",
+                    "status_message": "",
+                    # total exceeds the 800-vote single-call window.
+                    "result": {
+                        "count": 800,
+                        "total": 950,
+                        "range_start": 0,
+                        "range_end": 800,
+                    },
+                },
+                "data": [
+                    {"id": i, "vote": "yes", "fraction": {"id": 22}} for i in range(800)
+                ],
+            }
+
+        c = AWClient()
+        with patch.object(c, "get", side_effect=fake_get):
+            with pytest.raises(ValueError, match="exceeding the single-call window"):
+                c.get_votes_for_poll(4242)
+
+    def test_total_equal_to_window_does_not_raise(self) -> None:
+        """Exactly _VOTES_RANGE_END votes is within the window (no raise)."""
+        from src.ingestion.connectors.abgeordnetenwatch.client import _VOTES_RANGE_END
+
+        def fake_get(path: str, params: dict | None = None) -> dict:
+            return {
+                "meta": {
+                    "status": "ok",
+                    "status_message": "",
+                    "result": {
+                        "count": _VOTES_RANGE_END,
+                        "total": _VOTES_RANGE_END,
+                        "range_start": 0,
+                        "range_end": _VOTES_RANGE_END,
+                    },
+                },
+                "data": [
+                    {"id": i, "vote": "yes", "fraction": {"id": 22}}
+                    for i in range(_VOTES_RANGE_END)
+                ],
+            }
+
+        c = AWClient()
+        with patch.object(c, "get", side_effect=fake_get):
+            result = c.get_votes_for_poll(3602)
+        assert len(result) == _VOTES_RANGE_END
+
+    def test_raises_on_under_delivery(self) -> None:
+        """total says 709 but only 100 votes returned → raise (would corrupt tallies)."""
+
+        def fake_get(path: str, params: dict | None = None) -> dict:
+            return {
+                "meta": {
+                    "status": "ok",
+                    "status_message": "",
+                    "result": {
+                        "count": 100,
+                        "total": 709,
+                        "range_start": 0,
+                        "range_end": 800,
+                    },
+                },
+                "data": [
+                    {"id": i, "vote": "yes", "fraction": {"id": 22}} for i in range(100)
+                ],
+            }
+
+        c = AWClient()
+        with patch.object(c, "get", side_effect=fake_get):
+            with pytest.raises(ValueError, match="expected 709 votes but received 100"):
+                c.get_votes_for_poll(3602)
+
+    def test_raises_on_missing_total(self) -> None:
+        """A missing/non-int meta.result.total raises rather than bypassing the guards."""
+
+        def fake_get(path: str, params: dict | None = None) -> dict:
+            return {
+                "meta": {"status": "ok", "status_message": "", "result": {"count": 1}},
+                "data": [{"id": 1, "vote": "yes", "fraction": {"id": 22}}],
+            }
+
+        c = AWClient()
+        with patch.object(c, "get", side_effect=fake_get):
+            with pytest.raises(ValueError, match="missing/non-int"):
+                c.get_votes_for_poll(3602)
+
+
+# ---------------------------------------------------------------------------
+# Rate ceiling
+# ---------------------------------------------------------------------------
+
+
+class TestRateCeiling:
+    def test_30_calls_accumulate_at_least_58s(self) -> None:
+        """30 sequential get() calls must accumulate >=58s of sleep (<=30 req/60s).
+
+        Mocked-clock assertion: time.sleep is replaced with an accumulator.
+        No live network call is made — requests.Session.get is also mocked.
+        This asserts the rate-ceiling contract without actually waiting 60s.
+        """
+        mock_resp = _make_ok_response({"id": 1}, total=1, count=1)
+        total_slept = 0.0
+
+        def accumulate_sleep(seconds: float) -> None:
+            nonlocal total_slept
+            total_slept += seconds
+
+        with (
+            patch("time.sleep", side_effect=accumulate_sleep),
+            patch("requests.Session.get", return_value=mock_resp),
+        ):
+            c = AWClient()
+            for _ in range(30):
+                c.get("polls/3602")
+
+        assert total_slept >= 58.0, (
+            f"30 get() calls must sleep >=58s in total (<=30 req/60s ceiling). "
+            f"Got: {total_slept:.1f}s. "
+            f"Ensure AWClient sleeps >=2s per call (30 * 2.0 = 60.0s; 58.0s is the floor "
+            f"allowing for minor float drift)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# User-Agent identification
+# ---------------------------------------------------------------------------
+
+
+class TestUserAgent:
+    def test_session_identifies_wahl_chat(self) -> None:
+        """The retrying session must carry a wahl.chat-identifying User-Agent
+        (AW fair-use policy asks API consumers to identify themselves)."""
+        c = AWClient()
+        session = c._get_session()
+        assert session.headers.get("User-Agent") == (
+            "wahl.chat-ingestion/2.0 (https://wahl.chat)"
+        )

--- a/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_client.py
+++ b/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_client.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_connector.py
+++ b/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_connector.py
@@ -1,0 +1,815 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Tests for AbgeordnetenwatchVotesConnector — synchronous single-pass connector.
+
+The connector implements the 3-method ABC
+(discover/fetch/normalize) and returns list[ChunkRecord] from normalize().
+All Firestore/GCS/matcher seam tests are removed.
+
+Tests covered:
+  1. normalize() returns list[ChunkRecord] with external_id=poll_id
+  2. normalize() raises ValueError on zero-tally poll
+  3. GDPR wall: no "users/" path in any AW module (static assertion)
+  4. Registry: abgeordnetenwatch_votes registered; bundestag_votes deregistered
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# no ImportError skip guard — a broken connector import must FAIL the
+# suite loudly, not turn it green with an "s".
+from src.ingestion.connectors.abgeordnetenwatch.connector import (
+    AbgeordnetenwatchVotesConnector,
+)
+
+_FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_poll_3602() -> dict:
+    """Load the golden poll 3602 fixture as a raw payload dict."""
+    poll_raw = json.loads((_FIXTURES_DIR / "aw_poll_3602_poll.json").read_text())
+    votes_raw = json.loads((_FIXTURES_DIR / "aw_poll_3602_votes.json").read_text())
+    poll = poll_raw["data"]  # single poll item
+    votes = votes_raw["data"]  # list of vote items
+    return {"poll": poll, "votes": votes}
+
+
+def _make_zero_tally_raw() -> dict:
+    """Build a raw payload where all votes have no-fraction (zero usable tallies)."""
+    poll = {
+        "id": 9999,
+        "entity_type": "node",
+        "label": "Test Poll Zero Tally",
+        "abgeordnetenwatch_url": "https://www.abgeordnetenwatch.de/bundestag/19/abstimmungen/test",
+        "field_legislature": {"id": 111, "label": "Bundestag 2017 - 2021"},
+        "field_topics": [],
+        "field_intro": None,
+        "field_poll_date": "2020-05-14",
+        "field_related_links": [],
+    }
+    # All votes have fraction=[] — zero usable tallies (degenerate case)
+    votes: list[dict[str, Any]] = [
+        {
+            "id": i,
+            "vote": "no_show",
+            "fraction": [],
+            "mandate": None,
+            "poll": {"id": 9999},
+        }
+        for i in range(5)
+    ]
+    return {"poll": poll, "votes": votes}
+
+
+# ---------------------------------------------------------------------------
+# Static GDPR-wall assertion
+# ---------------------------------------------------------------------------
+
+
+class TestGdprWall:
+    """Static assertion: no AW module reads users/{uid}."""
+
+    def test_no_users_path_in_aw_modules(self) -> None:
+        """grep-based GDPR wall: no code accesses users/{uid} in any AW connector module.
+
+        Comments mentioning users/ in a documentation context (e.g., explaining what NOT to do)
+        are allowed.  Actual code paths that access Firestore users/ collection are not.
+        We detect code access by looking for .collection("users") or ["users"] patterns,
+        not bare 'users/' string mentions (which appear in security docstrings).
+        """
+        import os
+        import re
+
+        aw_src_dir = (
+            Path(__file__).parents[4]
+            / "src"
+            / "ingestion"
+            / "connectors"
+            / "abgeordnetenwatch"
+        )
+
+        # Pattern for actual Firestore users collection access (not docstring mentions)
+        _USERS_CODE_PATTERN = re.compile(
+            r'\.collection\(["\']users["\']|db\[.?users|collection\("users'
+        )
+
+        found_violations: list[str] = []
+        for root, _dirs, files in os.walk(str(aw_src_dir)):
+            for fname in files:
+                if not fname.endswith(".py"):
+                    continue
+                fpath = Path(root) / fname
+                text = fpath.read_text()
+                for lineno, line in enumerate(text.splitlines(), 1):
+                    # Skip comment lines and docstring mentions
+                    stripped = line.strip()
+                    if (
+                        stripped.startswith("#")
+                        or stripped.startswith('"""')
+                        or stripped.startswith("'''")
+                    ):
+                        continue
+                    if _USERS_CODE_PATTERN.search(line):
+                        found_violations.append(
+                            f"{fpath.relative_to(aw_src_dir)}:{lineno}: {line.strip()}"
+                        )
+
+        assert not found_violations, (
+            "GDPR Art.9 wall violation — code accesses users/ collection in AW modules:\n"
+            + "\n".join(found_violations)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Registry tests — these do NOT need the emulator
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    """abgeordnetenwatch_votes registered; bundestag_votes deregistered; BundestagVoteConnector importable."""
+
+    def test_abgeordnetenwatch_votes_in_registry(self) -> None:
+        from src.ingestion.registry import CONNECTOR_FACTORIES
+
+        assert "abgeordnetenwatch_votes" in CONNECTOR_FACTORIES, (
+            "abgeordnetenwatch_votes must be registered in CONNECTOR_FACTORIES"
+        )
+
+    def test_bundestag_votes_not_in_registry(self) -> None:
+        from src.ingestion.registry import CONNECTOR_FACTORIES
+
+        assert "bundestag_votes" not in CONNECTOR_FACTORIES, (
+            "bundestag_votes must be removed from CONNECTOR_FACTORIES"
+        )
+
+
+# ---------------------------------------------------------------------------
+# normalize() returns list[ChunkRecord] with external_id=poll_id
+# ---------------------------------------------------------------------------
+
+
+class TestNormalize:
+    """normalize() returns list[ChunkRecord]; external_id = raw poll_id int."""
+
+    def test_normalize_returns_chunk_record_list(self) -> None:
+        """normalize() must return list[ChunkRecord], not SourceItemRecord."""
+        from src.ingestion.connectors.abgeordnetenwatch.connector import (
+            AbgeordnetenwatchVotesConnector,
+        )
+        from src.ingestion.schemas import ChunkRecord
+
+        raw = _load_poll_3602()
+        connector = AbgeordnetenwatchVotesConnector()
+
+        result = connector.normalize(raw)
+
+        assert isinstance(result, list), "normalize() must return a list"
+        assert len(result) >= 1, (
+            "normalize() must return at least one ChunkRecord for poll 3602"
+        )
+        assert all(isinstance(c, ChunkRecord) for c in result), (
+            "every element in normalize() result must be a ChunkRecord"
+        )
+
+    def test_normalize_sets_external_id(self) -> None:
+        """Every chunk.external_id must equal poll_id (3602 for poll 3602)."""
+        from src.ingestion.connectors.abgeordnetenwatch.connector import (
+            AbgeordnetenwatchVotesConnector,
+        )
+
+        raw = _load_poll_3602()
+        connector = AbgeordnetenwatchVotesConnector()
+
+        chunks = connector.normalize(raw)
+
+        for chunk in chunks:
+            assert chunk.external_id == 3602, (
+                f"chunk.external_id must be 3602 (raw int), got {chunk.external_id!r}"
+            )
+
+    def test_normalize_zero_tally_raises(self) -> None:
+        """normalize() on a zero-tally poll raises ValueError (skip-and-warn path)."""
+        from src.ingestion.connectors.abgeordnetenwatch.connector import (
+            AbgeordnetenwatchVotesConnector,
+        )
+
+        raw = _make_zero_tally_raw()
+        connector = AbgeordnetenwatchVotesConnector()
+
+        with pytest.raises(ValueError, match="zero usable tallies"):
+            connector.normalize(raw)
+
+    def test_normalize_stamps_wahlperiode_legislature_111(self) -> None:
+        """normalize() stamps wahlperiode=19 for legislature_id=111 (19th Bundestag)."""
+        from src.ingestion.connectors.abgeordnetenwatch.connector import (
+            AbgeordnetenwatchVotesConnector,
+        )
+
+        raw = _load_poll_3602()
+        connector = AbgeordnetenwatchVotesConnector(legislature_id=111)
+
+        chunks = connector.normalize(raw)
+        for chunk in chunks:
+            assert chunk.wahlperiode == 19, (
+                f"legislature 111 must map to wahlperiode 19, got {chunk.wahlperiode!r}"
+            )
+
+    def test_normalize_stamps_wahlperiode_legislature_132(self) -> None:
+        """normalize() stamps wahlperiode=20 for legislature_id=132 (20th Bundestag).
+
+        The fixture poll is retagged to field_legislature.id=132 so the
+        legislature cross-check passes (the golden fixture is a period-111 poll).
+        """
+        from src.ingestion.connectors.abgeordnetenwatch.connector import (
+            AbgeordnetenwatchVotesConnector,
+        )
+
+        raw = _load_poll_3602()
+        raw["poll"] = dict(raw["poll"])
+        raw["poll"]["field_legislature"] = {"id": 132, "label": "Bundestag 2021 - 2025"}
+        connector = AbgeordnetenwatchVotesConnector(legislature_id=132)
+
+        chunks = connector.normalize(raw)
+        for chunk in chunks:
+            assert chunk.wahlperiode == 20, (
+                f"legislature 132 must map to wahlperiode 20, got {chunk.wahlperiode!r}"
+            )
+
+    def test_landtag_connector_stamps_wahlperiode_none(self) -> None:
+        """normalize() stamps wahlperiode=None for Landtag legislature IDs.
+
+        State Wahlperiode integers collide across states (Bayern 8th = some other state 8th),
+        so Landtag chunks MUST NOT carry a wahlperiode int.  legislature_period_id is the
+        sole period key for Landtage. Legislature 149 = Bayern 2023-2028.
+        The fixture poll is retagged to field_legislature.id=149 so the
+        legislature cross-check passes.
+        """
+        from src.ingestion.connectors.abgeordnetenwatch.connector import (
+            AbgeordnetenwatchVotesConnector,
+        )
+
+        raw = _load_poll_3602()
+        raw["poll"] = dict(raw["poll"])
+        raw["poll"]["field_legislature"] = {"id": 149, "label": "Bayern 2023 - 2028"}
+        connector = AbgeordnetenwatchVotesConnector(legislature_id=149)
+
+        chunks = connector.normalize(raw)
+        for chunk in chunks:
+            assert chunk.wahlperiode is None, (
+                f"Landtag legislature 149 must yield wahlperiode=None, "
+                f"got {chunk.wahlperiode!r}"
+            )
+
+    def test_normalize_raises_on_legislature_mismatch(self) -> None:
+        """normalizing a period-111 poll under a Bayern/149 connector must
+        raise ValueError (skip-and-warn via the runner) instead of silently
+        stamping region DE-BY on a Bundestag poll."""
+        from src.ingestion.connectors.abgeordnetenwatch.connector import (
+            AbgeordnetenwatchVotesConnector,
+        )
+
+        raw = _load_poll_3602()  # fixture poll carries field_legislature.id=111
+        connector = AbgeordnetenwatchVotesConnector(legislature_id=149)
+
+        with pytest.raises(ValueError, match="legislature 111"):
+            connector.normalize(raw)
+
+
+def test_unknown_legislature_raises_value_error() -> None:
+    """Constructing the connector with an id absent from LEGISLATURE_CONFIG raises ValueError.
+
+    __init__ looks up legislature_id in LEGISLATURE_CONFIG and raises ValueError
+    when the id is missing.
+    """
+    with pytest.raises(ValueError, match="LEGISLATURE_CONFIG"):
+        AbgeordnetenwatchVotesConnector(legislature_id=9999)
+
+
+# ---------------------------------------------------------------------------
+# TestPollSinceFloor — AW_POLL_SINCE optional date floor in discover()
+# ---------------------------------------------------------------------------
+
+
+def _make_stub_polls() -> list[dict[str, Any]]:
+    """Return a canned list of polls with varying dates and ids."""
+    return [
+        {"id": 100, "field_poll_date": "2019-12-15"},  # before 2020 floor
+        {"id": 200, "field_poll_date": "2020-01-01"},  # exactly at floor
+        {"id": 300, "field_poll_date": "2021-06-15"},  # after floor
+        {"id": 400, "field_poll_date": ""},  # empty date — excluded when floor set
+        {"id": 500, "field_poll_date": "2022-03-10"},  # after floor
+    ]
+
+
+class _MockQdrantEmpty:
+    """Mock Qdrant client returning no existing chunks (first-run scenario)."""
+
+    def scroll(self, **kwargs: Any) -> tuple:  # type: ignore[type-arg]
+        return ([], None)
+
+
+class _MockQdrantWithCursor:
+    """Mock Qdrant client returning a single point to simulate a prior cursor."""
+
+    def __init__(self, cursor_value: int) -> None:
+        self._cursor = cursor_value
+
+    def scroll(self, **kwargs: Any) -> tuple:  # type: ignore[type-arg]
+        class _Pt:
+            def __init__(self, ext_id: int) -> None:
+                self.payload = {"external_id": ext_id}
+
+        return ([_Pt(self._cursor)], None)
+
+
+class TestPollSinceFloor:
+    """AW_POLL_SINCE optional date-floor in discover()."""
+
+    def _make_connector(self) -> "AbgeordnetenwatchVotesConnector":
+        connector = AbgeordnetenwatchVotesConnector()
+        return connector
+
+    def _stub_client(self, connector: "AbgeordnetenwatchVotesConnector") -> None:
+        """Monkeypatch connector._client so discover() never hits the network."""
+
+        class _FakeClient:
+            def get_all(self, endpoint: str, params: dict) -> list[dict]:  # type: ignore[override]
+                # polls endpoint — return canned list
+                return _make_stub_polls()
+
+        connector._client = _FakeClient()  # type: ignore[assignment]
+
+    def _stub_qdrant_empty(self, connector: "AbgeordnetenwatchVotesConnector") -> None:
+        """Inject an empty Qdrant mock — simulates no prior chunks (leg_since=None)."""
+        connector._qdrant = _MockQdrantEmpty()  # type: ignore[assignment]
+
+    def _stub_qdrant_with_cursor(
+        self, connector: "AbgeordnetenwatchVotesConnector", cursor: int
+    ) -> None:
+        """Inject a Qdrant mock that returns a per-legislature cursor (leg_since=cursor)."""
+        connector._qdrant = _MockQdrantWithCursor(cursor)  # type: ignore[assignment]
+
+    def test_floor_set_drops_old_polls(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With AW_POLL_SINCE=2020-01-01, polls before 2020 and empty-date polls are dropped."""
+        monkeypatch.setenv("AW_POLL_SINCE", "2020-01-01")
+
+        connector = self._make_connector()
+        self._stub_client(connector)
+        self._stub_qdrant_empty(connector)  # no prior chunks → leg_since=None
+
+        ids = connector.discover(since=None)
+
+        # Expected: ids 200, 300, 500 (oldest-first). 100 (pre-2020) and 400 (empty) excluded.
+        assert ids == ["200", "300", "500"], (
+            f"Expected ['200', '300', '500'] but got {ids!r} — "
+            "polls before 2020-01-01 and empty-date polls must be excluded"
+        )
+
+    def test_floor_unset_returns_all(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When AW_POLL_SINCE is unset, all polls are returned sorted by integer id."""
+        monkeypatch.delenv("AW_POLL_SINCE", raising=False)
+
+        connector = self._make_connector()
+        self._stub_client(connector)
+        self._stub_qdrant_empty(connector)  # no prior chunks → leg_since=None
+
+        ids = connector.discover(since=None)
+
+        # All 5 polls returned, sorted ascending by INTEGER POLL ID (not by date).
+        # Previously sorted by (field_poll_date, id); this aligns the sort axis with
+        # the cursor axis (which walks on max(external_id)=max(poll_id)) so batch
+        # truncation never permanently drops polls with large ids but early dates.
+        assert set(ids) == {"100", "200", "300", "400", "500"}, (
+            f"All 5 polls should be returned when floor is unset, got {ids!r}"
+        )
+        # Integer-id order: 100 < 200 < 300 < 400 < 500
+        assert ids == ["100", "200", "300", "400", "500"], (
+            f"Expected integer-id order ['100', '200', '300', '400', '500'], got {ids!r}"
+        )
+
+    def test_floor_set_with_cursor_filters_both(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Floor + per-legislature cursor: only polls with id > leg_since AND date >= floor survive.
+
+        discover() ignores the global `since` arg in favour of the per-legislature cursor
+        from _get_legislature_cursor() (Qdrant scroll).  This test simulates a prior
+        Qdrant cursor of leg_since=200 so that only polls with id > 200 survive, then
+        the AW_POLL_SINCE floor removes pre-2020 and empty-date polls.
+        Remaining: id=300 (2021), id=500 (2022) — id=400 (empty date) excluded by floor.
+        """
+        monkeypatch.setenv("AW_POLL_SINCE", "2020-01-01")
+
+        connector = self._make_connector()
+        self._stub_client(connector)
+        # Simulate prior run: max external_id = 200 for this legislature.
+        self._stub_qdrant_with_cursor(connector, cursor=200)
+
+        # The global since=200 is still passed to preserve the ABC contract; however
+        # discover() uses leg_since=200 from the Qdrant mock, not the `since` arg.
+        ids = connector.discover(since=200)
+
+        assert ids == ["300", "500"], (
+            f"Expected ['300', '500'] with ingested={{200}} + floor=2020-01-01, got {ids!r}"
+        )
+
+    def test_set_difference_resurfaces_polls_below_highest_ingested(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Self-healing: a poll whose id is BELOW the highest already-ingested id must
+        still be (re)discovered. A max(external_id) high-water mark (the previous design)
+        would compute cursor=500 and permanently skip every poll with id <= 500 — the
+        vote-loss bug. Set-difference re-surfaces the missing polls."""
+        monkeypatch.delenv("AW_POLL_SINCE", raising=False)
+
+        connector = self._make_connector()
+        self._stub_client(connector)
+        # Only the highest poll (500) is ingested; 100-400 were skipped/failed earlier.
+        self._stub_qdrant_with_cursor(connector, cursor=500)
+
+        ids = connector.discover(since=None)
+
+        assert ids == ["100", "200", "300", "400"], (
+            "Polls below the highest ingested id must be re-surfaced by set-difference, "
+            f"not permanently dropped by a max watermark; got {ids!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Regression: discover() sorts by integer poll ID (not by field_poll_date)
+# ---------------------------------------------------------------------------
+
+
+def _make_mixed_polls() -> list[dict]:
+    """Polls where sorting by date produces a different order than sorting by id.
+
+    Poll 9999 has an EARLY date (2019-01-01) but a LARGE id.
+    Poll 1 has a LATE date (2023-12-31) but a SMALL id.
+    If discover() sorts by date, 9999 ends up at the HEAD — the cursor would
+    advance past id=1 but never past id=9999, permanently dropping it on a
+    batch-size-limited run.
+    Sorting by integer id produces [1, 9999] — the correct batch-tail position.
+    """
+    return [
+        {"id": 9999, "field_poll_date": "2019-01-01"},  # large id, early date
+        {"id": 1, "field_poll_date": "2023-12-31"},  # small id, late date
+        {"id": 500, "field_poll_date": "2021-06-15"},  # middle id, middle date
+    ]
+
+
+class TestDiscoverSortByPollId:
+    """discover() must sort poll ids ascending by integer id, not by date."""
+
+    def _make_connector(self) -> "AbgeordnetenwatchVotesConnector":
+        connector = AbgeordnetenwatchVotesConnector()
+        connector._qdrant = _MockQdrantEmpty()  # type: ignore[assignment]
+        return connector
+
+    def _stub_client_mixed(self, connector: "AbgeordnetenwatchVotesConnector") -> None:
+        class _FakeClient:
+            def get_all(self, endpoint: str, params: dict) -> list[dict]:  # type: ignore[override]
+                return _make_mixed_polls()
+
+        connector._client = _FakeClient()  # type: ignore[assignment]
+
+    def test_sorts_by_integer_id_ascending(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """discover() returns ids sorted ascending by integer poll id."""
+        monkeypatch.delenv("AW_POLL_SINCE", raising=False)
+        connector = self._make_connector()
+        self._stub_client_mixed(connector)
+
+        ids = connector.discover(since=None)
+
+        # Integer-id sort: 1 < 500 < 9999 — NOT date sort (which would be: 9999, 500, 1)
+        assert ids == ["1", "500", "9999"], (
+            f"discover() must sort by integer poll id, got {ids!r}. "
+            "Date-based sort would produce ['9999', '500', '1'] — wrong."
+        )
+
+    def test_batch_tail_holds_largest_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With batch_size truncation, the largest id ends up in the batch tail (not dropped)."""
+        monkeypatch.delenv("AW_POLL_SINCE", raising=False)
+        connector = self._make_connector()
+        self._stub_client_mixed(connector)
+
+        ids = connector.discover(since=None)
+
+        # batch[:2] includes ids 1 and 500; id 9999 is at the tail (index 2).
+        # After processing the batch, the cursor advances to 500, so id 9999 is
+        # picked up on the next run.  If sorted by date, id 9999 would be at index 0
+        # of the batch and the cursor would advance past 1 — permanently dropping 500.
+        batch_of_2 = ids[:2]
+        assert "9999" not in batch_of_2, (
+            "Largest id 9999 must sit in the TAIL, not the HEAD of the batch. "
+            f"Got batch[:2]={batch_of_2!r}"
+        )
+        assert ids[-1] == "9999", (
+            f"Largest id must be the last in ids list, got ids[-1]={ids[-1]!r}"
+        )
+
+    def test_normalize_raises_on_missing_date(self) -> None:
+        """normalize() raises ValueError on unparseable/missing date instead of fabricating."""
+        connector = AbgeordnetenwatchVotesConnector()
+
+        # Build a raw payload with a poll that has no date but has valid votes.
+        raw = _load_poll_3602()
+        raw["poll"] = dict(raw["poll"])  # shallow copy
+        raw["poll"]["field_poll_date"] = ""  # empty date
+
+        with pytest.raises(ValueError, match="unparseable field_poll_date"):
+            connector.normalize(raw)
+
+
+# ---------------------------------------------------------------------------
+# normalize() stamps legislature_period_id; per-legislature discover cursor
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeLegislaturePeriodId:
+    """normalize() must stamp legislature_period_id on every chunk."""
+
+    def test_normalize_stamps_legislature_period_id(self) -> None:
+        """Every chunk from normalize() carries legislature_period_id == 111 for legislature 111.
+
+        normalize() stamps legislature_period_id from config.
+        """
+        raw = _load_poll_3602()
+        connector = AbgeordnetenwatchVotesConnector(legislature_id=111)
+
+        chunks = connector.normalize(raw)
+
+        assert len(chunks) >= 1, (
+            "normalize() must return at least one chunk for poll 3602"
+        )
+        for chunk in chunks:
+            assert chunk.legislature_period_id == 111, (
+                f"Every chunk must have legislature_period_id=111 for legislature 111, "
+                f"got {chunk.legislature_period_id!r}. "
+                "Implement legislature_period_id stamping in normalize()."
+            )
+
+
+class TestPerLegislatureCursor:
+    """Per-legislature cursor: discover() must use _get_legislature_cursor() to scope to
+    the current legislature's poll ID space, ignoring the global `since` from run_connector().
+    """
+
+    class _MockPoint:
+        """Minimal mock for a Qdrant ScoredPoint with external_id in payload."""
+
+        def __init__(self, external_id: int) -> None:
+            self.payload = {"external_id": external_id}
+
+    class _MockQdrant:
+        """Mock Qdrant client: scroll returns a single point with external_id=30."""
+
+        def scroll(self, **kwargs: Any) -> tuple:  # type: ignore[type-arg]
+            return ([TestPerLegislatureCursor._MockPoint(30)], None)
+
+    def _make_connector_149(self) -> "AbgeordnetenwatchVotesConnector":
+        connector = AbgeordnetenwatchVotesConnector(legislature_id=149)
+        return connector
+
+    def _stub_client_with_bayern_polls(
+        self, connector: "AbgeordnetenwatchVotesConnector"
+    ) -> None:
+        """Stub the AW client to return Bayern polls with IDs 50, 60, 70 (all < 5000)."""
+
+        class _FakeBayernClient:
+            def get_all(self, endpoint: str, params: dict) -> list:  # type: ignore[type-arg]
+                # Bayern polls with low IDs that would be filtered out by a global since=5000
+                return [
+                    {"id": 50, "field_poll_date": "2024-01-15"},
+                    {"id": 60, "field_poll_date": "2024-02-10"},
+                    {"id": 70, "field_poll_date": "2024-03-20"},
+                ]
+
+        connector._client = _FakeBayernClient()  # type: ignore[assignment]
+
+    def test_per_legislature_cursor(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """discover(since=5000) for legislature 149 must still return Bayern polls.
+
+        When the global cursor is 5000 (from high-ID Bundestag polls), a naive
+        discover(since=5000) would filter out all Bayern polls (IDs 50-70 < 5000).
+        The per-legislature cursor for legislature 149 is 30 (mocked Qdrant), so
+        polls with id > 30 should be returned: 50, 60, 70.
+        """
+        monkeypatch.delenv("AW_POLL_SINCE", raising=False)
+
+        connector = self._make_connector_149()
+        self._stub_client_with_bayern_polls(connector)
+
+        # Pre-set the mock Qdrant so _get_qdrant() returns it when defined.
+        connector._qdrant = self._MockQdrant()  # type: ignore[attr-defined]
+
+        # Patch _get_qdrant on the connector instance (no-op if method doesn't exist yet).
+        mock_qdrant = self._MockQdrant()
+        try:
+            monkeypatch.setattr(connector, "_get_qdrant", lambda: mock_qdrant)
+        except AttributeError:
+            pass  # _get_qdrant not defined — that is acceptable here
+
+        # Global since=5000 from run_connector() would skip all Bayern polls.
+        # The per-legislature cursor for legislature 149 returns external_id=30 from
+        # the mocked Qdrant, so polls with id > 30 (i.e., 50, 60, 70) should be returned.
+        ids = connector.discover(since=5000)
+
+        assert ids == ["50", "60", "70"], (
+            f"discover(since=5000) for legislature 149 returned {ids!r}; expected ['50', '60', '70']. "
+            "The per-legislature cursor for id=149 is 30 (mocked), so polls with id > 30 must be "
+            "discovered regardless of the global since=5000. "
+            "Implement _get_legislature_cursor() in connector.py."
+        )
+
+
+# ---------------------------------------------------------------------------
+# normalize() stamps relevance_levels from field_topics.
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeRelevanceLevels:
+    """normalize() stamps relevance_levels from field_topics taxonomy."""
+
+    def test_normalize_stamps_relevance_levels(self) -> None:
+        """A poll with field_topics [{label:'Verteidigung'}] yields chunks with
+        relevance_levels == ['federal', 'state'].
+        """
+        from src.ingestion.connectors.abgeordnetenwatch.connector import (
+            AbgeordnetenwatchVotesConnector,
+        )
+
+        raw = _load_poll_3602()
+        raw = dict(raw)  # shallow copy of top-level dict
+        raw["poll"] = dict(raw["poll"])  # shallow copy of poll dict
+        raw["poll"]["field_topics"] = [{"id": 13, "label": "Verteidigung"}]
+
+        connector = AbgeordnetenwatchVotesConnector()
+        chunks = connector.normalize(raw)
+
+        assert len(chunks) >= 1, (
+            "normalize() must return at least one chunk for poll 3602"
+        )
+        for chunk in chunks:
+            assert chunk.relevance_levels == ["federal", "state"], (
+                f"Poll with Verteidigung topic must yield relevance_levels=['federal','state'], "
+                f"got {chunk.relevance_levels!r}. "
+                "Implement relevance_levels stamping in normalize()."
+            )
+
+    def test_normalize_no_topics_defaults_all_levels(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A poll with field_topics=[] yields chunks with relevance_levels==
+        ['federal','municipal','state'] and emits the no-topics warning.
+        """
+        import logging
+
+        from src.ingestion.connectors.abgeordnetenwatch.connector import (
+            AbgeordnetenwatchVotesConnector,
+        )
+        from src.ingestion.connectors.abgeordnetenwatch.topic_taxonomy_config import (
+            ALL_LEVELS,
+        )
+
+        raw = _load_poll_3602()
+        raw = dict(raw)  # shallow copy of top-level dict
+        raw["poll"] = dict(raw["poll"])  # shallow copy of poll dict
+        raw["poll"]["field_topics"] = []  # no topics → max-recall default
+
+        connector = AbgeordnetenwatchVotesConnector()
+
+        with caplog.at_level(logging.WARNING):
+            chunks = connector.normalize(raw)
+
+        assert len(chunks) >= 1, "normalize() must return at least one chunk"
+        expected = sorted(ALL_LEVELS)  # ['federal', 'municipal', 'state']
+        for chunk in chunks:
+            assert chunk.relevance_levels == expected, (
+                f"Poll with no field_topics must yield relevance_levels={expected!r}, "
+                f"got {chunk.relevance_levels!r}. "
+                "Implement relevance_levels stamping in normalize()."
+            )
+
+        # the 'no field_topics' warning must appear in the log
+        assert any("no field_topics" in rec.message for rec in caplog.records), (
+            "logger.warning must be emitted for polls with no field_topics. "
+            f"Captured log records: {[rec.message for rec in caplog.records]!r}"
+        )
+
+
+class TestDiscoverFailFast:
+    """discover() must raise ValueError when the AW API returns zero polls."""
+
+    def test_discover_fails_fast_on_zero_polls(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """discover() raises ValueError when AW returns zero polls for the configured legislature.
+
+        Zero polls from the API (before cursor filter) means the parliament_period_id
+        in LEGISLATURE_CONFIG is wrong.  The fail-fast must trigger BEFORE the cursor
+        filter so normal incremental runs (cursor up-to-date, filtered-to-empty) are
+        not wrongly flagged.
+        """
+        monkeypatch.delenv("AW_POLL_SINCE", raising=False)
+
+        connector = AbgeordnetenwatchVotesConnector(legislature_id=111)
+
+        class _EmptyPollClient:
+            """Stub AW client that returns zero polls (simulates wrong parliament_period_id)."""
+
+            def get_all(self, endpoint: str, params: dict) -> list:  # type: ignore[type-arg]
+                return []  # zero polls — wrong period ID
+
+        connector._client = _EmptyPollClient()  # type: ignore[assignment]
+
+        # Legislature 111 started 2017-10-24 — far older than the grace window.
+        with pytest.raises(ValueError, match="zero polls"):
+            connector.discover(since=None)
+
+    def test_discover_zero_polls_within_grace_window_returns_empty(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """a legitimately NEW term (period started <= 90 days ago) with zero
+        polls must NOT abort — warn and return [] instead."""
+        import logging
+        from datetime import date, timedelta
+
+        from src.ingestion.connectors.abgeordnetenwatch import connector as conn_mod
+        from src.ingestion.connectors.abgeordnetenwatch.legislature_config import (
+            LEGISLATURE_CONFIG,
+            LegislatureConfig,
+        )
+
+        monkeypatch.delenv("AW_POLL_SINCE", raising=False)
+        # Register a synthetic just-started legislature (30 days old).
+        recent_start = (date.today() - timedelta(days=30)).isoformat()
+        monkeypatch.setitem(
+            LEGISLATURE_CONFIG,
+            999001,
+            LegislatureConfig(
+                999001, "DE-XX", "Testland 2026 - 2031", recent_start, None
+            ),
+        )
+
+        connector = AbgeordnetenwatchVotesConnector(legislature_id=999001)
+
+        class _EmptyPollClient:
+            def get_all(self, endpoint: str, params: dict) -> list:  # type: ignore[type-arg]
+                return []
+
+        connector._client = _EmptyPollClient()  # type: ignore[assignment]
+
+        with caplog.at_level(logging.WARNING, logger=conn_mod.logger.name):
+            result = connector.discover(since=None)
+
+        assert result == [], "zero polls inside the grace window must return []"
+        assert any("grace window" in r.message for r in caplog.records), (
+            "the grace-window branch must log a warning"
+        )
+
+
+class TestDiscoverRefreshPath:
+    """AW_REFRESH=1 discover path hygiene."""
+
+    def test_refresh_path_filters_non_int_ids(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The isinstance(id, int) filter must apply on the AW_REFRESH path too —
+        a malformed poll entry must not crash sorting or leak a non-int id."""
+        monkeypatch.delenv("AW_POLL_SINCE", raising=False)
+        monkeypatch.setenv("AW_REFRESH", "1")
+
+        connector = AbgeordnetenwatchVotesConnector(legislature_id=111)
+
+        class _MalformedClient:
+            def get_all(self, endpoint: str, params: dict) -> list:  # type: ignore[type-arg]
+                return [
+                    {"id": 100, "field_poll_date": "2020-05-14"},
+                    {"id": "not-an-int", "field_poll_date": "2020-05-14"},
+                    {"field_poll_date": "2020-05-14"},  # id missing entirely
+                    {"id": 200, "field_poll_date": "2020-06-01"},
+                ]
+
+        connector._client = _MalformedClient()  # type: ignore[assignment]
+        # AW_REFRESH skips the Qdrant set-difference — no Qdrant mock needed.
+
+        ids = connector.discover(since=None)
+
+        assert ids == ["100", "200"], (
+            f"Refresh discover must keep only int-id polls, got {ids!r}"
+        )

--- a/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_connector.py
+++ b/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_connector.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -172,7 +173,7 @@ class TestNormalize:
         from src.ingestion.schemas import ChunkRecord
 
         raw = _load_poll_3602()
-        connector = AbgeordnetenwatchVotesConnector()
+        connector = AbgeordnetenwatchVotesConnector(legislature_id=111)
 
         result = connector.normalize(raw)
 
@@ -191,7 +192,7 @@ class TestNormalize:
         )
 
         raw = _load_poll_3602()
-        connector = AbgeordnetenwatchVotesConnector()
+        connector = AbgeordnetenwatchVotesConnector(legislature_id=111)
 
         chunks = connector.normalize(raw)
 
@@ -207,7 +208,7 @@ class TestNormalize:
         )
 
         raw = _make_zero_tally_raw()
-        connector = AbgeordnetenwatchVotesConnector()
+        connector = AbgeordnetenwatchVotesConnector(legislature_id=111)
 
         with pytest.raises(ValueError, match="zero usable tallies"):
             connector.normalize(raw)
@@ -339,7 +340,7 @@ class TestPollSinceFloor:
     """AW_POLL_SINCE optional date-floor in discover()."""
 
     def _make_connector(self) -> "AbgeordnetenwatchVotesConnector":
-        connector = AbgeordnetenwatchVotesConnector()
+        connector = AbgeordnetenwatchVotesConnector(legislature_id=111)
         return connector
 
     def _stub_client(self, connector: "AbgeordnetenwatchVotesConnector") -> None:
@@ -474,7 +475,7 @@ class TestDiscoverSortByPollId:
     """discover() must sort poll ids ascending by integer id, not by date."""
 
     def _make_connector(self) -> "AbgeordnetenwatchVotesConnector":
-        connector = AbgeordnetenwatchVotesConnector()
+        connector = AbgeordnetenwatchVotesConnector(legislature_id=111)
         connector._qdrant = _MockQdrantEmpty()  # type: ignore[assignment]
         return connector
 
@@ -524,7 +525,7 @@ class TestDiscoverSortByPollId:
 
     def test_normalize_raises_on_missing_date(self) -> None:
         """normalize() raises ValueError on unparseable/missing date instead of fabricating."""
-        connector = AbgeordnetenwatchVotesConnector()
+        connector = AbgeordnetenwatchVotesConnector(legislature_id=111)
 
         # Build a raw payload with a poll that has no date but has valid votes.
         raw = _load_poll_3602()
@@ -658,7 +659,7 @@ class TestNormalizeRelevanceLevels:
         raw["poll"] = dict(raw["poll"])  # shallow copy of poll dict
         raw["poll"]["field_topics"] = [{"id": 13, "label": "Verteidigung"}]
 
-        connector = AbgeordnetenwatchVotesConnector()
+        connector = AbgeordnetenwatchVotesConnector(legislature_id=111)
         chunks = connector.normalize(raw)
 
         assert len(chunks) >= 1, (
@@ -691,7 +692,7 @@ class TestNormalizeRelevanceLevels:
         raw["poll"] = dict(raw["poll"])  # shallow copy of poll dict
         raw["poll"]["field_topics"] = []  # no topics → max-recall default
 
-        connector = AbgeordnetenwatchVotesConnector()
+        connector = AbgeordnetenwatchVotesConnector(legislature_id=111)
 
         with caplog.at_level(logging.WARNING):
             chunks = connector.normalize(raw)
@@ -806,10 +807,115 @@ class TestDiscoverRefreshPath:
                 ]
 
         connector._client = _MalformedClient()  # type: ignore[assignment]
-        # AW_REFRESH skips the Qdrant set-difference — no Qdrant mock needed.
+        # AW_REFRESH reads the store for the inverse (prune) set-difference.
+        connector._qdrant = _MockQdrantEmpty()  # type: ignore[assignment]
 
         ids = connector.discover(since=None)
 
         assert ids == ["100", "200"], (
             f"Refresh discover must keep only int-id polls, got {ids!r}"
+        )
+
+    def test_refresh_surfaces_upstream_removed_polls(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A poll present in the store but gone upstream must be surfaced by the
+        refresh discover (after the live polls), short-circuited by fetch(), and
+        normalized to an authoritative [] so the runner deletes its footprint."""
+        monkeypatch.delenv("AW_POLL_SINCE", raising=False)
+        monkeypatch.setenv("AW_REFRESH", "1")
+
+        connector = AbgeordnetenwatchVotesConnector(legislature_id=111)
+
+        class _LiveClient:
+            def get_all(self, endpoint: str, params: dict) -> list:  # type: ignore[type-arg]
+                return [{"id": 100, "field_poll_date": "2020-05-14"}]
+
+        class _StoreWithRetractedPoll:
+            """Store contains polls 100 (still live) and 999 (retracted)."""
+
+            def scroll(self, **kwargs: object) -> tuple:
+                points = [
+                    SimpleNamespace(payload={"external_id": 100}),
+                    SimpleNamespace(payload={"external_id": 999}),
+                ]
+                return (points, None)
+
+        connector._client = _LiveClient()  # type: ignore[assignment]
+        connector._qdrant = _StoreWithRetractedPoll()  # type: ignore[assignment]
+
+        ids = connector.discover(since=None)
+        assert ids == ["100", "999"], (
+            f"refresh discover must surface the retracted poll LAST, got {ids!r}"
+        )
+
+        raw = connector.fetch("999")
+        assert raw.get("upstream_removed") is True, (
+            "fetch() must short-circuit a reconcile-discovered removal without "
+            f"hitting the API, got {raw!r}"
+        )
+        assert connector.normalize(raw) == [], (
+            "normalize() must map an upstream-removed poll to an authoritative "
+            "empty list (runner deletes the stored footprint)"
+        )
+
+
+class TestExplicitLegislatureRequired:
+    """No silent default period — the connector demands an explicit legislature."""
+
+    def test_missing_legislature_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AW_LEGISLATURE_ID", raising=False)
+        with pytest.raises(ValueError, match="explicit"):
+            AbgeordnetenwatchVotesConnector()
+
+    def test_env_legislature_accepted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AW_LEGISLATURE_ID", "132")
+        connector = AbgeordnetenwatchVotesConnector()
+        assert connector._legislature_id == 132
+
+    def test_federal_ids_are_current_plus_prior(self) -> None:
+        """FEDERAL_LEGISLATURE_IDS (the Makefile loop source) is the CURRENT +
+        PRIOR Bundestag periods — the same depth policy as the Landtage. A
+        default run must not silently stop at one historical period, and it
+        must not backfill older periods (those stay explicit-run only)."""
+        from src.ingestion.connectors.abgeordnetenwatch.legislature_config import (
+            FEDERAL_LEGISLATURE_IDS,
+            LEGISLATURE_CONFIG,
+        )
+
+        expected = [
+            key
+            for key, _cfg in sorted(
+                ((k, c) for k, c in LEGISLATURE_CONFIG.items() if c.region == "DE"),
+                key=lambda kv: kv[1].date_from,
+            )[-2:]
+        ]
+        assert FEDERAL_LEGISLATURE_IDS == expected
+        assert FEDERAL_LEGISLATURE_IDS == [132, 161], (
+            "current+prior Bundestag = WP20 (132) + WP21 (161); the 19th "
+            "Bundestag (111) stays explicit-run only"
+        )
+
+
+class TestBindStore:
+    """The runner-bound store handle wins over the self-constructed client."""
+
+    def test_bound_client_and_collection_are_used(self) -> None:
+        connector = AbgeordnetenwatchVotesConnector(legislature_id=111)
+
+        seen: dict = {}
+
+        class _BoundStore:
+            def scroll(self, **kwargs: object) -> tuple:
+                seen["collection"] = kwargs.get("collection_name")
+                return ([], None)
+
+        bound = _BoundStore()
+        connector.bind_store(bound, "custom_collection")
+
+        assert connector._get_qdrant() is bound
+        connector._get_ingested_poll_ids()
+        assert seen["collection"] == "custom_collection", (
+            "set-difference discovery must scroll the RUNNER's collection, "
+            f"got {seen.get('collection')!r}"
         )

--- a/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_stance.py
+++ b/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_stance.py
@@ -1,0 +1,295 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Unit tests for mappers/stance.py.
+
+build_qsp / TestBuildQsp removed — src/matcher/ deleted; the
+QuestionStancePair type no longer exists. The three surviving pure functions
+(aggregate_fraction_tallies, derive_stance, fraction_to_party_slug) are tested
+below.
+
+Tests defined here:
+  - test_derive_stance_agree: yes is the dominant bucket
+  - test_derive_stance_disagree: no is the dominant bucket
+  - test_derive_stance_neutral_abstain: abstain is the dominant bucket
+  - test_derive_stance_absent: no_show is the dominant bucket (fraktionslos case)
+  - test_derive_stance_tie: exact top-two tie resolves to neutral
+  - test_aggregate_skips_empty_fraction: votes with fraction=[] are skipped
+  - test_fraction_to_party_slug_unmapped: unknown fraction_id -> "unbekannt" quarantine
+  - test_golden_record_3602: poll 3602 full 709-vote fixture reproduces the exact
+    per-fraction stances (golden-record assertion)
+
+All tests are pure (no I/O, no Firestore, no network) — stance.py itself must be
+I/O-free (no firestore/requests/firebase imports).
+"""
+
+from __future__ import annotations
+
+
+from src.ingestion.connectors.abgeordnetenwatch.mappers.stance import (
+    aggregate_fraction_tallies,
+    derive_stance,
+    fraction_to_party_slug,
+)
+
+
+# ---------------------------------------------------------------------------
+# derive_stance — 5 outcomes + tie
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveStance:
+    def test_agree(self) -> None:
+        """Yes is the dominant bucket -> agree (SPD case: 144 yes, 0 no, 0 abstain, 8 no_show)."""
+        assert derive_stance(144, 0, 0, 8) == "agree"
+
+    def test_disagree(self) -> None:
+        """No is the dominant bucket -> disagree (FDP case: 0 yes, 75 no, 0 abstain, 5 no_show)."""
+        assert derive_stance(0, 75, 0, 5) == "disagree"
+
+    def test_neutral_abstain(self) -> None:
+        """Abstain is the dominant bucket -> neutral (GRÜNEN case: 0,1,59,7)."""
+        assert derive_stance(0, 1, 59, 7) == "neutral"
+
+    def test_absent(self) -> None:
+        """no_show is the dominant bucket -> absent (fraktionslos case: 0,2,0,4)."""
+        assert derive_stance(0, 2, 0, 4) == "absent"
+
+    def test_tie_top_two_equal(self) -> None:
+        """Exact tie between two buckets -> neutral (non-determinism guard)."""
+        assert derive_stance(5, 5, 0, 0) == "neutral"
+
+    def test_tie_preserves_locked_rule(self) -> None:
+        """Tie rule holds regardless of which bucket names are tied."""
+        assert derive_stance(0, 0, 3, 3) == "neutral"
+        assert derive_stance(10, 10, 5, 5) == "neutral"
+
+
+# ---------------------------------------------------------------------------
+# aggregate_fraction_tallies — degenerate-input guard
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateFractionTallies:
+    def test_skips_empty_fraction_list(self) -> None:
+        """Votes with fraction=[] (not a dict) are silently skipped."""
+        votes = [
+            {"fraction": [], "vote": "no_show"},
+            {
+                "fraction": {"id": 22, "entity_type": "fraction", "label": "SPD"},
+                "vote": "yes",
+            },
+        ]
+        tallies = aggregate_fraction_tallies(votes)
+        assert 22 in tallies, "SPD fraction (id=22) should be tallied"
+        assert tallies[22]["yes"] == 1
+        assert tallies[22]["no_show"] == 0
+        # The empty-fraction vote must NOT produce a tally entry
+        assert len(tallies) == 1, "Empty-fraction vote must be skipped, not included"
+
+    def test_skips_none_fraction(self) -> None:
+        """Votes with fraction=None are also skipped without raising."""
+        votes = [
+            {"fraction": None, "vote": "abstain"},
+            {
+                "fraction": {"id": 14, "entity_type": "fraction", "label": "FDP"},
+                "vote": "no",
+            },
+        ]
+        tallies = aggregate_fraction_tallies(votes)
+        assert 14 in tallies
+        assert tallies[14]["no"] == 1
+        assert len(tallies) == 1
+
+    def test_sums_counts_correctly(self) -> None:
+        """Tallies accumulate yes/no/abstain/no_show counts per fraction."""
+        frac = {"id": 81, "entity_type": "fraction", "label": "CDU/CSU"}
+        votes = [
+            {"fraction": frac, "vote": "yes"},
+            {"fraction": frac, "vote": "yes"},
+            {"fraction": frac, "vote": "abstain"},
+            {"fraction": frac, "vote": "no_show"},
+        ]
+        tallies = aggregate_fraction_tallies(votes)
+        assert tallies[81]["yes"] == 2
+        assert tallies[81]["abstain"] == 1
+        assert tallies[81]["no_show"] == 1
+        assert tallies[81]["no"] == 0
+
+    def test_unknown_vote_token_is_skipped(self) -> None:
+        """An unexpected vote token is skip-and-warned, never crashes."""
+        frac = {"id": 22, "entity_type": "fraction", "label": "SPD"}
+        votes = [
+            {"fraction": frac, "vote": "yes"},
+            {"fraction": frac, "vote": "enthalten"},  # unknown enum value
+            {"fraction": frac, "vote": "no"},
+        ]
+        # Must not raise — the unknown token is dropped.
+        tallies = aggregate_fraction_tallies(votes)
+        assert tallies[22]["yes"] == 1
+        assert tallies[22]["no"] == 1
+        # The unknown token contributes to no bucket.
+        assert tallies[22]["abstain"] == 0
+        assert tallies[22]["no_show"] == 0
+
+    def test_missing_vote_key_is_skipped(self) -> None:
+        """A vote dict missing the 'vote' key is skip-and-warned, not KeyError."""
+        frac = {"id": 22, "entity_type": "fraction", "label": "SPD"}
+        votes = [
+            {"fraction": frac},  # no "vote" key at all
+            {"fraction": frac, "vote": "yes"},
+            {"fraction": frac, "vote": None},  # explicit null
+        ]
+        tallies = aggregate_fraction_tallies(votes)
+        assert tallies[22]["yes"] == 1
+        assert sum(tallies[22][k] for k in ("yes", "no", "abstain", "no_show")) == 1, (
+            "Only the single valid 'yes' vote should be counted"
+        )
+
+    def test_fraction_missing_id_is_skipped(self) -> None:
+        """A fraction dict missing 'id' is skip-and-warned, not KeyError."""
+        votes = [
+            {"fraction": {"entity_type": "fraction", "label": "SPD"}, "vote": "yes"},
+            {"fraction": {"id": 14, "label": "FDP"}, "vote": "no"},
+        ]
+        tallies = aggregate_fraction_tallies(votes)
+        # Only the fraction WITH an id is tallied.
+        assert set(tallies.keys()) == {14}
+        assert tallies[14]["no"] == 1
+
+    def test_all_invalid_votes_yields_empty_tallies(self) -> None:
+        """A poll of only-malformed votes yields {} (so the connector skips it)."""
+        frac = {"id": 22, "label": "SPD"}
+        votes = [
+            {"fraction": frac, "vote": "bogus"},
+            {"fraction": frac, "vote": None},
+        ]
+        tallies = aggregate_fraction_tallies(votes)
+        assert tallies == {}
+
+    def test_label_selection_is_deterministic(self) -> None:
+        """The stored fraction label is the lexicographically smallest, order-independent."""
+        votes_order_a = [
+            {"fraction": {"id": 41, "label": "DIE LINKE (Gruppe)"}, "vote": "no"},
+            {"fraction": {"id": 41, "label": "DIE LINKE"}, "vote": "no"},
+        ]
+        votes_order_b = [
+            {"fraction": {"id": 41, "label": "DIE LINKE"}, "vote": "no"},
+            {"fraction": {"id": 41, "label": "DIE LINKE (Gruppe)"}, "vote": "no"},
+        ]
+        tallies_a = aggregate_fraction_tallies(votes_order_a)
+        tallies_b = aggregate_fraction_tallies(votes_order_b)
+        # Both orders must select the same (lexicographically smallest) label.
+        assert tallies_a[41]["fraction"]["label"] == "DIE LINKE"
+        assert tallies_b[41]["fraction"]["label"] == "DIE LINKE"
+        assert tallies_a[41]["no"] == 2 == tallies_b[41]["no"]
+
+
+# ---------------------------------------------------------------------------
+# fraction_to_party_slug — unmapped -> quarantine
+# ---------------------------------------------------------------------------
+
+
+class TestFractionToPartySlug:
+    def test_mapped_fraction(self) -> None:
+        """Known fraction_id resolves to the party slug."""
+        fraction_map = {22: "spd", 14: "fdp"}
+        assert fraction_to_party_slug(22, fraction_map) == "spd"
+        assert fraction_to_party_slug(14, fraction_map) == "fdp"
+
+    def test_unmapped_fraction_returns_unbekannt(self) -> None:
+        """Unknown fraction_id returns quarantine slug 'unbekannt'."""
+        fraction_map = {22: "spd"}
+        assert fraction_to_party_slug(999, fraction_map) == "unbekannt"
+
+    def test_empty_map_returns_unbekannt(self) -> None:
+        """Empty map -> always quarantine."""
+        assert fraction_to_party_slug(14, {}) == "unbekannt"
+
+
+# ---------------------------------------------------------------------------
+# Golden-record assertion — poll 3602
+# ---------------------------------------------------------------------------
+
+
+# Verified per-fraction stances from the live API (poll 3602)
+EXPECTED_3602_STANCES = {
+    14: "disagree",  # FDP: 0 yes, 75 no, 0 abstain, 5 no_show
+    22: "agree",  # SPD: 144 yes, 0 no, 0 abstain, 8 no_show
+    41: "disagree",  # DIE LINKE: 0 yes, 57 no, 0 abstain, 12 no_show
+    56: "disagree",  # AfD: 0 yes, 79 no, 0 abstain, 10 no_show
+    81: "agree",  # CDU/CSU: 225 yes, 0 no, 4 abstain, 17 no_show
+    153: "neutral",  # DIE GRÜNEN: 0 yes, 1 no, 59 abstain, 7 no_show
+    231: "absent",  # fraktionslos: 0 yes, 2 no, 0 abstain, 4 no_show
+}
+
+EXPECTED_3602_TALLIES = {
+    14: {"yes": 0, "no": 75, "abstain": 0, "no_show": 5},
+    22: {"yes": 144, "no": 0, "abstain": 0, "no_show": 8},
+    41: {"yes": 0, "no": 57, "abstain": 0, "no_show": 12},
+    56: {"yes": 0, "no": 79, "abstain": 0, "no_show": 10},
+    81: {"yes": 225, "no": 0, "abstain": 4, "no_show": 17},
+    153: {"yes": 0, "no": 1, "abstain": 59, "no_show": 7},
+    231: {"yes": 0, "no": 2, "abstain": 0, "no_show": 4},
+}
+
+
+class TestGoldenRecord3602:
+    def test_aggregate_tallies_match_research(self, aw_poll_3602_votes: dict) -> None:
+        """aggregate_fraction_tallies on the 710-vote fixture matches the verified tally table."""
+        votes = aw_poll_3602_votes["data"]
+        tallies = aggregate_fraction_tallies(votes)
+
+        for frac_id, expected in EXPECTED_3602_TALLIES.items():
+            assert frac_id in tallies, f"frac_id={frac_id} missing from tallies"
+            for key in ("yes", "no", "abstain", "no_show"):
+                assert tallies[frac_id][key] == expected[key], (
+                    f"frac_id={frac_id} {key}: "
+                    f"got {tallies[frac_id][key]}, expected {expected[key]}"
+                )
+
+    def test_empty_fraction_vote_is_skipped(self, aw_poll_3602_votes: dict) -> None:
+        """The fixture contains one fraction=[] vote; it must be silently skipped."""
+        votes = aw_poll_3602_votes["data"]
+        empty_fraction_votes = [v for v in votes if v.get("fraction") == []]
+        assert len(empty_fraction_votes) >= 1, (
+            "Fixture must contain at least one fraction=[] vote"
+        )
+
+        tallies = aggregate_fraction_tallies(votes)
+        # Only the 7 real fractions should appear — the empty-fraction vote must be absent
+        assert set(tallies.keys()) == set(EXPECTED_3602_TALLIES.keys()), (
+            f"Expected frac_ids {set(EXPECTED_3602_TALLIES.keys())}, got {set(tallies.keys())}"
+        )
+
+    def test_derive_stances_match_research(self, aw_poll_3602_votes: dict) -> None:
+        """derive_stance on each fraction's tally matches the verified expected stance."""
+        votes = aw_poll_3602_votes["data"]
+        tallies = aggregate_fraction_tallies(votes)
+
+        for frac_id, expected_stance in EXPECTED_3602_STANCES.items():
+            t = tallies[frac_id]
+            actual_stance = derive_stance(t["yes"], t["no"], t["abstain"], t["no_show"])
+            assert actual_stance == expected_stance, (
+                f"frac_id={frac_id}: expected stance '{expected_stance}', got '{actual_stance}'"
+            )
+
+    def test_fraktionslos_is_absent(self, aw_poll_3602_votes: dict) -> None:
+        """fraktionslos (frac_id=231, yes=0,no=2,abstain=0,no_show=4) -> absent."""
+        votes = aw_poll_3602_votes["data"]
+        tallies = aggregate_fraction_tallies(votes)
+        t = tallies[231]
+        assert derive_stance(t["yes"], t["no"], t["abstain"], t["no_show"]) == "absent"
+
+    def test_poll_fixture_metadata(self, aw_poll_3602_poll: dict) -> None:
+        """The poll fixture contains the expected metadata fields."""
+        poll = aw_poll_3602_poll["data"]
+        assert poll["id"] == 3602
+        assert poll["field_poll_date"] == "2020-05-14"
+        assert poll["field_legislature"]["id"] == 111
+        assert len(poll["field_topics"]) == 3
+        # First topic is Gesundheit -> topic_id "aw:gesundheit"
+        first_topic_url = poll["field_topics"][0]["abgeordnetenwatch_url"]
+        assert first_topic_url.endswith("/gesundheit")

--- a/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_stance.py
+++ b/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_stance.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -27,7 +27,11 @@ I/O-free (no firestore/requests/firebase imports).
 
 from __future__ import annotations
 
+import pytest
 
+from src.ingestion.connectors.abgeordnetenwatch.mappers.corpus import (
+    _canonical_party_slug,
+)
 from src.ingestion.connectors.abgeordnetenwatch.mappers.stance import (
     aggregate_fraction_tallies,
     derive_stance,
@@ -293,3 +297,55 @@ class TestGoldenRecord3602:
         # First topic is Gesundheit -> topic_id "aw:gesundheit"
         first_topic_url = poll["field_topics"][0]["abgeordnetenwatch_url"]
         assert first_topic_url.endswith("/gesundheit")
+
+
+class TestLandtagFractionAliases:
+    """Live Landtag fraction labels must resolve to real party slugs.
+
+    These exact label shapes exist in the live AW fraction catalogue for the
+    configured legislatures; an unmapped label quarantines to "unbekannt" and
+    the party's votes vanish from party-filtered retrieval.
+    """
+
+    @pytest.mark.parametrize(
+        ("label", "expected_slug"),
+        [
+            ("FDP/DVP (Baden-Württemberg 2021 - 2026)", "fdp"),
+            ("FDP (Gruppe) (Niedersachsen 2022 - 2027)", "fdp"),
+            ("FREIE WÄHLER (Gruppe) (Brandenburg 2019 - 2024)", "fw"),
+            ("BVB - Freie Wähler (Brandenburg 2024 - 2029)", "bvb-fw"),
+            ("BVB - Freie Wähler (Gruppe) (Brandenburg 2024 - 2029)", "bvb-fw"),
+            ("Die Linke (Gruppe) (Bundestag 2021 - 2025)", "linke"),
+            ("BSW (Gruppe) (Bundestag 2021 - 2025)", "bsw"),
+            ("CDU-Fraktion (Hamburg 2020 - 2025)", "cdu"),
+            ("SPD-Fraktion (Hamburg 2020 - 2025)", "spd"),
+            ("AfD-Fraktion (Hamburg 2020 - 2025)", "afd"),
+            ("Fraktion DIE LINKE (Hamburg 2020 - 2025)", "linke"),
+            ("Fraktion Bündnis 90/Die Grünen (Hamburg 2020 - 2025)", "gruene"),
+            ("Alternative für Deutschland (Sachsen 2024 - 2029)", "afd"),
+            ("Bündnis Sahra Wagenknecht (Sachsen 2024 - 2029)", "bsw"),
+            ("Bündnis Deutschland (Bremen 2023 - 2027)", "buendnis-deutschland"),
+        ],
+    )
+    def test_alias_resolves(self, label: str, expected_slug: str) -> None:
+        assert _canonical_party_slug(label) == expected_slug
+
+    def test_splinter_groups_do_not_merge_into_unbekannt(self) -> None:
+        """Distinct splinter fractions must keep DISTINCT slugs — merging several
+        unknowns into one "unbekannt" tally fabricates a combined vote count."""
+        slugs = {
+            _canonical_party_slug(
+                "Bürger für Mecklenburg-Vorpommern (M-V 2021 - 2026)"
+            ),
+            _canonical_party_slug(
+                "Wir für Brandenburg (Gruppe) (Brandenburg 2024 - 2029)"
+            ),
+            _canonical_party_slug("Saar-Linke (Saarland 2022 - 2027)"),
+        }
+        assert len(slugs) == 3
+        assert "unbekannt" not in slugs
+
+    def test_unknown_label_still_quarantines(self) -> None:
+        assert _canonical_party_slug("Völlig Unbekannte Liste (X 2020 - 2025)") == (
+            "unbekannt"
+        )

--- a/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_topic_taxonomy.py
+++ b/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_topic_taxonomy.py
@@ -1,0 +1,323 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Unit tests for topic_taxonomy_config.py.
+
+Test coverage:
+  1. Resolution:
+       - Known single-topic label → correct levels.
+       - Verteidigung → [federal, state].
+       - Unknown label → sorted(ALL_LEVELS) + logger.warning.
+       - Empty topic list → sorted(ALL_LEVELS) + logger.warning.
+  2. Coverage: all 53 AW Themen labels verified present in TOPIC_TAXONOMY.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+import src.ingestion.connectors.abgeordnetenwatch.topic_taxonomy_config as ttc
+from src.ingestion.connectors.abgeordnetenwatch.topic_taxonomy_config import (
+    ALL_LEVELS,
+    FEDERAL,
+    MUNICIPAL,
+    STATE,
+    TOPIC_TAXONOMY,
+    get_relevance_levels,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Resolution
+# ---------------------------------------------------------------------------
+
+
+def test_defense_returns_federal_and_state() -> None:
+    """Verteidigung → [federal, state].
+
+    A defense question in a Landtag election must surface Bundestag defense votes.
+    """
+    result = get_relevance_levels(["Verteidigung"])
+    assert result == ["federal", "state"], (
+        f"Verteidigung must map to ['federal', 'state'], got {result!r}"
+    )
+
+
+def test_federal_only_topic_returns_federal() -> None:
+    """A federal-only topic must return only ['federal']."""
+    result = get_relevance_levels(["Außenwirtschaft"])
+    assert result == ["federal"], f"Außenwirtschaft is federal-only, got {result!r}"
+
+
+def test_union_of_multiple_topics() -> None:
+    """Union: Außenwirtschaft (federal) ∪ Verteidigung (federal, state) = [federal, state]."""
+    result = get_relevance_levels(["Außenwirtschaft", "Verteidigung"])
+    assert result == ["federal", "state"], (
+        f"Union of federal ∪ (federal,state) must be ['federal', 'state'], got {result!r}"
+    )
+
+
+def test_unknown_label_returns_all_levels_and_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unknown AW Thema → sorted(ALL_LEVELS) + logger.warning (max recall).
+
+    A new or misspelled topic label must never be silently buried —
+    it falls back to ALL_LEVELS and emits a loud warning so the gap is visible.
+    """
+    unknown_label = "Unbekanntes Thema — nicht in der Taxonomie"
+    with caplog.at_level(logging.WARNING, logger=ttc.logger.name):
+        result = get_relevance_levels([unknown_label])
+
+    assert result == sorted(ALL_LEVELS), (
+        f"Unknown label must return sorted(ALL_LEVELS), got {result!r}"
+    )
+    assert any("not in TOPIC_TAXONOMY" in r.message for r in caplog.records), (
+        "Unknown label must emit a logger.warning mentioning TOPIC_TAXONOMY"
+    )
+
+
+def test_empty_topic_list_returns_all_levels_and_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Empty topic list → sorted(ALL_LEVELS) + logger.warning (no-topic default).
+
+    Polls without field_topics must not be silently buried — max-recall default.
+    """
+    with caplog.at_level(logging.WARNING, logger=ttc.logger.name):
+        result = get_relevance_levels([])
+
+    assert result == sorted(ALL_LEVELS), (
+        f"Empty list must return sorted(ALL_LEVELS), got {result!r}"
+    )
+    assert any("no field_topics" in r.message for r in caplog.records), (
+        "Empty topic list must emit a logger.warning"
+    )
+
+
+def test_result_is_always_sorted() -> None:
+    """get_relevance_levels must return a sorted list regardless of input order."""
+    result_forward = get_relevance_levels(["Verteidigung", "Außenwirtschaft"])
+    result_reverse = get_relevance_levels(["Außenwirtschaft", "Verteidigung"])
+    assert result_forward == result_reverse == sorted(result_forward), (
+        "get_relevance_levels must always return a sorted list"
+    )
+
+
+def test_str_cast_on_untrusted_input() -> None:
+    """Labels are cast to str before lookup (untrusted AW payload).
+
+    Passing a non-string value that str()-ifies to an unknown label falls back to
+    ALL_LEVELS.
+    """
+    result = get_relevance_levels([42])  # type: ignore[list-item]
+    assert result == sorted(ALL_LEVELS), (
+        "Non-string label should be cast to str, producing the ALL_LEVELS fallback"
+    )
+
+
+def test_soft_hyphen_in_label_still_resolves() -> None:
+    """A topic label carrying an invisible soft hyphen (U+00AD) must normalize and match
+    the taxonomy exactly — not silently fall back to ALL_LEVELS (which would make an
+    affected federal vote over-surface in state chats)."""
+    dirty = "Verteidi\u00adgung"  # U+00AD soft hyphen injected mid-word
+    assert get_relevance_levels([dirty]) == ["federal", "state"], (
+        "Soft-hyphen label must normalize to 'Verteidigung' and resolve to its levels"
+    )
+
+
+def test_reclassified_topics_include_state() -> None:
+    """Kultur, Tourismus and Reaktorsicherheit are state-salient (Kulturhoheit /
+    Länder execution) and must include STATE so they are not buried in Landtag chats."""
+    for label in ("Kultur", "Tourismus", "Reaktorsicherheit"):
+        assert get_relevance_levels([label]) == ["federal", "state"], (
+            f"{label} must resolve to ['federal', 'state']"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. Coverage: all 53 AW Themen labels must be in TOPIC_TAXONOMY
+# ---------------------------------------------------------------------------
+
+# Exact label strings verified from the AW v2 /topics endpoint (2026-06-26).
+_EXPECTED_53_LABELS: frozenset[str] = frozenset(
+    {
+        "Verteidigung",
+        "Außenpolitik und internationale Beziehungen",
+        "Europapolitik und Europäische Union",
+        "Außenwirtschaft",
+        "Entwicklungspolitik",
+        "Humanitäre Hilfe",
+        "Menschenrechte",
+        "Arbeit und Beschäftigung",
+        "Soziale Sicherung",
+        "Gesundheit",
+        "Öffentliche Finanzen, Steuern und Abgaben",
+        "Finanzen",
+        "Haushalt",
+        "Wirtschaft",
+        "Energie",
+        "Klima",
+        "Umwelt",
+        "Naturschutz",
+        "Verkehr",
+        "Bildung und Erziehung",
+        "Raumordnung, Bau- und Wohnungswesen",
+        "Landwirtschaft und Ernährung",
+        "Migration und Aufenthaltsrecht",
+        "Innere Sicherheit",
+        "Innere Angelegenheiten",
+        "Staat und Verwaltung",
+        "Recht",
+        "Gesellschaftspolitik, soziale Gruppen",
+        "Familie",
+        "Frauen",
+        "Jugend",
+        "Senioren",
+        "Digitale Agenda",
+        "digitale Infrastruktur",
+        "Medien, Kommunikation und Informationstechnik",
+        "Medien",
+        "Kultur",
+        "Sport",
+        "Sport, Freizeit und Tourismus",
+        "Tourismus",
+        "Verbraucherschutz",
+        "Forschung",
+        "Wissenschaft, Forschung und Technologie",
+        "Reaktorsicherheit",
+        "Technologiefolgenabschätzung",
+        "Lobbyismus & Transparenz",
+        "Politisches Leben, Parteien",
+        "Bundestag",
+        "Geschäftsordnung",
+        "Immunität",
+        "Petitionen",
+        "Wahlprüfung",
+        "Deutsche Einheit / Innerdeutsche Beziehungen (bis 1990)",
+    }
+)
+
+
+def test_taxonomy_has_exactly_53_entries() -> None:
+    """TOPIC_TAXONOMY must have exactly 53 entries."""
+    assert len(TOPIC_TAXONOMY) == 53, (
+        f"Expected 53 entries, got {len(TOPIC_TAXONOMY)}. "
+        "Missing: {_EXPECTED_53_LABELS - set(TOPIC_TAXONOMY)}"
+    )
+
+
+def test_all_53_labels_are_present() -> None:
+    """All 53 AW Themen labels must be present as exact-string keys."""
+    taxonomy_keys = set(TOPIC_TAXONOMY.keys())
+    missing = _EXPECTED_53_LABELS - taxonomy_keys
+    extra = taxonomy_keys - _EXPECTED_53_LABELS
+    assert not missing, f"Labels missing from TOPIC_TAXONOMY: {missing!r}"
+    assert not extra, f"Unexpected extra labels in TOPIC_TAXONOMY: {extra!r}"
+
+
+def test_all_taxonomy_values_are_subsets_of_all_levels() -> None:
+    """Every TOPIC_TAXONOMY value must be a non-empty subset of ALL_LEVELS."""
+    invalid = {
+        label: levels
+        for label, levels in TOPIC_TAXONOMY.items()
+        if not levels or not levels.issubset(ALL_LEVELS)
+    }
+    assert not invalid, f"TOPIC_TAXONOMY entries with invalid level sets: {invalid!r}"
+
+
+def test_all_levels_constant_matches_context_level_values() -> None:
+    """ALL_LEVELS must equal {FEDERAL, STATE, MUNICIPAL} matching Context.level values."""
+    assert ALL_LEVELS == {FEDERAL, STATE, MUNICIPAL}
+    assert FEDERAL == "federal"
+    assert STATE == "state"
+    assert MUNICIPAL == "municipal"
+
+
+# ---------------------------------------------------------------------------
+# 3. Short-form embedded-label aliases
+# ---------------------------------------------------------------------------
+
+
+def test_short_form_oeffentliche_finanzen_resolves_like_long_form() -> None:
+    """The embedded short form "Öffentliche Finanzen" must resolve to the same
+    levels as the canonical "Öffentliche Finanzen, Steuern und Abgaben"."""
+    short = get_relevance_levels(["Öffentliche Finanzen"])
+    long = get_relevance_levels(["Öffentliche Finanzen, Steuern und Abgaben"])
+    assert short == long == ["federal", "state"]
+
+
+def test_all_aliases_match_their_canonical_levels() -> None:
+    """Every _TOPIC_ALIASES value must be identical to a canonical key's levels."""
+    for alias, levels in ttc._TOPIC_ALIASES.items():
+        assert alias not in TOPIC_TAXONOMY, (
+            f"Alias {alias!r} shadows a canonical TOPIC_TAXONOMY key"
+        )
+        assert levels in TOPIC_TAXONOMY.values(), (
+            f"Alias {alias!r} levels {levels!r} do not match any canonical entry"
+        )
+
+
+def test_golden_fixture_labels_resolve_without_all_levels_fallback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """every field_topics label in the golden poll fixtures must resolve via
+    the taxonomy (canonical key or alias) WITHOUT the unknown-label ALL_LEVELS
+    fallback — the fallback would make the vote over-surface in state/municipal
+    chats and defeat the down-rank."""
+    import json
+    from pathlib import Path
+
+    fixtures_dir = Path(__file__).parent / "fixtures"
+    labels: list[str] = []
+    for fixture in sorted(fixtures_dir.glob("aw_poll_*_poll.json")):
+        poll = json.loads(fixture.read_text())["data"]
+        labels.extend(
+            str(t["label"])
+            for t in (poll.get("field_topics") or [])
+            if isinstance(t, dict) and t.get("label")
+        )
+    assert labels, "expected at least one field_topics label across golden fixtures"
+
+    for label in labels:
+        with caplog.at_level(logging.WARNING, logger=ttc.logger.name):
+            caplog.clear()
+            get_relevance_levels([label])
+        assert not any("not in TOPIC_TAXONOMY" in r.message for r in caplog.records), (
+            f"Golden-fixture label {label!r} fell back to ALL_LEVELS (unmapped)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. Missing-topics warning gate
+# ---------------------------------------------------------------------------
+
+
+def test_empty_topics_warning_suppressed_for_non_federal(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """warn_on_missing_topics=False (non-federal legislatures) must NOT emit the
+    per-poll no-field_topics WARNING; the ALL_LEVELS default still applies."""
+    with caplog.at_level(logging.WARNING, logger=ttc.logger.name):
+        result = get_relevance_levels([], warn_on_missing_topics=False)
+    assert result == sorted(ALL_LEVELS)
+    assert not any("no field_topics" in r.message for r in caplog.records), (
+        "no-field_topics WARNING must be suppressed when warn_on_missing_topics=False"
+    )
+
+
+def test_unknown_label_still_warns_with_suppressed_missing_topics(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unknown-label warnings stay loud everywhere — the gate only covers
+    the empty-input case."""
+    with caplog.at_level(logging.WARNING, logger=ttc.logger.name):
+        result = get_relevance_levels(
+            ["Definitiv unbekanntes Thema"], warn_on_missing_topics=False
+        )
+    assert result == sorted(ALL_LEVELS)
+    assert any("not in TOPIC_TAXONOMY" in r.message for r in caplog.records)

--- a/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_topic_taxonomy.py
+++ b/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_topic_taxonomy.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -207,7 +207,7 @@ def test_taxonomy_has_exactly_53_entries() -> None:
     """TOPIC_TAXONOMY must have exactly 53 entries."""
     assert len(TOPIC_TAXONOMY) == 53, (
         f"Expected 53 entries, got {len(TOPIC_TAXONOMY)}. "
-        "Missing: {_EXPECTED_53_LABELS - set(TOPIC_TAXONOMY)}"
+        f"Missing: {_EXPECTED_53_LABELS - set(TOPIC_TAXONOMY)}"
     )
 
 

--- a/ai-backend/tests/ingestion/test_enum_parity.py
+++ b/ai-backend/tests/ingestion/test_enum_parity.py
@@ -1,15 +1,16 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
 """
 Parity guards for duplicated constant surfaces.
 
-- retrieve.py duplicates the schemas enums as Literal types (clean Gemini
-  tool-schema generation, issue #409). Without a parity test, adding a new
+- retrieve.py duplicates the schemas enums as Literal types (Python Enum in a
+  Gemini tool declaration triggers a langchain-google-genai schema bug, so the
+  tool surface uses Literal[...]). Without a parity test, adding a new
   SourceType silently leaves the tool schema stale.
-- src/ingestion/levels.py hoists the governance-level constants out of the
-  abgeordnetenwatch connector; until the connector is re-pointed to
+- src/ingestion/governance_levels.py hoists the governance-level constants out
+  of the abgeordnetenwatch connector; until the connector is re-pointed to
   re-export from the shared module, both definitions must stay identical.
 """
 
@@ -35,7 +36,7 @@ def test_levels_module_matches_aw_taxonomy_definitions() -> None:
     """The AW taxonomy RE-EXPORTS the shared levels module's constants.
     Identity assertions guard against someone re-introducing local definitions
     in topic_taxonomy_config.py (equal-but-distinct objects would fail)."""
-    from src.ingestion import levels
+    from src.ingestion import governance_levels as levels
     from src.ingestion.connectors.abgeordnetenwatch import topic_taxonomy_config as aw
 
     assert aw.FEDERAL == levels.FEDERAL
@@ -51,10 +52,10 @@ def test_retrieve_imports_levels_from_shared_module() -> None:
     connector-owned or locally re-defined copy. Asserted by object identity: a
     re-defined ALL_LEVELS (or one sourced from a connector) would be a different
     object and fail here."""
-    import src.ingestion.levels as levels
+    import src.ingestion.governance_levels as levels
     import src.ingestion.retrieve as retrieve_mod
 
     assert retrieve_mod.ALL_LEVELS is levels.ALL_LEVELS, (
-        "retrieve.py must bind ALL_LEVELS from src.ingestion.levels, not a "
+        "retrieve.py must bind ALL_LEVELS from src.ingestion.governance_levels, not a "
         "connector-owned or locally re-defined copy"
     )

--- a/ai-backend/tests/ingestion/test_enum_parity.py
+++ b/ai-backend/tests/ingestion/test_enum_parity.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Parity guards for duplicated constant surfaces.
+
+- retrieve.py duplicates the schemas enums as Literal types (clean Gemini
+  tool-schema generation, issue #409). Without a parity test, adding a new
+  SourceType silently leaves the tool schema stale.
+- src/ingestion/levels.py hoists the governance-level constants out of the
+  abgeordnetenwatch connector; until the connector is re-pointed to
+  re-export from the shared module, both definitions must stay identical.
+"""
+
+from __future__ import annotations
+
+from typing import get_args
+
+from src.ingestion.retrieve import AuthorityTierLiteral, SourceTypeLiteral
+from src.ingestion.schemas import AuthorityTier, SourceType
+
+
+def test_source_type_literal_matches_enum() -> None:
+    """SourceTypeLiteral (retrieve.py tool surface) == SourceType enum values."""
+    assert set(get_args(SourceTypeLiteral)) == {e.value for e in SourceType}
+
+
+def test_authority_tier_literal_matches_enum() -> None:
+    """AuthorityTierLiteral (retrieve.py tool surface) == AuthorityTier enum values."""
+    assert set(get_args(AuthorityTierLiteral)) == {e.value for e in AuthorityTier}
+
+
+def test_levels_module_matches_aw_taxonomy_definitions() -> None:
+    """The AW taxonomy RE-EXPORTS the shared levels module's constants.
+    Identity assertions guard against someone re-introducing local definitions
+    in topic_taxonomy_config.py (equal-but-distinct objects would fail)."""
+    from src.ingestion import levels
+    from src.ingestion.connectors.abgeordnetenwatch import topic_taxonomy_config as aw
+
+    assert aw.FEDERAL == levels.FEDERAL
+    assert aw.STATE == levels.STATE
+    assert aw.MUNICIPAL == levels.MUNICIPAL
+    # Identity (not equality): a re-introduced local frozenset would be equal
+    # but not the SAME object — this is the actual re-export guard.
+    assert aw.ALL_LEVELS is levels.ALL_LEVELS
+
+
+def test_retrieve_imports_levels_from_shared_module() -> None:
+    """The framework retrieval module must use the SHARED levels objects, not a
+    connector-owned or locally re-defined copy. Asserted by object identity: a
+    re-defined ALL_LEVELS (or one sourced from a connector) would be a different
+    object and fail here."""
+    import src.ingestion.levels as levels
+    import src.ingestion.retrieve as retrieve_mod
+
+    assert retrieve_mod.ALL_LEVELS is levels.ALL_LEVELS, (
+        "retrieve.py must bind ALL_LEVELS from src.ingestion.levels, not a "
+        "connector-owned or locally re-defined copy"
+    )


### PR DESCRIPTION
V2 stack 3/9 — the first real connector: Abgeordnetenwatch roll-call votes, the canonical `vote_record` producer.

> **Diff-size note:** ~18.5k of the +22.7k lines are one captured AW API response (`fixtures/aw_poll_3602_votes.json` — the full per-MdB vote list for poll 3602 that the mapper tests replay). It's marked `linguist-generated`, so it renders collapsed. The **actual reviewable diff is ~4.2k lines across 17 files**, and half of that is tests.

- **AW API client** with the 2s/request rate limit and paged poll discovery.
- **Vote mapping**: one chunk per poll with per-party tallies and stances; `relevance_levels` tagging from the topic taxonomy so federal votes can be surfaced (down-ranked) in state chats where the topic actually applies.
- **`LEGISLATURE_CONFIG`**: federal WP19–21 plus all 16 Landtage, current + prior period each, with AW period IDs cited per row.

Two AW test files (`test_corpus_chunk_poll.py`, `test_legislature_config.py`) arrive in the manifestos PR instead of here — they assert region mapping through the manifesto mapper's `region_for_period`, so they'd break the build at this point in the stack.

Verified: ruff, mypy, 179 tests, GDPR wall guard.
