### PR TITLE
V2 stack 4/9: Bundestag speeches (DIP) connector

### DIFF
--- a/ai-backend/pyproject.toml
+++ b/ai-backend/pyproject.toml
@@ -36,6 +36,8 @@ dependencies = [
     "trafilatura>=2.1.0",
     "defusedxml>=0.7.1",
     "langchain-text-splitters>=1.1.2",
+    "httpx>=0.27",
+    "tenacity>=8.2",
 ]
 
 [dependency-groups]
@@ -43,7 +45,6 @@ dev = [
     "mypy>=1.12.0",
     "pre-commit>=4.0.0",
     "ruff>=0.8.0",
-    "httpx>=0.27",
     "pytest>=8.3",
     "pytest-asyncio>=0.24",
 ]

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/__init__.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""Bundestag speeches connector package — plenary protocol speeches → parliamentary_speech corpus.
+
+Source: DIP Bundestag API (search.dip.bundestag.de) for protocol discovery and
+XML download of individual plenary protocol transcripts.
+
+Live incremental connector: produces ChunkRecord list
+directly from normalize() — embed + upsert are owned by the runner (run.py).
+
+Package structure (mirrors connectors/abgeordnetenwatch/):
+  connector.py        — BundestagSpeechesConnector(BaseConnector): discover/fetch/normalize
+  client.py           — DipClient: paginated HTTP, curl challenge fallback
+  parser.py           — parse_speeches_from_xml (hardened via defusedxml)
+  mdb.py              — load_mdb_lookup, mdb_party_for_speech, mdb_record_for_speaker_name
+  constants.py        — BASE_URL, PARTY_ALIASES, VALID_PARTIES, MDB_STAMMDATEN_FILE
+  utils.py            — normalize_party, normalize_whitespace
+  bulk.py             — optional --from-jsonl backfill (manifestos bulk.py analog)
+  mappers/
+    corpus.py         — build_chunk_records, chunk_text, party_to_slug
+"""

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/__init__.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/bulk.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/bulk.py
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Standalone bulk CLI for replaying Bundestag plenary speeches from a local
+JSONL dump into ``wahlchat_chunks_{ENV}`` via the relocated corpus mapper.
+
+This is the --from-jsonl backfill entrypoint that keeps the existing 99 MB
+``speeches.jsonl`` replayable without re-fetching from the DIP API.  The
+live connector (``connector.py``) handles incremental runs via ``run.py``
+and the YYYYMMDD cursor; this script handles the one-shot historical backfill.
+
+Design notes:
+  - This is the ONLY file within the ``bundestag_speeches`` package permitted
+    to call the runner ``_embed_texts`` / ``_upsert_chunks`` helpers directly.
+    The connector never touches those helpers — ``run.py`` owns that path.
+  - Replayed rows pre-date the live connector, so ``build_chunk_records``
+    leaves ``external_id=None`` for the bulk path (the live connector stamps
+    YYYYMMDD in ``normalize()``; a future migration patches legacy rows).
+  - The script is idempotent: deterministic chunk UUIDs (via ``compute_chunk_id``)
+    mean re-running upserts the same Qdrant point IDs, which is a no-op.
+
+Usage (local dev):
+    cd ai-backend
+    uv run python -m src.ingestion.connectors.bundestag_speeches.bulk --help
+    uv run python -m src.ingestion.connectors.bundestag_speeches.bulk --limit 20
+    uv run python -m src.ingestion.connectors.bundestag_speeches.bulk speeches.jsonl
+    QDRANT_URL=http://localhost:6333 ENV=dev \\
+        uv run python -m src.ingestion.connectors.bundestag_speeches.bulk
+
+JSONL path resolution (CLI arg > SPEECHES_JSONL env > repo-root default):
+    1. Positional ``jsonl_path`` argument (also accepted as ``--from-jsonl``).
+    2. ``SPEECHES_JSONL`` environment variable.
+    3. Repo root ``speeches.jsonl`` (three levels above ``ai-backend/``).
+
+Requires: make stores-up first (Qdrant running at QDRANT_URL).
+          OPENAI_API_KEY in ai-backend/.env (auto-loaded if present).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from langchain_openai import OpenAIEmbeddings
+from qdrant_client import QdrantClient
+
+from datetime import date as _date_type
+
+from src.ingestion.connectors.bundestag_speeches.mappers.corpus import (
+    build_chunk_records,
+)
+from src.ingestion.run import _embed_texts, _upsert_chunks
+from src.ingestion.schemas import ChunkRecord
+from src.ingestion.setup_collection import COLLECTION_NAME, EMBEDDING_MODEL
+
+logger = logging.getLogger(__name__)
+
+_BATCH_SIZE = 100  # chunks per embed+upsert batch
+
+
+# =============================================================================
+# MAIN INGEST LOOP
+# =============================================================================
+
+
+def ingest(
+    jsonl_path: Path,
+    qdrant: QdrantClient,
+    embed: OpenAIEmbeddings,
+    limit: Optional[int] = None,
+) -> tuple[int, int]:
+    """Read speeches from *jsonl_path* and upsert into Qdrant in batches.
+
+    Each JSONL line is a speech dict passed through
+    ``build_chunk_records`` from the relocated corpus mapper.  Replayed
+    rows are stamped with ``external_id=YYYYMMDD`` so that
+    ``get_cursor("parliamentary_speech")`` picks up the backfill and the
+    first live incremental run does not re-embed everything.
+
+    Args:
+        jsonl_path:  Path to the speeches JSONL file (one JSON object per line).
+        qdrant:      Initialised QdrantClient.
+        embed:       Initialised OpenAIEmbeddings instance.
+        limit:       Maximum number of speeches to process (None = all).
+
+    Returns:
+        Tuple of (speeches_processed, chunks_upserted).
+    """
+    speeches_processed = 0
+    chunks_total = 0
+    batch: list[ChunkRecord] = []
+
+    def _flush(b: list[ChunkRecord]) -> int:
+        if not b:
+            return 0
+        vectors = _embed_texts(embed, [c.text for c in b])
+        _upsert_chunks(qdrant, COLLECTION_NAME, b, vectors)
+        return len(b)
+
+    with jsonl_path.open(encoding="utf-8") as fh:
+        for raw_line in fh:
+            raw_line = raw_line.strip()
+            if not raw_line:
+                continue
+
+            if limit is not None and speeches_processed >= limit:
+                break
+
+            speech = json.loads(raw_line)
+            records = build_chunk_records(speech)
+            if not records:
+                # Skip empty-text or unparseable-date speeches (no chunk emitted, not counted).
+                continue
+
+            # Stamp external_id=YYYYMMDD on each bulk-backfill record.
+            # build_chunk_records() leaves external_id=None for mapper neutrality.
+            # Without stamping, run.py's get_cursor() ignores these points entirely
+            # (exclude_none=True in _upsert_chunks drops the external_id key), so the
+            # first live incremental run re-fetches and re-embeds everything.
+            # Convention: same YYYYMMDD integer the live connector's normalize() uses.
+            # On missing/unparseable date, build_chunk_records already returns [] above,
+            # so raw_date here is always a valid ISO date string.
+            raw_date = speech.get("date") or ""
+            try:
+                parsed = _date_type.fromisoformat(raw_date)
+                yyyymmdd = int(parsed.strftime("%Y%m%d"))
+                records = [
+                    c.model_copy(update={"external_id": yyyymmdd}) for c in records
+                ]
+            except (ValueError, TypeError):
+                # Defensive guard: build_chunk_records would have already skipped a bad
+                # date, but guard here to be safe — skip without stamping.
+                logger.warning(
+                    "bulk.ingest: speech %r has unparseable date %r — skipping (no stamp).",
+                    speech.get("id"),
+                    raw_date,
+                )
+                continue
+
+            speeches_processed += 1
+            batch.extend(records)
+            chunks_total += len(records)
+
+            if len(batch) >= _BATCH_SIZE:
+                flushed = _flush(batch)
+                logger.info(
+                    "Flushed batch of %d chunks (total so far: %d)",
+                    flushed,
+                    chunks_total,
+                )
+                batch = []
+
+    _flush(batch)
+
+    return speeches_processed, chunks_total
+
+
+# =============================================================================
+# __main__ entrypoint
+# =============================================================================
+
+if __name__ == "__main__":
+    # Load ai-backend/.env if present.
+    # bulk.py sits at: ai-backend/src/ingestion/connectors/bundestag_speeches/bulk.py
+    # parents[4] = ai-backend/ (same depth as manifestos/bulk.py)
+    from dotenv import load_dotenv  # noqa: PLC0415
+
+    _env_path = Path(__file__).resolve().parents[4] / ".env"
+    if _env_path.exists():
+        # .env is the source of truth for local dev — let it win over any stale
+        # value inherited from the shell.
+        load_dotenv(_env_path, override=True)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Replay Bundestag plenary speeches from a local JSONL dump into the "
+            "Qdrant wahlchat_chunks_{ENV} collection via the relocated corpus mapper. "
+            "No DIP API key required — reads from speeches.jsonl, not the live API."
+        ),
+    )
+    parser.add_argument(
+        "jsonl_path",
+        nargs="?",
+        default=None,
+        metavar="JSONL_PATH",
+        help=(
+            "Path to speeches JSONL file. "
+            "Falls back to SPEECHES_JSONL env var or repo-root speeches.jsonl. "
+            "Also accepted as --from-jsonl."
+        ),
+    )
+    parser.add_argument(
+        "--from-jsonl",
+        dest="from_jsonl",
+        default=None,
+        metavar="JSONL_PATH",
+        help="Alias for the positional jsonl_path argument.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Process at most N speeches (for smoke testing).",
+    )
+    args = parser.parse_args()
+
+    # Resolve JSONL path: positional arg > --from-jsonl > env var > repo-root default.
+    raw_path = args.jsonl_path or args.from_jsonl
+    if raw_path:
+        resolved_path = Path(raw_path).resolve()
+    elif os.getenv("SPEECHES_JSONL"):
+        resolved_path = Path(os.environ["SPEECHES_JSONL"]).resolve()
+    else:
+        # Repo root is 5 levels above this file:
+        # ai-backend/src/ingestion/connectors/bundestag_speeches/bulk.py → parents[5]
+        resolved_path = Path(__file__).resolve().parents[5] / "speeches.jsonl"
+
+    if not resolved_path.exists():
+        print(f"ERROR: JSONL file not found: {resolved_path}", file=sys.stderr)
+        sys.exit(1)
+
+    qdrant_url = os.getenv("QDRANT_URL", "http://localhost:6333")
+    _qdrant = QdrantClient(url=qdrant_url)
+    _embed = OpenAIEmbeddings(model=EMBEDDING_MODEL)
+
+    print(f"Replaying speeches from {resolved_path} (limit={args.limit}) ...")
+    try:
+        processed, chunks = ingest(resolved_path, _qdrant, _embed, limit=args.limit)
+    except Exception:  # noqa: BLE001
+        import traceback  # noqa: PLC0415
+
+        print("ERROR: ingestion failed:", file=sys.stderr)
+        traceback.print_exc()
+        sys.exit(1)
+
+    print(f"Done. speeches_processed={processed}  chunks_upserted={chunks}")

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/bulk.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/bulk.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -8,18 +8,26 @@ JSONL dump into ``wahlchat_chunks_{ENV}`` via the relocated corpus mapper.
 
 This is the --from-jsonl backfill entrypoint that keeps the existing 99 MB
 ``speeches.jsonl`` replayable without re-fetching from the DIP API.  The
-live connector (``connector.py``) handles incremental runs via ``run.py``
-and the YYYYMMDD cursor; this script handles the one-shot historical backfill.
+live connector (``connector.py``) handles incremental runs via ``run.py``;
+this script handles the one-shot historical backfill.
 
 Design notes:
   - This is the ONLY file within the ``bundestag_speeches`` package permitted
     to call the runner ``_embed_texts`` / ``_upsert_chunks`` helpers directly.
     The connector never touches those helpers — ``run.py`` owns that path.
-  - Replayed rows pre-date the live connector, so ``build_chunk_records``
-    leaves ``external_id=None`` for the bulk path (the live connector stamps
-    YYYYMMDD in ``normalize()``; a future migration patches legacy rows).
+  - Embeddings come from the SAME factory as the runner
+    (``get_embeddings(task_type="RETRIEVAL_DOCUMENT")``), so the backfill
+    writes vectors in the configured provider/model space — a hardcoded
+    OpenAI client would silently corrupt a Gemini-configured corpus.
+  - Replacement-safe per speech: each speech's stored footprint (by
+    ``source_item_id``) is compared AFTER the new chunks are upserted, and
+    only orphaned higher-index chunk points are deleted — a corrected speech
+    that shrinks leaves no stale tail, and no window exists in which the
+    speech is absent. Speeches REMOVED from the dump are out of scope for a
+    per-row replay (no discover step) — the live connector's set-difference
+    reconciliation owns that.
   - The script is idempotent: deterministic chunk UUIDs (via ``compute_chunk_id``)
-    mean re-running upserts the same Qdrant point IDs, which is a no-op.
+    mean re-running upserts the same Qdrant point IDs.
 
 Usage (local dev):
     cd ai-backend
@@ -34,8 +42,9 @@ JSONL path resolution (CLI arg > SPEECHES_JSONL env > repo-root default):
     2. ``SPEECHES_JSONL`` environment variable.
     3. Repo root ``speeches.jsonl`` (three levels above ``ai-backend/``).
 
-Requires: make stores-up first (Qdrant running at QDRANT_URL).
-          OPENAI_API_KEY in ai-backend/.env (auto-loaded if present).
+Requires: make stores-up first (Qdrant running at QDRANT_URL) and the
+          configured embedding provider's API key in ai-backend/.env
+          (auto-loaded; exported shell env wins).
 """
 
 from __future__ import annotations
@@ -48,21 +57,89 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-from langchain_openai import OpenAIEmbeddings
-from qdrant_client import QdrantClient
+# CLI startup ONLY: load ai-backend/.env BEFORE the imports below — embeddings
+# and setup_collection freeze EMBEDDING_MODEL / EMBEDDING_DIM / COLLECTION_NAME
+# from the environment at import time, so a later load_dotenv() configures
+# nothing. override=False keeps explicitly-exported shell env (QDRANT_URL,
+# ENV, …) authoritative — a make/CI invocation that targets a specific store
+# must never be silently redirected by a local .env.
+if __name__ == "__main__":
+    from dotenv import load_dotenv
+
+    _env_path = Path(__file__).resolve().parents[4] / ".env"
+    if _env_path.exists():
+        load_dotenv(_env_path, override=False)
+
+from langchain_core.embeddings import Embeddings
+from qdrant_client import QdrantClient, models
 
 from datetime import date as _date_type
 
+from src.embeddings import get_embeddings
 from src.ingestion.connectors.bundestag_speeches.mappers.corpus import (
     build_chunk_records,
 )
+from src.ingestion.ids import compute_chunk_id
 from src.ingestion.run import _embed_texts, _upsert_chunks
 from src.ingestion.schemas import ChunkRecord
-from src.ingestion.setup_collection import COLLECTION_NAME, EMBEDDING_MODEL
+from src.ingestion.setup_collection import COLLECTION_NAME, check_fingerprint
 
 logger = logging.getLogger(__name__)
 
 _BATCH_SIZE = 100  # chunks per embed+upsert batch
+
+
+def _delete_shrunk_orphans(
+    qdrant: QdrantClient, collection_name: str, chunks: list[ChunkRecord]
+) -> int:
+    """Delete stored points a re-chunked speech no longer produces.
+
+    Runs AFTER the new chunks are durably upserted (no absence window): for
+    every source_item_id in *chunks*, scroll the stored footprint and delete
+    any point id the new output does not contain (a stale higher-index chunk
+    after a shrink).
+
+    Returns the number of deleted orphan points.
+    """
+    new_ids_by_siid: dict[str, set[str]] = {}
+    for c in chunks:
+        new_ids_by_siid.setdefault(str(c.source_item_id), set()).add(
+            str(compute_chunk_id(c.source_item_id, c.chunk_index))
+        )
+
+    orphans: list[str] = []
+    siids = sorted(new_ids_by_siid)
+    scroll_filter = models.Filter(
+        must=[
+            models.FieldCondition(
+                key="source_item_id", match=models.MatchAny(any=siids)
+            )
+        ]
+    )
+    next_offset = None
+    while True:
+        points, next_offset = qdrant.scroll(
+            collection_name=collection_name,
+            scroll_filter=scroll_filter,
+            limit=1000,
+            offset=next_offset,
+            with_payload=["source_item_id"],
+            with_vectors=False,
+        )
+        for p in points:
+            siid = str((p.payload or {}).get("source_item_id"))
+            if str(p.id) not in new_ids_by_siid.get(siid, set()):
+                orphans.append(str(p.id))
+        if next_offset is None:
+            break
+
+    if orphans:
+        qdrant.delete(
+            collection_name=collection_name,
+            points_selector=models.PointIdsList(points=sorted(orphans)),
+            wait=True,
+        )
+    return len(orphans)
 
 
 # =============================================================================
@@ -73,8 +150,9 @@ _BATCH_SIZE = 100  # chunks per embed+upsert batch
 def ingest(
     jsonl_path: Path,
     qdrant: QdrantClient,
-    embed: OpenAIEmbeddings,
+    embed: Embeddings,
     limit: Optional[int] = None,
+    collection_name: str = COLLECTION_NAME,
 ) -> tuple[int, int]:
     """Read speeches from *jsonl_path* and upsert into Qdrant in batches.
 
@@ -84,11 +162,15 @@ def ingest(
     ``get_cursor("parliamentary_speech")`` picks up the backfill and the
     first live incremental run does not re-embed everything.
 
+    Batch commit order: embed → upsert (wait=True) → delete shrunk orphans.
+    The old footprint is never removed before its replacement is durable.
+
     Args:
         jsonl_path:  Path to the speeches JSONL file (one JSON object per line).
         qdrant:      Initialised QdrantClient.
-        embed:       Initialised OpenAIEmbeddings instance.
+        embed:       Embeddings client from ``get_embeddings()``.
         limit:       Maximum number of speeches to process (None = all).
+        collection_name: Target collection (injectable for tests).
 
     Returns:
         Tuple of (speeches_processed, chunks_upserted).
@@ -101,7 +183,10 @@ def ingest(
         if not b:
             return 0
         vectors = _embed_texts(embed, [c.text for c in b])
-        _upsert_chunks(qdrant, COLLECTION_NAME, b, vectors)
+        _upsert_chunks(qdrant, collection_name, b, vectors)
+        # Only after the replacement is durably written: prune stale
+        # higher-index chunks of re-chunked speeches.
+        _delete_shrunk_orphans(qdrant, collection_name, b)
         return len(b)
 
     with jsonl_path.open(encoding="utf-8") as fh:
@@ -167,17 +252,6 @@ def ingest(
 # =============================================================================
 
 if __name__ == "__main__":
-    # Load ai-backend/.env if present.
-    # bulk.py sits at: ai-backend/src/ingestion/connectors/bundestag_speeches/bulk.py
-    # parents[4] = ai-backend/ (same depth as manifestos/bulk.py)
-    from dotenv import load_dotenv  # noqa: PLC0415
-
-    _env_path = Path(__file__).resolve().parents[4] / ".env"
-    if _env_path.exists():
-        # .env is the source of truth for local dev — let it win over any stale
-        # value inherited from the shell.
-        load_dotenv(_env_path, override=True)
-
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
     parser = argparse.ArgumentParser(
@@ -230,8 +304,13 @@ if __name__ == "__main__":
         sys.exit(1)
 
     qdrant_url = os.getenv("QDRANT_URL", "http://localhost:6333")
-    _qdrant = QdrantClient(url=qdrant_url)
-    _embed = OpenAIEmbeddings(model=EMBEDDING_MODEL)
+    _qdrant = QdrantClient(url=qdrant_url, api_key=os.getenv("QDRANT_API_KEY"))
+    # Same provider factory + task type as run.py — the backfill must write
+    # vectors in the corpus's configured embedding space.
+    _embed = get_embeddings(task_type="RETRIEVAL_DOCUMENT")
+    # Refuse to write into a collection whose fingerprint contradicts the
+    # current provider/model configuration.
+    check_fingerprint(_qdrant, COLLECTION_NAME)
 
     print(f"Replaying speeches from {resolved_path} (limit={args.limit}) ...")
     try:

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/client.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/client.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""DipClient — the single I/O home for all DIP Bundestag API calls.
+
+Design goals (mirrors abgeordnetenwatch/client.py posture):
+  - BASE_URL is a pinned module constant — host never derived from a caller arg.
+  - curl_get uses a fixed arg list, no shell=True.
+  - DipClient.get paces requests with a 0.2 s sleep (DIP cap = 25 concurrent).
+  - Enodia challenge-page redirect handled via curl fallback.
+
+Public API:
+  DipClient(api_key, sleep=0.2)  — paced session; .get(endpoint, params) and .pages(endpoint, params)
+  fetch_text(url) -> str          — fetch XML text, curl fallback on challenge redirect
+  curl_get(url, accept) -> str    — fixed-arg subprocess curl, no shell=True
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from urllib.parse import urlencode
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+import logging as _logging
+
+from .constants import BASE_URL, _MAX_PAGES
+
+_client_logger = _logging.getLogger(__name__)
+
+# User-Agent identifying wahl.chat (same string the AW client sends). Honest
+# identification over a spoofed browser UA; the DIP WAF's .enodia/challenge is
+# handled by the curl fallback in get(), not by masquerading here.
+_USER_AGENT = "wahl.chat-ingestion/2.0 (https://wahl.chat)"
+
+
+class DipChallengeError(RuntimeError):
+    """Raised when the Bundestag .enodia/challenge page cannot be bypassed."""
+
+
+class DipClient:
+    """Paced HTTP client for the DIP Bundestag API v1.
+
+    Enforces:
+      - Sequential 0.2 s sleep between requests (DIP documented cap = 25 concurrent).
+      - Up to 3 attempts per request; curl fallback on .enodia/challenge redirect.
+
+    Args:
+        api_key: DIP API key (from DIP_API_KEY env var — see connector._require_dip_key()).
+        sleep: Inter-request delay in seconds (default 0.2).
+    """
+
+    def __init__(self, api_key: str, sleep: float = 0.2) -> None:
+        self.api_key = api_key
+        self.sleep = sleep
+        self.session = requests.Session()
+        # Retry transient HTTP failures at the adapter level (mirrors the AW
+        # client): urllib3 backs off on 429/5xx and honours Retry-After. The
+        # .enodia/challenge redirect is NOT an HTTP error status, so it is
+        # handled separately (curl fallback) in get().
+        retry = Retry(
+            total=3,
+            backoff_factor=1.0,
+            status_forcelist=(429, 500, 502, 503, 504),
+            allowed_methods=("GET",),
+            respect_retry_after_header=True,
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        self.session.mount("https://", adapter)
+        self.session.mount("http://", adapter)
+        self.session.headers.update(
+            {
+                "Accept": "application/json",
+                "User-Agent": _USER_AGENT,
+            }
+        )
+
+    def get(self, endpoint: str, params: dict | None = None) -> dict:
+        """Make a single GET request to the DIP API, with challenge-page fallback.
+
+        Args:
+            endpoint: API path (e.g. "/plenarprotokoll").
+            params: Query parameters (apikey is injected automatically).
+
+        Returns:
+            Parsed JSON response dict.
+
+        Raises:
+            requests.HTTPError: on non-2xx responses (after all attempts).
+            DipChallengeError: if curl fallback also hits the challenge page.
+        """
+        params = dict(params or {})
+        params["apikey"] = self.api_key
+        params["format"] = "json"
+        url = BASE_URL + endpoint + "?" + urlencode(params, doseq=True)
+
+        for attempt in range(3):
+            response = self.session.get(BASE_URL + endpoint, params=params, timeout=60)
+            if ".enodia/challenge" not in response.url:
+                break
+            if attempt == 2:
+                data = curl_get(url, accept="application/json")
+                time.sleep(self.sleep)
+                return json.loads(data)
+            time.sleep(5 * (attempt + 1))
+
+        response.raise_for_status()
+        time.sleep(self.sleep)
+        return response.json()
+
+    def pages(self, endpoint: str, params: dict | None = None):  # type: ignore[return]
+        """Walk all cursor-pages for an endpoint, yielding one page dict at a time.
+
+        Stops when the cursor is absent or unchanged (DIP documented cursor-until-unchanged
+        contract). Each page dict contains a "documents" list and a "cursor" string.
+
+        Args:
+            endpoint: API path (e.g. "/plenarprotokoll").
+            params: Base query parameters (cursor is injected automatically).
+
+        Yields:
+            dict: One page of API results.
+        """
+        params = dict(params or {})
+        last_cursor = None
+        page_count = 0
+
+        while True:
+            # Enforce a hard page cap (mirrors the AW client's _MAX_PAGES) so a
+            # stuck/malformed cursor cannot loop indefinitely.  _MAX_PAGES (from
+            # constants.py) is generous enough for any full legislature's protocol
+            # list but provably finite.
+            page_count += 1
+            if page_count > _MAX_PAGES:
+                _client_logger.warning(
+                    "DipClient.pages(): hit hard page cap of %d for endpoint %r — stopping.",
+                    _MAX_PAGES,
+                    endpoint,
+                )
+                break
+
+            data = self.get(endpoint, params)
+            yield data
+
+            cursor = data.get("cursor")
+            if not cursor or cursor == last_cursor:
+                break
+
+            params["cursor"] = cursor
+            last_cursor = cursor
+
+
+def fetch_text(url: str) -> str:
+    """Fetch text content from a URL, using curl fallback on .enodia/challenge redirect.
+
+    Used to retrieve protocol XML from DIP fundstelle.xml_url.
+
+    Args:
+        url: Full URL to fetch (DIP-returned xml_url — not user-supplied).
+
+    Returns:
+        Response text (UTF-8 decoded).
+
+    Raises:
+        requests.HTTPError: on non-2xx responses.
+        DipChallengeError: if curl fallback fails.
+    """
+    response = requests.get(url, timeout=60)
+    if ".enodia/challenge" in response.url:
+        return curl_get(url, accept="text/xml")
+
+    response.raise_for_status()
+    response.encoding = response.encoding or "utf-8"
+    return response.text
+
+
+def curl_get(url: str, accept: str = "*/*") -> str:
+    """Fetch a URL via subprocess curl with a fixed argument list (no shell=True).
+
+    Security: the URL is DIP-derived, not user-supplied; the arg
+    list is fixed at call time and never passed through a shell.
+
+    Args:
+        url: URL to fetch (DIP-derived; not user-supplied).
+        accept: Accept header value (default "*/*").
+
+    Returns:
+        Response body as a string.
+
+    Raises:
+        DipChallengeError: if curl exits non-zero.
+    """
+    # Fixed arg list — no shell=True
+    command = ["curl", "-sS", "-L", "--fail", "-H", f"Accept: {accept}", url]
+    result = subprocess.run(command, text=True, capture_output=True, timeout=90)
+    if result.returncode != 0:
+        raise DipChallengeError(
+            result.stderr.strip() or "curl could not fetch the official Bundestag URL"
+        )
+    return result.stdout

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/client.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/client.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/connector.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/connector.py
@@ -1,0 +1,704 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+BundestagSpeechesConnector — live incremental connector.
+
+This connector implements the 3-method
+synchronous ABC (discover/fetch/normalize) and produces list[ChunkRecord]
+directly from normalize() — no Firestore, no GCS, no work_queue.
+
+The runner (run.py) owns embed + upsert; this connector is pure data-transform.
+The cursor (since) is a YYYYMMDD integer derived by the runner from Qdrant
+max(external_id) for "parliamentary_speech" — passed to discover() as the date
+floor.  No watermark methods needed.
+
+Security notes:
+    DIP_API_KEY fail-loud: _require_dip_key() raises RuntimeError
+    at construction when DIP_API_KEY is unset.  NO hardcoded key.
+
+    DESC → ASC re-sort: DIP returns protocols newest-first.
+    discover() re-sorts ascending by (datum, id) so run_connector processes
+    oldest-first and the YYYYMMDD cursor advances monotonically.
+
+    fetch() never raises: missing xml_url / parse failures return a
+    skip_reason dict; normalize() raises ValueError → runner skip-and-warn.
+    The cursor does NOT advance past skipped protocols (idempotent upsert
+    handles re-processing if a protocol later becomes available).
+
+    DIP XML fetched via absorbed fetch_text/defusedxml; the
+    xml_url comes only from DIP responses, never from caller input.
+
+CONCURRENCY HAZARD:
+    The DIP and openparliament_tv schedules MUST be serialized — never run both
+    connectors concurrently. The interleaving "DIP resurrection-guard passes →
+    op ingests + supersedes → DIP commits" can strand a DIP twin that no later
+    run's new-chunk/orphan filters ever cover. As a cheap self-heal, normalize()
+    records the siids it SKIPPED as op-superseded in ``last_superseded_siids``;
+    run_connector deletes any stored points under them on the next (serialized)
+    DIP run.
+"""
+
+from __future__ import annotations
+
+import difflib
+import logging
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+from src.ingestion.connector import BaseConnector
+from src.ingestion.connectors.bundestag_speeches.client import DipClient, fetch_text
+from src.ingestion.connectors.bundestag_speeches.constants import MDB_STAMMDATEN_FILE
+from src.ingestion.connectors.bundestag_speeches.mappers import corpus as corpus_mapper
+from src.ingestion.connectors.bundestag_speeches.mdb import (
+    ensure_mdb_lookup,
+    mdb_party_for_speech,
+    mdb_record_for_speaker_name,
+)
+from src.ingestion.connectors.bundestag_speeches.parser import parse_speeches_from_xml
+from src.ingestion.connectors.bundestag_speeches.utils import normalize_party
+from src.ingestion.ids import compute_source_item_id
+from src.ingestion.schemas import ChunkRecord, SourceType
+from src.ingestion.setup_collection import COLLECTION_NAME
+
+# Shared speech-dedup helpers — one definition for both speech connectors
+# and the op supersede module; drift between copies would silently break
+# cross-source dedup.
+from src.ingestion.speech_dedup import (
+    LOOKBACK_DAYS,  # noqa: F401 — re-export: docstrings/operators reference it here
+    RESURRECTION_TEXT_MATCH_RATIO as _RESURRECTION_TEXT_MATCH_RATIO,
+)
+from src.ingestion.speech_dedup import datum_to_external_id as _datum_to_external_id
+from src.ingestion.speech_dedup import lookback_floor as _lookback_floor
+from src.ingestion.speech_dedup import norm_speech_text as _norm_speech_text
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level path for MdB-Stammdaten XML
+# ---------------------------------------------------------------------------
+
+# Resolved relative to the ai-backend/ directory (connector.py is 4 levels deep:
+# src/ingestion/connectors/bundestag_speeches/connector.py → parents[4] = ai-backend/)
+_MDB_PATH: Path = Path(__file__).resolve().parents[4] / MDB_STAMMDATEN_FILE
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_dip_key() -> str:
+    """Read DIP_API_KEY from env; raise RuntimeError when unset.
+
+    No hardcoded default key — published keys expire. The caller MUST
+    supply a fresh key via DIP_API_KEY in .env (local dev) or the Cloud Run Job
+    environment.
+
+    Returns:
+        The DIP API key string.
+
+    Raises:
+        RuntimeError: When DIP_API_KEY is not set in the environment.
+    """
+    key = os.getenv("DIP_API_KEY", "").strip()
+    if not key:
+        raise RuntimeError(
+            "DIP_API_KEY not set. "
+            "Fetch the current public key from "
+            "https://dip.bundestag.de/über-dip/hilfe/api "
+            "and add it to ai-backend/.env as DIP_API_KEY=<key>."
+        )
+    return key
+
+
+# LOOKBACK_DAYS and _lookback_floor are imported from src/ingestion/speech_dedup.py
+# above. run.py's batch budget ensures already-present protocols inside the
+# window do not stall the batch.
+
+
+def _yyyymmdd_int_to_iso(since: int) -> str:
+    """Convert a YYYYMMDD integer cursor to an ISO date string.
+
+    Args:
+        since: Integer cursor e.g. 20260615.
+
+    Returns:
+        ISO date string e.g. "2026-06-15".
+    """
+    s = str(since)
+    return f"{s[0:4]}-{s[4:6]}-{s[6:8]}"
+
+
+def _is_non_mdb_speaker(speech: dict) -> bool:
+    """Return True when the speaker_xml_id is in the non-MdB 999… range.
+
+    These are parliamentary officials (Präsident/Vizepräsident etc.) who are
+    not party members; their 999… IDs are not in the MdB-Stammdaten and their
+    speeches are typically not party-attributed content.
+
+    Args:
+        speech: Speech dict from parse_speeches_from_xml.
+
+    Returns:
+        True when the ID starts with "999", False otherwise.
+    """
+    person_id = speech.get("speaker_xml_id") or ""
+    return str(person_id).startswith("999")
+
+
+# A DIP speech is treated as op-superseded only when an op speech under the SAME
+# speech_key has matching text at/above _RESURRECTION_TEXT_MATCH_RATIO (shared
+# constant, speech_dedup.py). speech_key is not unique per speech, so a
+# bare "an op owns this key" test would skip a DISTINCT DIP speech a speaker
+# gave under the same agenda item that op never aligned. Same speech across
+# op/DIP scores ~0.99; a different speech scores far lower.
+
+
+def is_op_superseded(
+    qdrant: Any,
+    collection_name: str,
+    speech_key: Optional[str],
+    dip_text: Optional[str] = None,
+) -> bool:
+    """Return True when op has already ingested THIS speech.
+
+    The DIP connector consults this BEFORE inserting a speech: if op already holds
+    the SAME speech, the DIP duplicate must NOT be (re)inserted — even during a
+    full backfill / cursor reset (``since=None``). Because it keys on the STORED op
+    chunk rather than the incremental cursor, a cursor reset cannot resurrect the
+    op-superseded DIP duplicate.
+
+    Precise match: ``speech_key`` is NOT unique per speech, so "an op
+    owns this key" is not enough — a speaker's second turn under the same agenda
+    item shares the key but is a DISTINCT speech op may never have aligned.
+    When ``dip_text`` is given we scroll the op speeches under the key and treat
+    this DIP speech as superseded ONLY if some op speech's full text matches it
+    (``ratio >= _RESURRECTION_TEXT_MATCH_RATIO``). A ``dip_text`` that folds to
+    EMPTY after normalization is unverifiable — return False (insert; fail-safe)
+    rather than trusting bare key existence. Without ``dip_text`` (None)
+    the guard falls back to the coarse "any op under the key" test.
+
+    Fail-safe: when Qdrant is unreachable / the scroll raises, return
+    False (do NOT skip → insert) so a transient outage cannot abort the run; the
+    op supersede + retrieval prefer-op dedup still collapse any transient dup.
+
+    Returns:
+        True when op already holds this speech (skip insert), else False.
+    """
+    if not speech_key:
+        return False
+    try:
+        from qdrant_client import models  # noqa: PLC0415
+
+        op_filter = models.Filter(
+            must=[
+                models.FieldCondition(
+                    key="speech_key", match=models.MatchValue(value=speech_key)
+                ),
+                models.FieldCondition(
+                    key="source", match=models.MatchValue(value="op")
+                ),
+            ]
+        )
+        if dip_text is None:
+            # Coarse legacy path: existence check only.
+            points, _ = qdrant.scroll(
+                collection_name=collection_name,
+                scroll_filter=op_filter,
+                limit=1,
+                with_payload=False,
+                with_vectors=False,
+            )
+            return bool(points)
+
+        # Precise path: collect op speeches (full text by source_item_id) under
+        # the key. chunk_index is fetched so a multi-chunk speech joins in chunk
+        # order, not scroll order — an out-of-order "B+A" concatenation
+        # would score ~0.5 against the DIP "A+B" and silently miss the match.
+        op_texts: dict[Any, list] = {}
+        offset = None
+        while True:
+            points, offset = qdrant.scroll(
+                collection_name=collection_name,
+                scroll_filter=op_filter,
+                limit=256,
+                offset=offset,
+                with_payload=["source_item_id", "text", "chunk_index"],
+                with_vectors=False,
+            )
+            for point in points:
+                payload = point.payload or {}
+                op_texts.setdefault(payload.get("source_item_id"), []).append(
+                    (payload.get("chunk_index") or 0, payload.get("text") or "")
+                )
+            if offset is None:
+                break
+    except Exception as exc:  # noqa: BLE001 — Qdrant unreachable → fail-safe insert
+        logger.warning(
+            "resurrection guard: Qdrant consult failed for speech_key %r (%s) — "
+            "inserting (fail-safe)",
+            speech_key,
+            exc,
+        )
+        return False
+
+    if not op_texts:
+        return False
+    dip_norm = _norm_speech_text(dip_text)
+    if not dip_norm:
+        # No comparable text → cannot verify it is the SAME speech; fail safe
+        # and insert: a bare "an op holds the key" existence test would
+        # skip a DISTINCT same-key DIP speech, consistent with the fail-safe
+        # posture everywhere else in this guard. The op supersede pass and the
+        # query-time prefer-op dedup collapse any transient duplicate.
+        return False
+    for texts in op_texts.values():
+        # Join in chunk_index order, never scroll order.
+        op_norm = _norm_speech_text(
+            " ".join(t for _idx, t in sorted(texts, key=lambda pair: pair[0]))
+        )
+        if op_norm and difflib.SequenceMatcher(None, dip_norm, op_norm).ratio() >= (
+            _RESURRECTION_TEXT_MATCH_RATIO
+        ):
+            return True
+    return False
+
+
+def _build_speech_row(
+    protocol: dict,
+    speech: dict,
+    mdb_lookup: dict,
+) -> dict:
+    """Build a speech row dict suitable for corpus_mapper.build_chunk_records.
+
+    Party resolution order:
+      1. normalize_party(speech['party']) — from XML <fraktion>
+      2. mdb_party_for_speech(speech, mdb_lookup) — MdB-Stammdaten fallback
+
+    person_id override:
+      If mdb_record_for_speaker_name resolves to a different non-empty id,
+      use the MdB record id.
+
+    Args:
+        protocol: Protocol metadata dict from DIP (keys: id, datum, wahlperiode, fundstelle).
+        speech:   Speech dict from parse_speeches_from_xml.
+        mdb_lookup: MdB-Stammdaten lookup built once in discover().
+
+    Returns:
+        Dict compatible with corpus_mapper.build_chunk_records input contract.
+    """
+    # --- party resolution ---
+    # Track whether party came from the XML <fraktion> tag or MdB-Stammdaten fallback.
+    # The CSU refinement (below) runs ONLY for the fraktion path — if party already
+    # came from MdB, it's already the speaker's true party and must not be re-refined.
+    party = normalize_party(speech.get("party"))
+    party_from_fraktion = party is not None
+    if not party:
+        party = mdb_party_for_speech(speech, mdb_lookup)
+
+    # --- CSU disambiguation (Union/cdu fraktion → per-speaker csu refinement) ---
+    # When the XML <fraktion> resolved to the joint Union label (slug "cdu"), the
+    # speaker may individually be a CSU member.  Consult the already-loaded MdB
+    # lookup for THIS speaker and refine cdu → csu only when:
+    #   (a) party came from the XML <fraktion> (not from MdB fallback)
+    #   (b) the fraktion slug is exactly "cdu" (Union family)
+    #   (c) the per-speaker MdB entry resolves to slug "csu"
+    # Any other party (SPD, AfD, etc.) is never touched by this block.
+    if (
+        party_from_fraktion
+        and party is not None
+        and corpus_mapper.party_to_slug(party) == "cdu"
+    ):
+        mdb_party = mdb_party_for_speech(speech, mdb_lookup)
+        if mdb_party is not None and corpus_mapper.party_to_slug(mdb_party) == "csu":
+            party = mdb_party
+
+    # --- person_id override ---
+    person_id = speech.get("speaker_xml_id")
+    mdb_record = mdb_record_for_speaker_name(speech, mdb_lookup)
+    if mdb_record and mdb_record.get("id") and mdb_record["id"] != person_id:
+        person_id = mdb_record["id"]
+
+    # --- protocol metadata ---
+    # protocol_id is the human "Wahlperiode/Sitzung" dokumentnummer (e.g. "20/101").
+    # The shared speech_key derives the session number from it (session =
+    # protocol_id.split("/")[1]) for parity with op's session.number — so it MUST be
+    # the "wp/session" form, not the internal DIP document id. Fall back to the
+    # internal id only when the dokumentnummer is absent. protocol_api_id keeps the
+    # internal DIP document id for API lookups.
+    protocol_api_id = str(protocol.get("id") or "")
+    dokumentnummer = str(protocol.get("dokumentnummer") or "").strip()
+    protocol_id = dokumentnummer or protocol_api_id
+    protocol_datum = protocol.get("datum") or ""
+
+    # xml_url from fundstelle (used as citation_url fallback — pdf_url may be absent)
+    fundstelle = protocol.get("fundstelle") or {}
+    pdf_url = fundstelle.get("pdf_url") or None
+
+    return {
+        "id": speech.get("xml_rede_id") or "",
+        "text": speech.get("text") or "",
+        "date": protocol_datum,
+        "party": party,
+        "speaker_name": speech.get("speaker_name") or "",
+        "protocol_id": protocol_id,
+        "protocol_api_id": protocol_api_id,
+        "pdf_url": pdf_url,
+        "person_id": person_id,
+        "xml_rede_id": speech.get("xml_rede_id") or None,
+        "wahlperiode": protocol.get("wahlperiode"),
+        # Enclosing <tagesordnungspunkt top-id> for the shared agenda-bearing speech_key.
+        "agenda_top_id": speech.get("agenda_top_id"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# BundestagSpeechesConnector
+# ---------------------------------------------------------------------------
+
+
+class BundestagSpeechesConnector(BaseConnector):
+    """Connector for Bundestag plenary speeches → parliamentary_speech ChunkRecords.
+
+    Live incremental connector:
+        discover(since) → fetch → normalize → [runner embeds + upserts]
+
+    The cursor (since) is the max external_id (YYYYMMDD integer of the protocol
+    date) already committed to Qdrant for "parliamentary_speech", derived by the
+    runner via get_cursor().  No Firestore, no GCS, no work queue.
+
+    The connector fetches plenary protocols from the DIP Bundestag API (/plenarprotokoll),
+    downloads and parses the XML for each protocol, and returns ChunkRecords with
+    party-attributed speech text.
+
+    Args:
+        wahlperiode: Bundestag Wahlperiode (legislature period) to scope discovery.
+                     Defaults to 21 (21st Bundestag 2025-) or DIP_WAHLPERIODE env.
+    """
+
+    # Class attribute: used by runner.get_cursor() to scope the Qdrant scroll.
+    source_type: str = SourceType.PARLIAMENTARY_SPEECH.value
+
+    # Connector discriminator: stamps chunks source="dip" and keeps the op
+    # supersede hook op-gated (fires only for source="op").
+    source: str = "dip"
+
+    # The DIP cursor must NOT be scoped to source="dip". op progressively
+    # supersede-DELETES dip points, so max(external_id, source="dip") walks
+    # BACKWARD as coverage grows (worst case None → the run re-fetches and
+    # re-parses the whole Wahlperiode every time). op external_ids are the same
+    # YYYYMMDD scale and op only ever supersedes a dip twin that WAS ingested,
+    # so the cross-source max over parliamentary_speech is a valid,
+    # non-regressing floor; the lookback window still re-covers recent gaps.
+    # (op keeps its own source-scoped cursor via the BaseConnector default.)
+    cursor_source = None
+
+    def __init__(
+        self,
+        wahlperiode: Optional[int] = None,
+        qdrant: Optional[Any] = None,
+        collection_name: str = COLLECTION_NAME,
+    ) -> None:
+        # Read DIP_WAHLPERIODE at CALL time, not import time — a default-arg
+        # getenv freezes the value when the module is first imported, ignoring
+        # any later environment change in the same process.
+        if wahlperiode is None:
+            wahlperiode = int(os.getenv("DIP_WAHLPERIODE", "21"))
+        self._wahlperiode = wahlperiode
+        self._client = DipClient(api_key=_require_dip_key())
+        # Per-run cache: populated in discover(), read in fetch()
+        self._protocols: dict[str, dict] = {}
+        # MdB-Stammdaten lookup: loaded once per run in discover(), reused in fetch()/normalize()
+        self._mdb_lookup: Optional[dict] = None
+        # Resurrection guard: a QdrantClient consulted before inserting each
+        # DIP speech. Injectable for tests; lazily built from QDRANT_URL on first use
+        # in production. Kept optional so the guard degrades to fail-safe insert when
+        # no client can be constructed.
+        self._qdrant: Optional[Any] = qdrant
+        self._collection_name = collection_name
+        # Lazy-build a real QdrantClient from QDRANT_URL only when no client was
+        # injected (production path). Instances created without __init__ (unit tests
+        # via object.__new__) lack this flag → getattr default False → guard disabled
+        # (fail-safe insert), so discover/normalize unit tests issue no Qdrant calls.
+        self._qdrant_lazy_enabled: bool = qdrant is None
+        # Self-heal: siids normalize() skipped as op-superseded on the LAST
+        # item. run_connector deletes any stored points under them (a stranded
+        # DIP twin from an interleaved concurrent DIP+op run).
+        self.last_superseded_siids: tuple[str, ...] = ()
+
+    def _get_qdrant(self) -> Optional[Any]:
+        """Return the QdrantClient for the resurrection guard, lazily constructed.
+
+        Uses an injected client when present (tests). In production, builds a
+        QdrantClient from QDRANT_URL once and caches it. Any construction failure
+        returns None so the guard degrades to fail-safe insert rather than
+        aborting the run.
+        """
+        qdrant = getattr(self, "_qdrant", None)
+        if qdrant is not None:
+            return qdrant
+        # Only lazy-construct on the production path (__init__ ran with no injected
+        # client). Test instances built via object.__new__ lack the flag → no build.
+        if not getattr(self, "_qdrant_lazy_enabled", False):
+            return None
+        try:
+            from qdrant_client import QdrantClient  # noqa: PLC0415
+
+            qdrant_url = os.getenv("QDRANT_URL", "http://localhost:6333")
+            self._qdrant = QdrantClient(
+                url=qdrant_url, api_key=os.getenv("QDRANT_API_KEY")
+            )
+        except Exception as exc:  # noqa: BLE001 — no client → fail-safe insert
+            logger.warning(
+                "resurrection guard: could not construct QdrantClient (%s) — "
+                "guard disabled (fail-safe insert)",
+                exc,
+            )
+            self._qdrant = None
+        return self._qdrant
+
+    # ------------------------------------------------------------------
+    # 1. discover — YYYYMMDD cursor → DIP date floor; re-sort ASC
+    # ------------------------------------------------------------------
+
+    def discover(self, since: Optional[int]) -> list[str]:
+        """Return protocol ids to process for the configured Wahlperiode.
+
+        Queries DIP /plenarprotokoll with f.wahlperiode and (when since is set)
+        f.datum.start floored at ``since − LOOKBACK_DAYS`` — an inclusive floor
+        at the raw since date would permanently exclude any earlier-dated
+        protocol that transiently failed on a prior run (the max external_id
+        advanced past it). The lookback keeps API cost bounded (no full WP-history
+        walk) while re-discovering recent failures; run.py's batch-budget fix
+        ensures already-present protocols inside the window do not stall.
+        Walks all cursor-pages.
+        Filters to Bundestagsprotokolle (herausgeber == "BT").
+        Re-sorts ascending by (datum, id) — DIP returns DESC.
+        Populates self._protocols (per-run cache).
+        Loads self._mdb_lookup once per run.
+
+        Args:
+            since: Max external_id (YYYYMMDD integer) already committed to
+                   Qdrant for "parliamentary_speech", or None on first run.
+                   Derived by the runner via get_cursor().
+
+        Returns:
+            List of protocol id strings sorted ascending by (datum, id).
+        """
+        floor_int: Optional[int] = _lookback_floor(since) if since is not None else None
+        params: dict = {"f.wahlperiode": self._wahlperiode}
+        if floor_int is not None:
+            params["f.datum.start"] = _yyyymmdd_int_to_iso(floor_int)
+
+        docs: list[dict] = []
+        for page in self._client.pages("/plenarprotokoll", params):
+            for doc in page.get("documents", []):
+                # herausgeber == "BT" filter: skip non-Bundestag protocols (e.g. Bundesrat).
+                fundstelle = doc.get("fundstelle") or {}
+                herausgeber = (
+                    fundstelle.get("herausgeber") or doc.get("herausgeber") or ""
+                )
+                if herausgeber and herausgeber != "BT":
+                    continue
+                docs.append(doc)
+
+        # Client-side floor filter: DIP server-side f.datum.start is an optimisation;
+        # post-filter here for correctness since the fake client (and early DIP responses)
+        # may return protocols before the floor. Uses the SAME lookback-adjusted floor
+        # as the server-side param so a failed-below-max protocol is re-discovered.
+        if floor_int is not None:
+            floor_iso = _yyyymmdd_int_to_iso(floor_int)
+            docs = [d for d in docs if (d.get("datum") or "") >= floor_iso]
+
+        # DIP sorts DESC; BaseConnector.discover contract (connector.py L49) wants ASC.
+        # Re-sort ascending by (datum, id) so run_connector processes oldest-first.
+        docs.sort(key=lambda d: (d.get("datum") or "", str(d.get("id") or "")))
+
+        # Populate per-run cache
+        self._protocols = {str(d["id"]): d for d in docs}
+
+        # Load MdB-Stammdaten once per run (cached — never load per-fetch).
+        # ensure_* fetches on a cache miss and fails loud if the master data is
+        # unavailable, rather than degrading every minister/president to "unbekannt".
+        if self._mdb_lookup is None:
+            self._mdb_lookup = ensure_mdb_lookup(_MDB_PATH)
+
+        return [str(d["id"]) for d in docs]
+
+    # ------------------------------------------------------------------
+    # 2. fetch — read from cache; return skip_reason dict on failure (never raises)
+    # ------------------------------------------------------------------
+
+    def fetch(self, external_id: str) -> dict:
+        """Fetch and parse the XML for one protocol; return skip_reason on failure.
+
+        Reads from the per-run cache populated by discover().  Never raises
+        (all failure modes return a skip_reason dict — normalize() converts
+        these to ValueError so run_connector skip-and-warns).
+
+        Args:
+            external_id: String protocol id (e.g. "12345").
+
+        Returns:
+            Dict with keys:
+              - "protocol": the protocol metadata dict (or None)
+              - "speeches": list of speech dicts from parse_speeches_from_xml
+              - "mdb_lookup": the MdB-Stammdaten lookup dict
+            OR a skip_reason dict:
+              - "protocol": ..., "speeches": [], "skip_reason": "<reason>"
+        """
+        protocol = self._protocols.get(external_id)
+        if protocol is None:
+            return {
+                "protocol": None,
+                "speeches": [],
+                "skip_reason": f"protocol {external_id} not in discover cache",
+            }
+
+        fundstelle = protocol.get("fundstelle") or {}
+        xml_url = fundstelle.get("xml_url") or ""
+        if not xml_url:
+            return {
+                "protocol": protocol,
+                "speeches": [],
+                "skip_reason": f"protocol {external_id} has no xml_url",
+            }
+
+        try:
+            xml_text = fetch_text(xml_url)
+            speeches = parse_speeches_from_xml(xml_text)
+        except Exception as exc:  # noqa: BLE001 — ParseError/RequestException → skip-and-warn
+            return {
+                "protocol": protocol,
+                "speeches": [],
+                "skip_reason": f"xml parse failed for protocol {external_id}: {exc}",
+            }
+
+        return {
+            "protocol": protocol,
+            "speeches": speeches,
+            "mdb_lookup": self._mdb_lookup,
+        }
+
+    # ------------------------------------------------------------------
+    # 3. normalize — build ChunkRecords + stamp external_id=YYYYMMDD
+    # ------------------------------------------------------------------
+
+    def normalize(self, raw: dict) -> list[ChunkRecord]:
+        """Build ChunkRecords from fetch() payload; stamp YYYYMMDD external_id.
+
+        Skip-and-warn contract:
+            - If raw contains a "skip_reason" key, raises ValueError immediately.
+            - If the protocol produces zero usable speeches (all dropped),
+              raises ValueError so run_connector skip-and-continues — UNLESS ≥1
+              speech was skipped as op-superseded and none remain: that is
+              a fully-op-covered protocol, returned as [] (clean no-op).
+
+        Party resolution (collector.build_speech_row logic):
+            XML <fraktion> → normalize_party → MdB-Stammdaten fallback.
+            is_non_mdb_speaker (999…) speakers are dropped.
+
+        External_id stamp:
+            Every chunk gets external_id=YYYYMMDD(protocol.datum) via model_copy.
+            wahlperiode is also stamped from the protocol metadata.
+
+        Args:
+            raw: Dict returned by fetch(), with keys "protocol", "speeches",
+                 "mdb_lookup" (and optionally "skip_reason").
+
+        Returns:
+            list[ChunkRecord] — one or more chunks, each with external_id=YYYYMMDD.
+
+        Raises:
+            ValueError: If raw has a skip_reason, or if zero usable speeches result.
+        """
+        # skip_reason → ValueError (run_connector catches and warns)
+        if raw.get("skip_reason"):
+            raise ValueError(raw["skip_reason"])
+
+        protocol: dict = raw["protocol"]
+        speeches: list[dict] = raw.get("speeches", [])
+        mdb_lookup: dict = raw.get("mdb_lookup") or {"by_id": {}, "by_name": {}}
+
+        # Build speech rows, dropping non-MdB speakers (999…) and empty-text speeches
+        rows: list[dict] = []
+        for speech in speeches:
+            if not speech.get("text"):
+                continue
+            if _is_non_mdb_speaker(speech):
+                continue
+            rows.append(_build_speech_row(protocol, speech, mdb_lookup))
+
+        # Durable resurrection guard: before building/inserting a DIP chunk,
+        # consult the indexed speech_key and SKIP any speech op has already
+        # superseded (an op point with the same speech_key). This runs regardless of
+        # the incremental cursor (full backfill / since=None included) so a cursor
+        # reset cannot resurrect op-superseded DIP duplicates. Qdrant-unreachable
+        # fails safe (is_op_superseded returns False → insert).
+        qdrant = self._get_qdrant()
+
+        # Build ChunkRecord list via the relocated mapper. Skipped-as-superseded
+        # siids are collected and exposed via last_superseded_siids so the runner
+        # can delete a stranded twin from an interleaved concurrent run.
+        records: list[ChunkRecord] = []
+        superseded_siids: list[str] = []
+        for row in rows:
+            if qdrant is not None:
+                speech_key = corpus_mapper.compute_speech_key(row)
+                if speech_key is not None and is_op_superseded(
+                    qdrant, self._collection_name, speech_key, dip_text=row.get("text")
+                ):
+                    logger.info(
+                        "resurrection guard: skipping op-superseded DIP speech "
+                        "(speech_key=%s)",
+                        speech_key,
+                    )
+                    superseded_siids.append(
+                        str(
+                            compute_source_item_id(
+                                "parliamentary_speech",
+                                str(row.get("id") or ""),
+                                source="dip",
+                            )
+                        )
+                    )
+                    continue
+            records.extend(corpus_mapper.build_chunk_records(row))
+        # Per-item report (reset every normalize call; () when nothing skipped).
+        self.last_superseded_siids = tuple(superseded_siids)
+
+        # Skip-and-warn: zero usable speeches → ValueError. EXCEPTION: when
+        # ≥1 speech was skipped as op-superseded and none remain, the protocol is
+        # FULLY covered by op — a clean no-op, not an error. Raising here would
+        # re-surface the protocol into failed_ids on every run for the whole
+        # lookback window (60 days of noise for correct behavior).
+        if not records:
+            if superseded_siids:
+                logger.info(
+                    "protocol %s: all usable speeches already op-superseded — clean no-op",
+                    (protocol or {}).get("id", "unknown"),
+                )
+                return []
+            protocol_id = (protocol or {}).get("id", "unknown")
+            raise ValueError(
+                f"protocol {protocol_id} produced zero usable speeches "
+                "(all speeches were empty, non-MdB, or had no text)"
+            )
+
+        # Stamp external_id = YYYYMMDD(protocol.datum) and wahlperiode on every chunk.
+        # ChunkRecord is frozen; use model_copy(update=...) to create new instances.
+        datum = (protocol or {}).get("datum") or ""
+        external_id = _datum_to_external_id(datum) if datum else None
+
+        raw_wp = (protocol or {}).get("wahlperiode")
+        wahlperiode = int(raw_wp) if raw_wp is not None else None
+
+        return [
+            chunk.model_copy(
+                update={"external_id": external_id, "wahlperiode": wahlperiode}
+            )
+            for chunk in records
+        ]

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/connector.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/connector.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -10,9 +10,14 @@ synchronous ABC (discover/fetch/normalize) and produces list[ChunkRecord]
 directly from normalize() — no Firestore, no GCS, no work_queue.
 
 The runner (run.py) owns embed + upsert; this connector is pure data-transform.
-The cursor (since) is a YYYYMMDD integer derived by the runner from Qdrant
-max(external_id) for "parliamentary_speech" — passed to discover() as the date
-floor.  No watermark methods needed.
+The runner still passes its Qdrant-derived cursor to discover() (ABC contract),
+but discover() deliberately IGNORES it: discovery is a per-Wahlperiode
+SET-DIFFERENCE against the store (protocols in DIP minus protocols with stored
+DIP chunks) plus a recent-update sweep over DIP's ``aktualisiert`` timestamp.
+A date-floor cursor was order-dependent (openparliament or a newer Wahlperiode
+advancing the shared max starved older DIP backfills) and permanently lost
+protocols that failed for longer than the lookback window; set-difference
+re-surfaces every gap and needs no watermark.
 
 Security notes:
     DIP_API_KEY fail-loud: _require_dip_key() raises RuntimeError
@@ -20,7 +25,7 @@ Security notes:
 
     DESC → ASC re-sort: DIP returns protocols newest-first.
     discover() re-sorts ascending by (datum, id) so run_connector processes
-    oldest-first and the YYYYMMDD cursor advances monotonically.
+    oldest-first.
 
     fetch() never raises: missing xml_url / parse failures return a
     skip_reason dict; normalize() raises ValueError → runner skip-and-warn.
@@ -45,6 +50,8 @@ from __future__ import annotations
 import difflib
 import logging
 import os
+from datetime import date as date_type
+from datetime import timedelta
 from pathlib import Path
 from typing import Any, Optional
 
@@ -67,11 +74,9 @@ from src.ingestion.setup_collection import COLLECTION_NAME
 # and the op supersede module; drift between copies would silently break
 # cross-source dedup.
 from src.ingestion.speech_dedup import (
-    LOOKBACK_DAYS,  # noqa: F401 — re-export: docstrings/operators reference it here
     RESURRECTION_TEXT_MATCH_RATIO as _RESURRECTION_TEXT_MATCH_RATIO,
 )
 from src.ingestion.speech_dedup import datum_to_external_id as _datum_to_external_id
-from src.ingestion.speech_dedup import lookback_floor as _lookback_floor
 from src.ingestion.speech_dedup import norm_speech_text as _norm_speech_text
 
 logger = logging.getLogger(__name__)
@@ -114,39 +119,12 @@ def _require_dip_key() -> str:
     return key
 
 
-# LOOKBACK_DAYS and _lookback_floor are imported from src/ingestion/speech_dedup.py
-# above. run.py's batch budget ensures already-present protocols inside the
-# window do not stall the batch.
-
-
-def _yyyymmdd_int_to_iso(since: int) -> str:
-    """Convert a YYYYMMDD integer cursor to an ISO date string.
-
-    Args:
-        since: Integer cursor e.g. 20260615.
-
-    Returns:
-        ISO date string e.g. "2026-06-15".
-    """
-    s = str(since)
-    return f"{s[0:4]}-{s[4:6]}-{s[6:8]}"
-
-
-def _is_non_mdb_speaker(speech: dict) -> bool:
-    """Return True when the speaker_xml_id is in the non-MdB 999… range.
-
-    These are parliamentary officials (Präsident/Vizepräsident etc.) who are
-    not party members; their 999… IDs are not in the MdB-Stammdaten and their
-    speeches are typically not party-attributed content.
-
-    Args:
-        speech: Speech dict from parse_speeches_from_xml.
-
-    Returns:
-        True when the ID starts with "999", False otherwise.
-    """
-    person_id = speech.get("speaker_xml_id") or ""
-    return str(person_id).startswith("999")
+# Recent-update sweep window: protocols whose DIP ``aktualisiert`` timestamp is
+# within this many days are re-surfaced even when already ingested, so upstream
+# transcript corrections propagate (content_hash makes unchanged ones cheap
+# skips). DIP publishes corrections shortly after a sitting; 30 days is well
+# beyond the observed correction latency.
+_UPDATE_SWEEP_DAYS = 30
 
 
 # A DIP speech is treated as op-superseded only when an op speech under the SAME
@@ -352,6 +330,10 @@ def _build_speech_row(
         "wahlperiode": protocol.get("wahlperiode"),
         # Enclosing <tagesordnungspunkt top-id> for the shared agenda-bearing speech_key.
         "agenda_top_id": speech.get("agenda_top_id"),
+        # Citation coordinates from the protocol TOC (parser xref map).
+        "source_page": speech.get("source_page"),
+        "page_quadrant": speech.get("page_quadrant"),
+        "pdf_page": speech.get("pdf_page"),
     }
 
 
@@ -366,9 +348,13 @@ class BundestagSpeechesConnector(BaseConnector):
     Live incremental connector:
         discover(since) → fetch → normalize → [runner embeds + upserts]
 
-    The cursor (since) is the max external_id (YYYYMMDD integer of the protocol
-    date) already committed to Qdrant for "parliamentary_speech", derived by the
-    runner via get_cursor().  No Firestore, no GCS, no work queue.
+    Discovery is a per-Wahlperiode SET-DIFFERENCE against the store (protocols
+    in DIP minus protocols whose DIP chunks are already stored), plus a
+    recent-update sweep over DIP's ``aktualisiert`` timestamp so transcript
+    corrections propagate. The runner's Qdrant-derived cursor is accepted (ABC
+    contract) but ignored — a date cursor was order-dependent (another source
+    or Wahlperiode advancing the shared max starved DIP backfills) and lost
+    protocols that failed longer than a lookback window.
 
     The connector fetches plenary protocols from the DIP Bundestag API (/plenarprotokoll),
     downloads and parses the XML for each protocol, and returns ChunkRecords with
@@ -386,14 +372,8 @@ class BundestagSpeechesConnector(BaseConnector):
     # supersede hook op-gated (fires only for source="op").
     source: str = "dip"
 
-    # The DIP cursor must NOT be scoped to source="dip". op progressively
-    # supersede-DELETES dip points, so max(external_id, source="dip") walks
-    # BACKWARD as coverage grows (worst case None → the run re-fetches and
-    # re-parses the whole Wahlperiode every time). op external_ids are the same
-    # YYYYMMDD scale and op only ever supersedes a dip twin that WAS ingested,
-    # so the cross-source max over parliamentary_speech is a valid,
-    # non-regressing floor; the lookback window still re-covers recent gaps.
-    # (op keeps its own source-scoped cursor via the BaseConnector default.)
+    # The runner still derives a cursor (ABC contract) even though discover()
+    # ignores it; unscoped so the derivation stays cheap and meaningful in logs.
     cursor_source = None
 
     def __init__(
@@ -461,37 +441,104 @@ class BundestagSpeechesConnector(BaseConnector):
         return self._qdrant
 
     # ------------------------------------------------------------------
-    # 1. discover — YYYYMMDD cursor → DIP date floor; re-sort ASC
+    # 1. discover — per-Wahlperiode set-difference + recent-update sweep
     # ------------------------------------------------------------------
+
+    def _get_ingested_protocol_ids(self) -> set[str]:
+        """Return protocol ids (DIP document ids) with stored DIP chunks for
+        this Wahlperiode.
+
+        Reads ``source_parent_key`` ("parliamentary_speech:dip:<protocol_id>",
+        stamped by the runner) from every dip point of the configured
+        Wahlperiode. Points written before parent keys existed are simply not
+        counted — their protocols are re-discovered and become cheap
+        content-hash present-skips.
+
+        Returns the empty set when no store client is available (standalone use
+        outside the runner): everything is then discovered, which is safe —
+        the runner's already-present guard keeps re-processing cheap.
+        """
+        from qdrant_client import models  # noqa: PLC0415
+
+        qdrant = (
+            self._store_client
+            if self._store_client is not None
+            else (self._get_qdrant())
+        )
+        if qdrant is None:
+            return set()
+        collection_name = self._store_collection or self._collection_name
+        ingested: set[str] = set()
+        scroll_filter = models.Filter(
+            must=[
+                models.FieldCondition(
+                    key="source_type",
+                    match=models.MatchValue(value=self.source_type),
+                ),
+                models.FieldCondition(
+                    key="source", match=models.MatchValue(value="dip")
+                ),
+                models.FieldCondition(
+                    key="wahlperiode",
+                    match=models.MatchValue(value=self._wahlperiode),
+                ),
+            ]
+        )
+        next_offset = None
+        try:
+            while True:
+                points, next_offset = qdrant.scroll(
+                    collection_name=collection_name,
+                    scroll_filter=scroll_filter,
+                    limit=1000,
+                    offset=next_offset,
+                    with_payload=["source_parent_key"],
+                    with_vectors=False,
+                )
+                for p in points:
+                    parent_key = (p.payload or {}).get("source_parent_key") or ""
+                    # "parliamentary_speech:dip:<protocol_id>" → protocol_id
+                    if parent_key:
+                        ingested.add(str(parent_key).rsplit(":", 1)[-1])
+                if next_offset is None:
+                    break
+        except Exception as exc:  # noqa: BLE001 — store unreachable → discover all
+            logger.warning(
+                "set-difference discovery: store scroll failed (%s) — "
+                "treating store as empty (already-present items skip cheaply)",
+                exc,
+            )
+            return set()
+        return ingested
 
     def discover(self, since: Optional[int]) -> list[str]:
         """Return protocol ids to process for the configured Wahlperiode.
 
-        Queries DIP /plenarprotokoll with f.wahlperiode and (when since is set)
-        f.datum.start floored at ``since − LOOKBACK_DAYS`` — an inclusive floor
-        at the raw since date would permanently exclude any earlier-dated
-        protocol that transiently failed on a prior run (the max external_id
-        advanced past it). The lookback keeps API cost bounded (no full WP-history
-        walk) while re-discovering recent failures; run.py's batch-budget fix
-        ensures already-present protocols inside the window do not stall.
-        Walks all cursor-pages.
-        Filters to Bundestagsprotokolle (herausgeber == "BT").
+        SET-DIFFERENCE + UPDATE SWEEP, no date cursor:
+          1. Enumerate ALL /plenarprotokoll metadata for f.wahlperiode
+             (cheap catalogue pages, no XML), filtered to herausgeber "BT".
+          2. Set-difference: keep protocols with no stored DIP chunks — this
+             re-surfaces every transient failure forever (a max(external_id)
+             watermark permanently lost anything that failed longer than a
+             lookback window) and is immune to another source or Wahlperiode
+             advancing a shared cursor.
+          3. Update sweep: ALSO keep already-ingested protocols whose DIP
+             ``aktualisiert`` timestamp is within _UPDATE_SWEEP_DAYS, so
+             upstream transcript corrections are re-fetched; the runner's
+             content_hash guard rewrites only real changes.
+
         Re-sorts ascending by (datum, id) — DIP returns DESC.
         Populates self._protocols (per-run cache).
         Loads self._mdb_lookup once per run.
 
         Args:
-            since: Max external_id (YYYYMMDD integer) already committed to
-                   Qdrant for "parliamentary_speech", or None on first run.
-                   Derived by the runner via get_cursor().
+            since: Runner-derived cursor, accepted for the ABC contract but
+                   IGNORED — set-difference supersedes it.
 
         Returns:
             List of protocol id strings sorted ascending by (datum, id).
         """
-        floor_int: Optional[int] = _lookback_floor(since) if since is not None else None
         params: dict = {"f.wahlperiode": self._wahlperiode}
-        if floor_int is not None:
-            params["f.datum.start"] = _yyyymmdd_int_to_iso(floor_int)
 
         docs: list[dict] = []
         for page in self._client.pages("/plenarprotokoll", params):
@@ -505,20 +552,29 @@ class BundestagSpeechesConnector(BaseConnector):
                     continue
                 docs.append(doc)
 
-        # Client-side floor filter: DIP server-side f.datum.start is an optimisation;
-        # post-filter here for correctness since the fake client (and early DIP responses)
-        # may return protocols before the floor. Uses the SAME lookback-adjusted floor
-        # as the server-side param so a failed-below-max protocol is re-discovered.
-        if floor_int is not None:
-            floor_iso = _yyyymmdd_int_to_iso(floor_int)
-            docs = [d for d in docs if (d.get("datum") or "") >= floor_iso]
+        ingested = self._get_ingested_protocol_ids()
+        sweep_floor = (
+            date_type.today() - timedelta(days=_UPDATE_SWEEP_DAYS)
+        ).isoformat()
+        selected: list[dict] = []
+        for doc in docs:
+            doc_id = str(doc.get("id") or "")
+            if doc_id not in ingested:
+                selected.append(doc)  # new or previously failed → ingest
+                continue
+            # Already ingested: re-surface only when DIP marked it updated
+            # recently (aktualisiert is an ISO timestamp; prefix compare on the
+            # date part is safe for ISO-8601).
+            aktualisiert = str(doc.get("aktualisiert") or "")
+            if aktualisiert and aktualisiert[:10] >= sweep_floor:
+                selected.append(doc)
 
-        # DIP sorts DESC; BaseConnector.discover contract (connector.py L49) wants ASC.
+        # DIP sorts DESC; BaseConnector.discover contract wants ASC.
         # Re-sort ascending by (datum, id) so run_connector processes oldest-first.
-        docs.sort(key=lambda d: (d.get("datum") or "", str(d.get("id") or "")))
+        selected.sort(key=lambda d: (d.get("datum") or "", str(d.get("id") or "")))
 
         # Populate per-run cache
-        self._protocols = {str(d["id"]): d for d in docs}
+        self._protocols = {str(d["id"]): d for d in selected}
 
         # Load MdB-Stammdaten once per run (cached — never load per-fetch).
         # ensure_* fetches on a cache miss and fails loud if the master data is
@@ -526,7 +582,7 @@ class BundestagSpeechesConnector(BaseConnector):
         if self._mdb_lookup is None:
             self._mdb_lookup = ensure_mdb_lookup(_MDB_PATH)
 
-        return [str(d["id"]) for d in docs]
+        return [str(d["id"]) for d in selected]
 
     # ------------------------------------------------------------------
     # 2. fetch — read from cache; return skip_reason dict on failure (never raises)
@@ -598,8 +654,15 @@ class BundestagSpeechesConnector(BaseConnector):
               a fully-op-covered protocol, returned as [] (clean no-op).
 
         Party resolution (collector.build_speech_row logic):
-            XML <fraktion> → normalize_party → MdB-Stammdaten fallback.
-            is_non_mdb_speaker (999…) speakers are dropped.
+            XML <fraktion> → normalize_party → MdB-Stammdaten fallback (by
+            speaker id, then by name). Non-MdB speakers (999… ids: federal /
+            state ministers, state secretaries, Ministerpräsidenten,
+            Bundesrat members) are KEPT — their speeches are real
+            parliamentary content. Ministers who are also MdBs resolve to
+            their party via the name lookup; genuinely party-less or
+            unresolvable speakers quarantine as "unbekannt" (surfaced in the
+            runner's chunks_unbekannt drift signal) rather than being
+            silently dropped from the corpus.
 
         External_id stamp:
             Every chunk gets external_id=YYYYMMDD(protocol.datum) via model_copy.
@@ -623,12 +686,13 @@ class BundestagSpeechesConnector(BaseConnector):
         speeches: list[dict] = raw.get("speeches", [])
         mdb_lookup: dict = raw.get("mdb_lookup") or {"by_id": {}, "by_name": {}}
 
-        # Build speech rows, dropping non-MdB speakers (999…) and empty-text speeches
+        # Build speech rows, skipping only empty-text speeches. Non-MdB
+        # speakers (999… ids) are kept — see the docstring's party-resolution
+        # policy; dropping them removed entire minister/Ministerpräsident
+        # speeches from the corpus.
         rows: list[dict] = []
         for speech in speeches:
             if not speech.get("text"):
-                continue
-            if _is_non_mdb_speaker(speech):
                 continue
             rows.append(_build_speech_row(protocol, speech, mdb_lookup))
 

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/constants.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/constants.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""Connector-level constants for the bundestag_speeches package.
+
+DIP_API_KEY is read from .env.
+
+Security: BASE_URL is a pinned module constant — never derived
+from a caller arg or runtime input (mirrors abgeordnetenwatch/_AW_BASE).
+"""
+
+from __future__ import annotations
+
+# DIP API base URL — pinned; never derive the host from a method arg.
+BASE_URL = "https://search.dip.bundestag.de/api/v1"
+
+# Hard page cap for DipClient.pages() (mirrors the AW client's _MAX_PAGES).
+# Rationale: a full 20th Bundestag legislature (~4 years) has ~130 plenary protocols,
+# each yielding roughly one DIP API page. 500 pages is more than enough for any
+# plenary-protocol listing while preventing an infinite loop on a stuck/malformed cursor.
+_MAX_PAGES = 500
+
+# MdB-Stammdaten XML path (relative to ai-backend/). ~15 MB, gitignored.
+# The speech connectors fetch it on demand at run time (mdb.ensure_mdb_lookup);
+# `make fetch-mdb-stammdaten` pre-fetches it for the host dev loop.
+MDB_STAMMDATEN_FILE = "data/MDB_STAMMDATEN.XML"
+
+# Bundestag OpenData ZIP holding MDB_STAMMDATEN.XML. Pinned module constant —
+# never derived from a caller arg. If this 404s the blob was rotated: get the
+# current link from https://www.bundestag.de/services/opendata ("Stammdaten
+# aller Abgeordneten"). Single source of truth for both the runtime fetch and
+# `make fetch-mdb-stammdaten`.
+MDB_STAMMDATEN_URL = "https://www.bundestag.de/resource/blob/472878/MdB-Stammdaten.zip"
+
+# Party alias normalisation map — maps raw XML / DIP strings to canonical party labels.
+# Keys are uppercased + whitespace-collapsed before lookup (see utils.normalize_party).
+PARTY_ALIASES: dict[str, str] = {
+    "SPD": "SPD",
+    "SOZIALDEMOKRATISCHE PARTEI DEUTSCHLANDS": "SPD",
+    "FRAKTION DER SOZIALDEMOKRATISCHEN PARTEI DEUTSCHLANDS": "SPD",
+    "FRAKTION DER SPD (GAST)": "SPD",
+    "CDU": "CDU",
+    "CSU": "CSU",
+    "CDU/CSU": "CDU/CSU",
+    "CSUS": "CDU/CSU",
+    "FRAKTION DER CHRISTLICH DEMOKRATISCHEN UNION/CHRISTLICH - SOZIALEN UNION": "CDU/CSU",
+    "FRAKTION DER CHRISTLICH DEMOKRATISCHEN UNION/CHRISTLICH-SOZIALEN UNION": "CDU/CSU",
+    "FRAKTION DER CDU/CSU (GAST)": "CDU/CSU",
+    "BÜNDNIS 90/DIE GRÜNEN": "BÜNDNIS 90/DIE GRÜNEN",
+    "GRÜNE": "BÜNDNIS 90/DIE GRÜNEN",
+    "DIE GRÜNEN/BÜNDNIS 90": "BÜNDNIS 90/DIE GRÜNEN",
+    "FRAKTION BÜNDNIS 90/DIE GRÜNEN": "BÜNDNIS 90/DIE GRÜNEN",
+    "FRAKTION DIE GRÜNEN": "BÜNDNIS 90/DIE GRÜNEN",
+    "FRAKTION DIE GRÜNEN/BÜNDNIS 90": "BÜNDNIS 90/DIE GRÜNEN",
+    "GRUPPE BÜNDNIS 90/DIE GRÜNEN": "BÜNDNIS 90/DIE GRÜNEN",
+    "FDP": "FDP",
+    "FRAKTION DER FREIEN DEMOKRATISCHEN PARTEI": "FDP",
+    "FRAKTION DER FDP (GAST)": "FDP",
+    "AFD": "AfD",
+    "FRAKTION ALTERNATIVE FÜR DEUTSCHLAND": "AfD",
+    "DIE LINKE": "DIE LINKE",
+    "DIE LINKE.": "DIE LINKE",
+    "FRAKTION DIE LINKE": "DIE LINKE",
+    "FRAKTION DIE LINKE.": "DIE LINKE",
+    "GRUPPE DIE LINKE": "DIE LINKE",
+    "BSW": "BSW",
+    "GRUPPE BSW - BÜNDNIS SAHRA WAGENKNECHT - VERNUNFT UND GERECHTIGKEIT": "BSW",
+    "FRAKTIONSLOS": "fraktionslos",
+    "FRAKTIONSLOSER": "fraktionslos",
+    "FRAKTIONSLOSE": "fraktionslos",
+    "PLOS": "fraktionslos",
+}
+
+# Set of canonical party labels (values of PARTY_ALIASES) — used by is_known_party().
+VALID_PARTIES: set[str] = set(PARTY_ALIASES.values())

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/constants.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/constants.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/mappers/__init__.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/mappers/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""Bundestag speeches mappers subpackage.
+
+Pure transform functions — no I/O.
+
+  corpus.py    — build_chunk_records, chunk_text, party_to_slug
+"""

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/mappers/__init__.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/mappers/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/mappers/corpus.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/mappers/corpus.py
@@ -1,0 +1,300 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Pure corpus mapper for the bundestag_speeches connector.
+
+Exports:
+    build_chunk_records(speech)  — produces list[ChunkRecord] from a speech dict
+    chunk_text(text, ...)        — shared boundary-aware character splitter
+                                   (re-exported from src.ingestion.chunking)
+    party_to_slug(party)         — maps a raw party label to a canonical slug
+
+Security notes:
+    - Pydantic ChunkRecord validation (extra="forbid"): malformed fields are
+      rejected at validation time, not silently dropped.
+    - Empty-text speeches skipped (build_chunk_records returns [] for whitespace-
+      only text).
+    - publish_date: strict date.fromisoformat() with today() fallback — no
+      arbitrary eval or strptime format strings.
+    - Unknown party labels default to "unbekannt" rather than propagating a raw
+      label into the corpus.
+
+external_id handling:
+    external_id is NOT set explicitly in build_chunk_records. The ChunkRecord
+    default (None) is preserved so the caller (connector.normalize()) can stamp
+    YYYYMMDD via model_copy(update={"external_id": ...}) without the mapper
+    carrying protocol-date knowledge.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sys
+from datetime import date as date_type
+from typing import Optional
+
+from src.ingestion.chunking import chunk_text
+from src.ingestion.ids import compute_source_item_id, make_chunk_key
+from src.ingestion.party_slugs import (
+    CANONICAL_PARTY_SLUGS,
+    PARTY_SLUG_QUARANTINE,
+    normalize_party_label,
+)
+from src.ingestion.schemas import AuthorityTier, ChunkRecord, SpeechMeta, SourceType
+from src.ingestion.speech_key import (
+    agenda_slug_from_top_id,
+    make_speech_key,
+    slugify_speaker,
+)
+
+_corpus_logger = logging.getLogger(__name__)
+
+# Connector discriminator stamped on every DIP chunk. Drives the
+# source-scoped cursor (run.py::get_cursor) and the op supersede / DIP
+# resurrection-guard filters, both keyed on speech_key + source.
+_DIP_SOURCE = "dip"
+
+
+def compute_speech_key(speech: dict) -> Optional[str]:
+    """Compute the shared cross-source ``speech_key`` for a DIP speech dict.
+
+    Uses the SAME ``src/ingestion/speech_key.py`` helper op uses so the two sources
+    derive byte-identical keys for the same real speech:
+      - ``ep``            = ``speech["wahlperiode"]``
+      - ``session``       = ``speech["protocol_id"].split("/")[1]`` (dokumentnummer "20/101" → 101)
+      - ``speaker_slug``  = ``slugify_speaker(full_name=speech["speaker_name"])``
+      - ``agenda_slug``   = ``agenda_slug_from_top_id(speech["agenda_top_id"])``
+
+    Graceful degradation: a missing / unparseable agenda yields an empty
+    agenda component (no-agenda fallback) but still a valid key. When the
+    wahlperiode or the session cannot be parsed, returns ``None`` rather than
+    emitting a mismatched key that would silently break dedup / the supersede
+    filter / the resurrection guard.
+
+    Returns:
+        The ``de-{ep}-{session}-{slug}-{agenda_slug}`` key, or ``None`` when ep /
+        session are unparseable.
+    """
+    raw_wp = speech.get("wahlperiode")
+    try:
+        ep = int(raw_wp)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+    protocol_id = str(speech.get("protocol_id") or "")
+    parts = protocol_id.split("/")
+    if len(parts) < 2:
+        return None
+    try:
+        session = int(parts[1].strip())
+    except (TypeError, ValueError):
+        return None
+
+    return make_speech_key(
+        ep=ep,
+        session=session,
+        speaker_slug=slugify_speaker(full_name=speech.get("speaker_name") or ""),
+        agenda_slug=agenda_slug_from_top_id(speech.get("agenda_top_id")),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Party slug map — normalised case-insensitively on the stripped party string.
+# Covers every distinct value produced by constants.PARTY_ALIASES:
+#   SPD, CDU/CSU, BÜNDNIS 90/DIE GRÜNEN, FDP, AfD, DIE LINKE, BSW, fraktionslos
+# Unknown/missing party values default to "unbekannt".
+# ---------------------------------------------------------------------------
+
+# Speeches only ever carry Bundestag fraction labels, so the map is the shared
+# major-party core (incl. the CDU/CSU rule — see src/ingestion/party_slugs.py)
+# plus an explicit DSU→quarantine: a non-fraction party appearing in a speech
+# label should quarantine rather than mis-tenant.
+_PARTY_SLUG_MAP: dict[str, str] = {
+    **CANONICAL_PARTY_SLUGS,
+    "dsu": PARTY_SLUG_QUARANTINE,
+}
+
+
+# Shared normaliser (soft-hyphen strip + whitespace collapse + lowercase).
+_normalize_party_label = normalize_party_label
+
+
+def party_to_slug(party: Optional[str]) -> str:
+    """Map a raw party string from the speeches dict to a canonical slug.
+
+    Matching is case-insensitive on the stripped string, with invisible
+    formatting characters removed before lookup (U+00AD soft hyphen guard).
+    Unknown or missing party strings map to "unbekannt".
+
+    Covers every distinct value in constants.PARTY_ALIASES:
+    SPD, CDU/CSU, BÜNDNIS 90/DIE GRÜNEN, FDP, AfD, DIE LINKE, BSW, fraktionslos.
+
+    Args:
+        party: Raw party string from the speech dict, or None.
+
+    Returns:
+        Canonical party slug (e.g. "spd", "fdp", "unbekannt").
+    """
+    if not party:
+        return "unbekannt"
+    clean = _normalize_party_label(party)
+    if not clean:
+        return "unbekannt"
+    return _PARTY_SLUG_MAP.get(clean, "unbekannt")
+
+
+# ---------------------------------------------------------------------------
+# Chunking is centralised: chunk_text is imported from src.ingestion.chunking
+# and re-exported here (the openparliament_tv mapper imports it from this
+# module). Speeches use the shared boundary-aware character defaults.
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Per-speech record builder (pure, no embeddings — unit-testable)
+# ---------------------------------------------------------------------------
+
+
+def build_chunk_records(speech: dict) -> list[ChunkRecord]:
+    """Build ChunkRecord(s) for a single speech dict (no embeddings required).
+
+    Skips speeches with empty or whitespace-only ``text``.
+
+    Speech-specific descriptive fields (person_id, speaker_name, xml_rede_id,
+    protocol_id, protocol_api_id) are packed into a SpeechMeta dict and stored
+    in the envelope ``meta`` field. Top-level vote-specific fields are
+    not set (defaults to None, excluded by exclude_none on upsert).
+
+    ``external_id`` is NOT set explicitly here.
+    The ChunkRecord field default (None) is preserved so the connector's
+    normalize() can stamp YYYYMMDD via model_copy(update={"external_id": ...})
+    without the mapper carrying protocol-date knowledge.
+
+    Args:
+        speech: Dict from the speeches JSONL with keys:
+                id, text, date, party, speaker_name, protocol_id,
+                pdf_url (optional), wahlperiode (optional),
+                person_id (optional), xml_rede_id (optional),
+                protocol_api_id (optional).
+
+    Returns:
+        List of ChunkRecord instances (one per token chunk). Empty list if
+        the speech text is absent or whitespace-only.
+    """
+    text = speech.get("text") or ""
+    if not text.strip():
+        return []
+
+    # Deterministic source_item_id from speech id string. source="dip" keeps the
+    # id space disjoint from op's (op and DIP share source_type but draw ids from
+    # different upstreams — see compute_source_item_id).
+    speech_id = str(speech.get("id", ""))
+    source_item_id = compute_source_item_id(
+        "parliamentary_speech", speech_id, source="dip"
+    )
+
+    # Publish date — parse ISO YYYY-MM-DD; on error log a warning and return []
+    # so the speech is skipped (consistent with the empty-text skip already in
+    # this function, and with programs.py/qa.py policy). A date.today() fallback
+    # would pollute the deterministic publish_date.
+    raw_date = speech.get("date") or ""
+    try:
+        publish_date = date_type.fromisoformat(raw_date)
+    except (ValueError, TypeError):
+        _corpus_logger.warning(
+            "build_chunk_records: speech %r has missing or unparseable date %r — skipping speech.",
+            speech_id,
+            raw_date,
+        )
+        print(
+            f"WARNING: skipping speech {speech_id!r}: unparseable date {raw_date!r}",
+            file=sys.stderr,
+        )
+        return []
+
+    party_slug = party_to_slug(speech.get("party"))
+
+    speaker_name = speech.get("speaker_name") or ""
+    protocol_id = speech.get("protocol_id") or ""
+    citation_title = f"{speaker_name}, {raw_date} (Protokoll {protocol_id})"
+    citation_url: Optional[str] = speech.get("pdf_url") or None
+
+    # Wahlperiode — optional top-level indexed field.
+    raw_wahlperiode = speech.get("wahlperiode")
+    wahlperiode: Optional[int] = (
+        int(raw_wahlperiode) if raw_wahlperiode is not None else None
+    )
+
+    # Build source-owned SpeechMeta; omit None-valued fields.
+    speech_meta_obj = SpeechMeta(
+        person_id=speech.get("person_id") or None,
+        speaker_name=speech.get("speaker_name") or None,
+        xml_rede_id=speech.get("xml_rede_id") or None,
+        protocol_id=speech.get("protocol_id") or None,
+        protocol_api_id=speech.get("protocol_api_id") or None,
+    )
+    meta_dict = speech_meta_obj.model_dump(mode="json", exclude_none=True)
+    meta: Optional[dict] = meta_dict if meta_dict else None
+
+    # Shared cross-source dedup identity + source discriminator.
+    speech_key = compute_speech_key(speech)
+
+    text_chunks = chunk_text(text)
+
+    records: list[ChunkRecord] = []
+    for chunk_index, chunk_str in enumerate(text_chunks):
+        chunk_key = make_chunk_key(source_item_id, chunk_index)
+        # Change-aware content_hash (mirrors the op mapper): PER-CHUNK text so an
+        # upstream re-chunk or correction re-writes via run.py's guard; includes
+        # the resolved party slug (indexed tenant field) so a slug fix re-writes
+        # the stale tenant too.
+        content_hash = hashlib.sha256(
+            json.dumps(
+                {
+                    "text": chunk_str,
+                    "party_slug": party_slug,
+                    "speech_key": speech_key,
+                    "source": _DIP_SOURCE,
+                    "protocol_id": protocol_id,
+                },
+                sort_keys=True,
+                ensure_ascii=False,
+            ).encode("utf-8")
+        ).hexdigest()
+        records.append(
+            ChunkRecord(
+                chunk_key=chunk_key,
+                source_item_id=source_item_id,
+                chunk_index=chunk_index,
+                text=chunk_str,
+                party_id=party_slug,
+                region="DE",
+                # A plenary speech is a factual parliamentary record
+                # regardless of transport — unified with the op mapper
+                # (FACTUAL_RECORD) so the surviving tier no longer depends on
+                # which connector won the dedup. Existing chunks keep the old
+                # tier until re-ingest (tier is not part of content_hash).
+                authority_tier=AuthorityTier.FACTUAL_RECORD,
+                source_type=SourceType.PARLIAMENTARY_SPEECH,
+                publish_date=publish_date,
+                citation_url=citation_url,
+                citation_title=citation_title,
+                # NOTE: external_id intentionally NOT set here.
+                # The connector's normalize() stamps YYYYMMDD via model_copy.
+                # Legislative period — stamped when available in source.
+                wahlperiode=wahlperiode,
+                # Cross-source dedup identity + discriminator.
+                speech_key=speech_key,
+                source=_DIP_SOURCE,
+                # Change-aware re-write guard (run.py).
+                content_hash=content_hash,
+                # Source-owned nested metadata.
+                meta=meta,
+            )
+        )
+
+    return records

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/mappers/corpus.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/mappers/corpus.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -220,14 +220,32 @@ def build_chunk_records(speech: dict) -> list[ChunkRecord]:
 
     speaker_name = speech.get("speaker_name") or ""
     protocol_id = speech.get("protocol_id") or ""
-    citation_title = f"{speaker_name}, {raw_date} (Protokoll {protocol_id})"
+    source_page = str(speech.get("source_page") or "") or None
+    citation_title = f"{speaker_name}, {raw_date} (Protokoll {protocol_id}"
+    citation_title += f", S. {source_page})" if source_page else ")"
     citation_url: Optional[str] = speech.get("pdf_url") or None
+    # Deep-link into the protocol PDF when the parser could derive the PDF page
+    # safely (start-seitennr present). Only appended to a fragment-free URL —
+    # never clobber an existing anchor.
+    pdf_page = speech.get("pdf_page")
+    if citation_url and isinstance(pdf_page, int) and "#" not in citation_url:
+        citation_url = f"{citation_url}#page={pdf_page}"
 
-    # Wahlperiode — optional top-level indexed field.
+    # Wahlperiode — optional top-level indexed field. Tolerant coercion: bulk
+    # JSONL rows can carry it as a string (or garbage) — degrade to None like
+    # every other optional metadata field instead of aborting the speech.
     raw_wahlperiode = speech.get("wahlperiode")
-    wahlperiode: Optional[int] = (
-        int(raw_wahlperiode) if raw_wahlperiode is not None else None
-    )
+    wahlperiode: Optional[int] = None
+    if raw_wahlperiode is not None:
+        try:
+            wahlperiode = int(raw_wahlperiode)
+        except (TypeError, ValueError):
+            _corpus_logger.warning(
+                "build_chunk_records: speech %r has non-integer wahlperiode %r — "
+                "stamping None.",
+                speech_id,
+                raw_wahlperiode,
+            )
 
     # Build source-owned SpeechMeta; omit None-valued fields.
     speech_meta_obj = SpeechMeta(
@@ -236,6 +254,8 @@ def build_chunk_records(speech: dict) -> list[ChunkRecord]:
         xml_rede_id=speech.get("xml_rede_id") or None,
         protocol_id=speech.get("protocol_id") or None,
         protocol_api_id=speech.get("protocol_api_id") or None,
+        source_page=source_page,
+        page_quadrant=str(speech.get("page_quadrant") or "") or None,
     )
     meta_dict = speech_meta_obj.model_dump(mode="json", exclude_none=True)
     meta: Optional[dict] = meta_dict if meta_dict else None
@@ -251,7 +271,9 @@ def build_chunk_records(speech: dict) -> list[ChunkRecord]:
         # Change-aware content_hash (mirrors the op mapper): PER-CHUNK text so an
         # upstream re-chunk or correction re-writes via run.py's guard; includes
         # the resolved party slug (indexed tenant field) so a slug fix re-writes
-        # the stale tenant too.
+        # the stale tenant too, and the displayed citation (URL/title carry the
+        # page coordinates) so a citation correction is refreshable rather than
+        # permanently stale.
         content_hash = hashlib.sha256(
             json.dumps(
                 {
@@ -260,6 +282,8 @@ def build_chunk_records(speech: dict) -> list[ChunkRecord]:
                     "speech_key": speech_key,
                     "source": _DIP_SOURCE,
                     "protocol_id": protocol_id,
+                    "citation_url": citation_url,
+                    "citation_title": citation_title,
                 },
                 sort_keys=True,
                 ensure_ascii=False,

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/mdb.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/mdb.py
@@ -1,0 +1,257 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""MdB-Stammdaten lookup — load speaker→party mapping from the Bundestag master file.
+
+Uses defusedxml.ElementTree to block entity-expansion attacks when loading
+the 15 MB MdB-Stammdaten XML.
+
+Public API:
+  load_mdb_lookup(path) -> dict[str, dict]
+    Builds {by_id: {id: record}, by_name: {normalized_name: record}} from
+    the MdB-Stammdaten XML. Returns empty lookups if the file is missing
+    (graceful degradation — for bulk/backfill callers that tolerate it).
+
+  ensure_mdb_lookup(path) -> dict[str, dict]
+    Live-run variant: downloads the file first if absent, then loads it, and
+    RAISES on an empty result. A scheduled speech run must resolve
+    minister/president speakers, so silent degradation to "unbekannt" is a
+    fail-loud stop rather than a warning.
+
+  download_mdb_stammdaten(dest) -> Path
+    Fetches + extracts the OpenData ZIP to ``dest`` (transient failures retried,
+    a 404 fails fast — the blob rotated).
+
+  mdb_party_for_speech(xml_speech, mdb_lookup) -> str | None
+    Resolves party by speaker_xml_id first, then by normalized name.
+
+  mdb_record_for_speaker_name(xml_speech, mdb_lookup) -> dict | None
+    Returns the unique MdB record for a speaker name (by_name lookup).
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import zipfile
+from pathlib import Path
+
+import defusedxml.ElementTree as ElementTree  # blocks entity-expansion / billion-laughs
+import httpx
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from .constants import MDB_STAMMDATEN_FILE, MDB_STAMMDATEN_URL
+from .utils import (
+    normalize_name_for_lookup,
+    normalize_party,
+    normalize_whitespace,
+    parse_int,
+)
+
+# Default on-disk path (relative to ai-backend/). mdb.py sits at the same depth
+# as connector.py, so the parents[4] anchor matches the connectors' _MDB_PATH.
+_DEFAULT_MDB_PATH: Path = Path(__file__).resolve().parents[4] / MDB_STAMMDATEN_FILE
+
+# The single XML member inside the OpenData ZIP.
+_MDB_ZIP_MEMBER = "MDB_STAMMDATEN.XML"
+
+
+class StammdatenUnavailableError(RuntimeError):
+    """MdB-Stammdaten could not be obtained, or loaded to a non-empty lookup.
+
+    Fail-loud signal for the live speech path: without this master data,
+    empty-``<fraktion>`` speakers (ministers, the president) all resolve to
+    "unbekannt", so ingesting would quietly poison party attribution.
+    """
+
+
+@retry(
+    # Retry transient network faults and 5xx. A 404 is raised as
+    # StammdatenUnavailableError below (not in this set), so it fails fast.
+    retry=retry_if_exception_type((httpx.TransportError, httpx.HTTPStatusError)),
+    stop=stop_after_attempt(5),
+    wait=wait_exponential(multiplier=1, min=2, max=30),
+    reraise=True,
+)
+def _fetch_zip_bytes(url: str) -> bytes:
+    resp = httpx.get(url, timeout=60.0, follow_redirects=True)
+    if resp.status_code == 404:
+        raise StammdatenUnavailableError(
+            f"MdB-Stammdaten not found at {url} (HTTP 404) — the OpenData blob "
+            "was likely rotated; get the current link from "
+            "https://www.bundestag.de/services/opendata"
+        )
+    resp.raise_for_status()  # 5xx → HTTPStatusError → retried
+    return resp.content
+
+
+def download_mdb_stammdaten(
+    dest: Path | str = _DEFAULT_MDB_PATH, *, url: str = MDB_STAMMDATEN_URL
+) -> Path:
+    """Download the OpenData ZIP and extract MDB_STAMMDATEN.XML to ``dest``.
+
+    In-memory extraction (no temp file). Transient failures are retried with
+    backoff; a 404 fails fast (rotated blob — see StammdatenUnavailableError).
+    """
+    dest = Path(dest)
+    print(f"Fetching MdB-Stammdaten from {url} …", file=sys.stderr)
+    payload = _fetch_zip_bytes(url)
+    with zipfile.ZipFile(io.BytesIO(payload)) as zf:
+        try:
+            data = zf.read(_MDB_ZIP_MEMBER)
+        except KeyError as exc:
+            raise StammdatenUnavailableError(
+                f"{_MDB_ZIP_MEMBER} not present in the ZIP at {url}"
+            ) from exc
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(data)
+    print(f"Saved MdB-Stammdaten to {dest} ({len(data)} bytes).", file=sys.stderr)
+    return dest
+
+
+def ensure_mdb_lookup(
+    path: Path | str = _DEFAULT_MDB_PATH, *, download: bool = True
+) -> dict:
+    """Load the MdB-Stammdaten lookup, fetching the file first when absent.
+
+    The live-run counterpart to load_mdb_lookup: it downloads on a cache miss
+    and REQUIRES a non-empty result, raising StammdatenUnavailableError
+    otherwise. ``download=False`` skips the fetch (used where a caller wants
+    the strict emptiness check without network access).
+    """
+    path = Path(path)
+    if download and not path.exists():
+        download_mdb_stammdaten(path)
+    lookup = load_mdb_lookup(path)
+    if not lookup["by_id"] and not lookup["by_name"]:
+        raise StammdatenUnavailableError(
+            f"MdB-Stammdaten lookup is empty (file: {path}). Refusing to ingest "
+            "speeches: every empty-<fraktion> speaker would degrade to 'unbekannt'."
+        )
+    return lookup
+
+
+def name_from_mdb_entry(name_entry) -> str | None:
+    parts = [name_entry.findtext("VORNAME"), name_entry.findtext("NACHNAME")]
+    return normalize_whitespace(" ".join(part for part in parts if part))
+
+
+def latest_fraction_party(mdb) -> str | None:
+    parties: list[tuple[int, str]] = []
+    for term in mdb.findall("WAHLPERIODEN/WAHLPERIODE"):
+        term_number = parse_int(term.findtext("WP"))
+        for institution in term.findall("INSTITUTIONEN/INSTITUTION"):
+            if (
+                normalize_whitespace(institution.findtext("INSART_LANG"))
+                != "Fraktion/Gruppe"
+            ):
+                continue
+            party = normalize_party(institution.findtext("INS_LANG"))
+            if party:
+                parties.append((term_number, party))
+
+    if not parties:
+        return None
+    return max(parties, key=lambda item: item[0])[1]
+
+
+def parse_mdb_record(mdb) -> dict:
+    names = [name_from_mdb_entry(name) for name in mdb.findall("NAMEN/NAME")]
+    party = normalize_party(
+        mdb.findtext("BIOGRAFISCHE_ANGABEN/PARTEI_KURZ")
+    ) or latest_fraction_party(mdb)
+    return {
+        "id": normalize_whitespace(mdb.findtext("ID")),
+        "names": [name for name in names if name],
+        "party": party,
+    }
+
+
+def load_mdb_lookup(path) -> dict:
+    """Load the MdB-Stammdaten XML into {by_id, by_name} lookup dicts.
+
+    Returns empty lookups (not an error) when the file is absent — the
+    connector degrades gracefully to XML <fraktion> as the sole party source.
+    Raises defusedxml.EntitiesForbidden on entity-expansion attacks.
+    """
+    path = Path(path)
+    if not path.exists():
+        print(f"Warning: MDB Stammdaten file not found: {path}")
+        return {"by_id": {}, "by_name": {}}
+
+    root = ElementTree.parse(str(path)).getroot()
+    by_id: dict[str, dict] = {}
+    name_candidates: dict[str, list[dict]] = {}
+
+    for mdb in root.findall("MDB"):
+        record = parse_mdb_record(mdb)
+        if record["id"]:
+            by_id[record["id"]] = record
+
+        for name in record["names"]:
+            lookup_name = normalize_name_for_lookup(name)
+            if lookup_name:
+                name_candidates.setdefault(lookup_name, []).append(record)
+
+    by_name: dict[str, dict] = {}
+    for name, records in name_candidates.items():
+        if len({record["id"] for record in records}) == 1:
+            by_name[name] = records[0]
+
+    return {"by_id": by_id, "by_name": by_name}
+
+
+def mdb_party_for_speech(xml_speech: dict, mdb_lookup: dict) -> str | None:
+    """Resolve party for a speech dict via the MdB lookup.
+
+    Resolution order:
+      1. by_id[speaker_xml_id].party
+      2. by_name[normalize_name_for_lookup(speaker_name)].party
+      3. None (caller falls back to XML <fraktion>)
+    """
+    person_id = xml_speech.get("speaker_xml_id")
+    if person_id:
+        record = mdb_lookup["by_id"].get(person_id)
+        if record and record["party"]:
+            return record["party"]
+
+    speaker_name = normalize_name_for_lookup(xml_speech.get("speaker_name"))
+    if speaker_name:
+        record = mdb_lookup["by_name"].get(speaker_name)
+        if record and record["party"]:
+            return record["party"]
+
+    return None
+
+
+def mdb_record_for_speaker_name(xml_speech: dict, mdb_lookup: dict) -> dict | None:
+    """Return the unique MdB record for a speaker name (by_name lookup), or None."""
+    speaker_name = normalize_name_for_lookup(xml_speech.get("speaker_name"))
+    if not speaker_name:
+        return None
+    return mdb_lookup["by_name"].get(speaker_name)
+
+
+def main() -> None:
+    """Pre-fetch the MdB-Stammdaten XML to the default path (host dev convenience).
+
+    Idempotent: skips the download when the file is already present (delete it
+    to refresh). Wired to `make fetch-mdb-stammdaten`.
+    """
+    if _DEFAULT_MDB_PATH.exists():
+        print(
+            f"MdB-Stammdaten already present ({_DEFAULT_MDB_PATH}) — skipping.",
+            file=sys.stderr,
+        )
+        return
+    download_mdb_stammdaten(_DEFAULT_MDB_PATH)
+
+
+if __name__ == "__main__":
+    main()

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/mdb.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/mdb.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/parser.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/parser.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""parse_speeches_from_xml — XML→speech-dict transform, hardened via defusedxml.
+
+Security: uses defusedxml.ElementTree to block billion-laughs /
+entity-expansion attacks on remote protocol XML.
+
+Public API:
+  parse_speeches_from_xml(xml_text: str) -> list[dict]
+    Extracts speaker/party/text dicts from a plenary protocol XML string.
+    Skips <kommentar> nodes; applies merged-name visible-label override.
+"""
+
+from __future__ import annotations
+
+import re
+
+import defusedxml.ElementTree as ElementTree  # blocks entity-expansion / billion-laughs
+
+from .utils import is_known_party, normalize_party, normalize_whitespace
+
+
+def parse_visible_speaker_label(tail: str | None) -> dict:
+    tail = normalize_whitespace(tail)
+    if not tail:
+        return {}
+
+    match = re.match(r"^(?P<name>.+?)\s*\((?P<party>[^()]*)\)$", tail.rstrip(":"))
+    if not match:
+        return {}
+
+    party = normalize_party(match.group("party"))
+    if not is_known_party(party):
+        return {}
+
+    return {
+        "speaker_name": normalize_whitespace(match.group("name")),
+        "party": party,
+    }
+
+
+def has_merged_name(value: str | None) -> bool:
+    value = normalize_whitespace(value)
+    return bool(value and re.search(r"[a-zäöüß][A-ZÄÖÜ]", value))
+
+
+def has_suspicious_speaker_metadata(speaker: dict) -> bool:
+    return not is_known_party(speaker.get("party")) or has_merged_name(
+        speaker.get("speaker_name")
+    )
+
+
+def parse_speaker(redner) -> dict:  # type: ignore[return]
+    name = redner.find("name")
+    if name is None:
+        return {}
+
+    title = normalize_whitespace(
+        " ".join(node.text or "" for node in name.findall("titel"))
+    )
+    first_name = normalize_whitespace(
+        " ".join(node.text or "" for node in name.findall("vorname"))
+    )
+    last_name = normalize_whitespace(
+        " ".join(node.text or "" for node in name.findall("nachname"))
+    )
+    party = normalize_whitespace(name.findtext("fraktion"))
+
+    speaker: dict = {
+        "speaker_xml_id": redner.get("id"),
+        "speaker_name": " ".join(
+            part for part in [title, first_name, last_name] if part
+        ),
+        "party": party,
+    }
+
+    # Some official XML records have merged structured metadata, while the visible label is correct.
+    visible_speaker = parse_visible_speaker_label(redner.tail)
+    if visible_speaker and has_suspicious_speaker_metadata(speaker):
+        speaker.update(visible_speaker)
+
+    return speaker
+
+
+def paragraph_text(paragraph) -> str:
+    parts = []
+    if paragraph.text:
+        parts.append(paragraph.text)
+
+    for child in paragraph:
+        if child.tag != "kommentar":
+            parts.append(" ".join(child.itertext()))
+        if child.tail:
+            parts.append(child.tail)
+
+    return normalize_whitespace(" ".join(parts)) or ""
+
+
+def parse_speeches_from_xml(xml_text: str) -> list[dict]:
+    """Parse a plenary protocol XML string into a list of speech dicts.
+
+    Each dict contains: xml_rede_id, speaker_xml_id, speaker_name, party, text,
+    agenda_top_id.
+    Skips <kommentar> nodes (applause, interjections).
+    Applies merged-name visible-label override (parse_speaker).
+
+    agenda_top_id is the ``top-id`` of the enclosing <tagesordnungspunkt> for
+    each <rede> (e.g. "20"), or None when a rede has no enclosing agenda item
+    (graceful no-agenda fallback). ElementTree exposes no parent pointers,
+    so the enclosing agenda is resolved by walking each <tagesordnungspunkt> and
+    recording a rede_id → top_id map before the main <rede> loop.
+
+    Raises defusedxml.EntitiesForbidden on entity-expansion attacks.
+    Returns [] on malformed XML (ParseError is NOT caught here — callers
+    that need graceful degradation should catch ElementTree.ParseError).
+    """
+    try:
+        root = ElementTree.fromstring(xml_text.encode("utf-8"))
+    except ElementTree.ParseError:
+        return []
+
+    # Map each <rede> id to the top-id of its enclosing <tagesordnungspunkt>.
+    # ElementTree has no parent pointers, so iterate the agenda items and their
+    # descendant <rede> nodes to build the lookup. A rede with no enclosing
+    # tagesordnungspunkt is simply absent from the map → agenda_top_id None.
+    agenda_top_id_by_rede: dict[str, str] = {}
+    for agenda_node in root.findall(".//tagesordnungspunkt"):
+        top_id = agenda_node.get("top-id")
+        if not top_id:
+            continue
+        for rede_node in agenda_node.findall(".//rede"):
+            rede_id = rede_node.get("id")
+            if rede_id is not None:
+                agenda_top_id_by_rede.setdefault(rede_id, top_id)
+
+    speeches: list[dict] = []
+
+    for speech_node in root.findall(".//rede"):
+        speaker_node = speech_node.find("./p[@klasse='redner']/redner")
+        speaker = parse_speaker(speaker_node) if speaker_node is not None else {}
+        speaker_id = speaker.get("speaker_xml_id")
+        collect_text = bool(speaker_id)
+
+        paragraphs: list[str] = []
+        for child in list(speech_node):
+            if child.tag == "p" and child.get("klasse") == "redner":
+                redner = child.find("redner")
+                current_speaker_id = redner.get("id") if redner is not None else None
+                collect_text = bool(speaker_id) and current_speaker_id == speaker_id
+                continue
+
+            if child.tag == "name":
+                collect_text = False
+                continue
+
+            if child.tag == "kommentar":
+                continue
+
+            if child.tag != "p" or not collect_text:
+                continue
+
+            text = paragraph_text(child)
+            if text:
+                paragraphs.append(text)
+
+        rede_id = speech_node.get("id")
+        speeches.append(
+            {
+                "xml_rede_id": rede_id,
+                "text": "\n".join(paragraphs).strip() or None,
+                "agenda_top_id": agenda_top_id_by_rede.get(rede_id)
+                if rede_id is not None
+                else None,
+                **speaker,
+            }
+        )
+
+    return speeches

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/parser.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/parser.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -112,9 +112,17 @@ def parse_speeches_from_xml(xml_text: str) -> list[dict]:
     so the enclosing agenda is resolved by walking each <tagesordnungspunkt> and
     recording a rede_id → top_id map before the main <rede> loop.
 
+    Citation coordinates: the table of contents maps every rede to its printed
+    page and quadrant via ``<xref ref-type="rede" rid=… pnr=… div=…>``; each
+    speech dict carries them as ``source_page`` / ``page_quadrant`` (None when
+    the TOC has no entry). ``pdf_page`` is the 1-based page inside the protocol
+    PDF, derived from the root's ``start-seitennr`` (printed page of the PDF's
+    first page); None when that attribute is absent or unparseable — a citation
+    deep-link must not guess.
+
     Raises defusedxml.EntitiesForbidden on entity-expansion attacks.
-    Returns [] on malformed XML (ParseError is NOT caught here — callers
-    that need graceful degradation should catch ElementTree.ParseError).
+    Returns [] on malformed XML (ElementTree.ParseError is caught here and
+    mapped to an empty list — callers treat "no speeches" as the skip signal).
     """
     try:
         root = ElementTree.fromstring(xml_text.encode("utf-8"))
@@ -134,6 +142,23 @@ def parse_speeches_from_xml(xml_text: str) -> list[dict]:
             rede_id = rede_node.get("id")
             if rede_id is not None:
                 agenda_top_id_by_rede.setdefault(rede_id, top_id)
+
+    # Citation coordinates from the TOC xrefs: rede id → (printed page pnr,
+    # quadrant div). First entry wins (a speech spans pages; the TOC points at
+    # where it starts).
+    page_by_rede: dict[str, tuple[str, str | None]] = {}
+    for xref in root.findall(".//xref[@ref-type='rede']"):
+        rid = xref.get("rid")
+        pnr = xref.get("pnr")
+        if rid and pnr:
+            page_by_rede.setdefault(rid, (pnr, xref.get("div")))
+
+    # start-seitennr = printed page number of the PDF's first page; the offset
+    # (pnr − start + 1) turns a printed page into the PDF page for #page= links.
+    start_page: int | None = None
+    raw_start = root.get("start-seitennr")
+    if raw_start and raw_start.isdigit():
+        start_page = int(raw_start)
 
     speeches: list[dict] = []
 
@@ -166,6 +191,16 @@ def parse_speeches_from_xml(xml_text: str) -> list[dict]:
                 paragraphs.append(text)
 
         rede_id = speech_node.get("id")
+        source_page, page_quadrant = (
+            page_by_rede.get(rede_id, (None, None))
+            if rede_id is not None
+            else (None, None)
+        )
+        pdf_page: int | None = None
+        if source_page is not None and start_page is not None and source_page.isdigit():
+            candidate = int(source_page) - start_page + 1
+            if candidate >= 1:
+                pdf_page = candidate
         speeches.append(
             {
                 "xml_rede_id": rede_id,
@@ -173,6 +208,9 @@ def parse_speeches_from_xml(xml_text: str) -> list[dict]:
                 "agenda_top_id": agenda_top_id_by_rede.get(rede_id)
                 if rede_id is not None
                 else None,
+                "source_page": source_page,
+                "page_quadrant": page_quadrant,
+                "pdf_page": pdf_page,
                 **speaker,
             }
         )

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/utils.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/utils.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""Shared text-normalisation utilities for the bundestag_speeches connector.
+
+Public API:
+  normalize_whitespace(text) -> str | None
+  normalize_name_for_lookup(text) -> str
+  normalize_party(value) -> str | None   (alias resolution via PARTY_ALIASES)
+  is_known_party(value) -> bool
+  parse_int(value) -> int
+"""
+
+from __future__ import annotations
+
+import re
+
+from .constants import PARTY_ALIASES, VALID_PARTIES
+
+
+def normalize_whitespace(text: str | None) -> str | None:
+    if text is None:
+        return None
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def normalize_name_for_lookup(text: str | None) -> str:
+    text = normalize_whitespace(text) or ""
+    text = text.replace(" ", " ")
+    text = re.sub(r"\b(Dr|Prof)\.\s*", "", text)
+    text = re.sub(r"\([^)]*\)", "", text)
+    return re.sub(r"[^a-zäöüß ]", "", text.lower()).strip()
+
+
+def normalize_party(value: str | None) -> str | None:
+    value = normalize_whitespace(value)
+    if not value:
+        return None
+
+    key = value.replace(" ", " ")
+    key = re.sub(r"\s+", " ", key).strip().upper()
+    return PARTY_ALIASES.get(key, value)
+
+
+def is_known_party(value: str | None) -> bool:
+    return normalize_party(value) in VALID_PARTIES
+
+
+def parse_int(value: str | None) -> int:
+    try:
+        return int(normalize_whitespace(value) or 0)
+    except ValueError:
+        return 0

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/utils.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/src/ingestion/schemas.py
+++ b/ai-backend/src/ingestion/schemas.py
@@ -117,6 +117,13 @@ class SpeechMeta(BaseModel):
     protocol_api_id: Optional[str] = Field(
         None, description="API-level protocol identifier"
     )
+    source_page: Optional[str] = Field(
+        None,
+        description="Printed page (Plenarprotokoll pagination) where the speech starts",
+    )
+    page_quadrant: Optional[str] = Field(
+        None, description="Page quadrant (A–D) of the speech start on source_page"
+    )
 
 
 class ChunkRecord(BaseModel):

--- a/ai-backend/src/ingestion/speech_dedup.py
+++ b/ai-backend/src/ingestion/speech_dedup.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/src/ingestion/speech_dedup.py
+++ b/ai-backend/src/ingestion/speech_dedup.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Shared speech-dedup constants and helpers — imported by BOTH speech connectors
+(``bundestag_speeches``, ``openparliament_tv``) and the op supersede module, NOT
+owned by either. They live in one shared module so there is a SINGLE definition:
+a drift between copies would silently break cross-source dedup.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date as date_type
+from datetime import timedelta
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Text-match ratio — ONE constant, two documented aliases.
+#
+# The op→DIP supersede pass and the DIP pre-insert resurrection guard apply the
+# SAME question ("is this the same speech across sources?") from opposite
+# directions, so they MUST share one threshold. The proceedings text is
+# byte-identical in intent across op/DIP but ~99% identical in practice (op
+# runs ~1% longer); a DIFFERENT speech by the same speaker under the same
+# agenda item scores far lower (~0.3–0.6). The aliases document which policy is
+# reading the value at each call site.
+# ---------------------------------------------------------------------------
+SPEECH_TEXT_MATCH_RATIO: float = 0.85
+SUPERSEDE_TEXT_MATCH_RATIO: float = SPEECH_TEXT_MATCH_RATIO
+RESURRECTION_TEXT_MATCH_RATIO: float = SPEECH_TEXT_MATCH_RATIO
+
+# Lookback window (days) subtracted from the since-derived YYYYMMDD floor so an
+# item that transiently failed (DIP) or only just aligned (op, ~3–4 weeks
+# backlog) BELOW the max-external_id watermark is re-discovered on a later run.
+# Shared by both speech connectors — kept equal deliberately.
+LOOKBACK_DAYS: int = 60
+
+
+def norm_speech_text(text: Optional[str]) -> str:
+    """Lowercase, alphanumeric-only fold for order-stable cross-source text compare."""
+    return re.sub(r"[^a-z0-9]+", "", (text or "").lower())
+
+
+def lookback_floor(since: int, lookback_days: int = LOOKBACK_DAYS) -> int:
+    """Translate a YYYYMMDD cursor into a ``since − lookback_days`` YYYYMMDD floor.
+
+    Args:
+        since:         Integer YYYYMMDD cursor e.g. 20260601.
+        lookback_days: Window size (default: the shared LOOKBACK_DAYS).
+
+    Returns:
+        Integer YYYYMMDD floor e.g. 20260402 (malformed input returns ``since``
+        unchanged so a bad cursor degrades to the old strict-floor behavior).
+    """
+    s = str(since)
+    try:
+        cursor_date = date_type(int(s[0:4]), int(s[4:6]), int(s[6:8]))
+    except (ValueError, IndexError):
+        return since
+    floored = cursor_date - timedelta(days=lookback_days)
+    return int(floored.strftime("%Y%m%d"))
+
+
+def datum_to_external_id(date_start: Optional[str]) -> Optional[int]:
+    """Convert an ISO date/datetime string to a YYYYMMDD integer external_id.
+
+    Accepts both DIP's bare ``"2026-06-15"`` and op's full
+    ``"2023-04-28T10:12:00+02:00"`` (only the date prefix is read).
+
+    Returns:
+        Integer e.g. 20260615, or None for a missing/malformed input.
+    """
+    iso = str(date_start or "")[:10]
+    try:
+        return int(iso.replace("-", ""))
+    except ValueError:
+        return None

--- a/ai-backend/src/ingestion/speech_key.py
+++ b/ai-backend/src/ingestion/speech_key.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -149,14 +149,16 @@ def agenda_slug_from_official(
     Rules: detect the item KIND — an official title starting with
     ``Zusatzpunkt`` → ``zp{n}``, otherwise ``top{n}`` — where ``{n}`` is the
     FIRST integer in the title (identical extraction to
-    ``agenda_slug_from_top_id`` for byte-parity); anything else — including
-    ``agenda_type == "opening"`` — yields the empty string (the graceful
-    no-agenda fallback). Opening segments have NO DIP counterpart slug (DIP
-    yields ``""`` for redes outside any <tagesordnungspunkt>), so an op-side
-    ``"opening"`` slug would break cross-source dedup for opening-segment
-    speeches. ``agenda_type`` is kept in the signature for call-site
-    compatibility but no longer influences the slug.
+    ``agenda_slug_from_top_id`` for byte-parity). ``agenda_type == "opening"``
+    ALWAYS yields the empty string, even when the title contains a number
+    (e.g. "Eröffnung der 90. Sitzung" must not become ``top90``): opening
+    segments have NO DIP counterpart slug (DIP yields ``""`` for redes outside
+    any <tagesordnungspunkt>), so any op-side opening slug would break
+    cross-source dedup for opening-segment speeches. Titles without an
+    integer also yield ``""`` (the graceful no-agenda fallback).
     """
+    if agenda_type == "opening":
+        return ""
     if official_title:
         match = _FIRST_INT_RE.search(official_title)
         if match:

--- a/ai-backend/src/ingestion/speech_key.py
+++ b/ai-backend/src/ingestion/speech_key.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Shared deterministic speech-key helper — imported by BOTH speech connectors
+(``openparliament_tv`` and ``bundestag_speeches``), NOT owned by either.
+
+speech_key = ``de-{ep}-{session}-{speaker_slug}-{agenda_slug}``
+
+This is the cross-source dedup identity: the supersede-delete filter, the DIP
+pre-insert resurrection guard, and the migration backfill all key on it. op
+derives it from discrete ``firstname``/``lastname``; DIP derives it from a
+merged ``speaker_name`` string (possibly carrying an academic title). The two
+MUST produce byte-identical keys for the same speech — hence ONE shared slugify
+function.
+
+Determinism doctrine (mirrors ids.py): the slug/key rules here MUST NOT change
+after the first production ingest. Any change shifts every speech_key and
+silently breaks dedup, the supersede filter, and the resurrection guard across
+already-stamped chunks. Treat this like the WAHL_CHAT_NS namespace: frozen.
+
+The current rules were only safe to establish because no production ingest has
+happened yet — every stored dev corpus is disposable and will be re-ingested.
+Any change after a production ingest requires a full re-key migration.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Optional
+
+# Umlaut / eszett expansions applied BEFORE any NFKD decomposition or
+# non-alphanumeric stripping — so the German characters expand to their ASCII
+# digraph (ae/oe/ue/ss) instead of being decomposed to a bare base letter and
+# dropped. Both cases are mapped so the transform is order-independent w.r.t.
+# lowercasing.
+_UMLAUT_MAP = {
+    "ä": "ae",
+    "Ä": "Ae",
+    "ö": "oe",
+    "Ö": "Oe",
+    "ü": "ue",
+    "Ü": "Ue",
+    "ß": "ss",
+    "ẞ": "Ss",
+}
+
+# Academic / role title tokens dropped from the speaker slug so DIP's merged
+# "Dr. Mareike Lotte Wulf" and op's discrete firstname/lastname agree.
+#
+# Compound German academic titles tokenize into these fragments after the
+# non-alphanumeric split: "Dr. h. c." → h, c; "Dr.-Ing." → ing; "Dr. med." →
+# med; "Dr. jur." → jur; "Dr. rer. nat." → rer, nat; "Dr. rer. pol." → pol;
+# "Dr. habil." → habil; "Dr. E. h." → e, h. Without them a DIP merged name like
+# "Dr. h. c. Thomas Sattelberger" keeps stray h/c tokens and never matches op's
+# discrete firstname/lastname key — the twin is never superseded.
+#
+# Single letters "e"/"h"/"c" could theoretically appear as hyphenated-name
+# fragments, but real MdB surnames never slugify to a bare single letter (the
+# tokenizer splits on non-alphanumerics; German surname fragments like "Meyer",
+# "Lühmann", "van" are all multi-letter), so dropping them is safe here.
+_TITLE_TOKENS = frozenset(
+    {"dr", "prof", "h", "c", "ing", "med", "jur", "rer", "nat", "pol", "habil", "e"}
+)
+
+# Name-particle (nobiliary/preposition) tokens dropped from the speaker slug —
+# SOURCE-INDEPENDENT so DIP (whose parser never reads <namenszusatz>, yielding
+# "Beatrix Storch") and op (whose lastname includes the particle, "von Storch")
+# agree on one key: both sides drop the particle → beatrix-storch.
+_PARTICLE_TOKENS = frozenset(
+    {"von", "der", "van", "de", "zu", "graf", "freiherr", "freifrau", "baron", "prinz"}
+)
+
+
+def _expand_umlauts(text: str) -> str:
+    for src, dst in _UMLAUT_MAP.items():
+        text = text.replace(src, dst)
+    return text
+
+
+def _ascii_fold(text: str) -> str:
+    """NFKD-decompose then drop any remaining combining marks / non-ASCII."""
+    decomposed = unicodedata.normalize("NFKD", text)
+    return decomposed.encode("ascii", "ignore").decode("ascii")
+
+
+def slugify_speaker(
+    *,
+    firstname: Optional[str] = None,
+    lastname: Optional[str] = None,
+    full_name: Optional[str] = None,
+) -> str:
+    """Deterministic speaker slug shared by op (discrete names) and DIP (merged).
+
+    Accepts EITHER op's discrete ``firstname``/``lastname`` OR DIP's merged
+    ``full_name``. Steps (order matters for parity):
+      1. NFC-normalize (a decomposed NFD ``o`` + combining diaeresis must become
+         the composed ``ö`` BEFORE the umlaut expansion, else it silently folds
+         to a bare ``o``);
+      2. expand umlauts ``ä→ae ö→oe ü→ue ß→ss`` BEFORE folding (never dropped);
+      3. NFKD-fold remaining accents to ASCII;
+      4. lowercase;
+      5. tokenize on non-alphanumerics and drop academic-title tokens
+         (``dr``/``prof`` + compound-title fragments) and name particles
+         (``von``/``der``/``van``/...);
+      6. join surviving tokens with single ``-``.
+
+    ``"Mareike Lotte Wulf"`` and op ``firstname="Mareike Lotte", lastname="Wulf"``
+    both yield ``mareike-lotte-wulf``.
+    """
+    if full_name is not None:
+        raw = full_name
+    else:
+        raw = " ".join(part for part in (firstname, lastname) if part)
+
+    raw = unicodedata.normalize("NFC", raw)
+    raw = _expand_umlauts(raw)
+    raw = _ascii_fold(raw)
+    raw = raw.lower()
+
+    tokens = [tok for tok in re.split(r"[^a-z0-9]+", raw) if tok]
+    tokens = [
+        tok
+        for tok in tokens
+        if tok not in _TITLE_TOKENS and tok not in _PARTICLE_TOKENS
+    ]
+    return "-".join(tokens)
+
+
+# Agenda-item kind detection. Both sides MUST agree on kind AND number so the
+# op (official-title) path and the DIP (top-id) path produce byte-identical
+# slugs, while a Zusatzpunkt and a Tagesordnungspunkt with the same number stay
+# DISTINCT (otherwise supersede-delete could destroy an unrelated agenda item).
+# Slug shape: ``{zp|top}{n}``. Number extraction is the SAME on both
+# sides: the FIRST integer found (tolerant of letter suffixes / combined items
+# like "20 a" or "5 und 6" — a single deterministic rule applied identically).
+_ZP_OFFICIAL_RE = re.compile(r"^\s*zusatzpunkt", re.IGNORECASE)
+_FIRST_INT_RE = re.compile(r"(\d+)")
+
+
+def agenda_slug_from_official(
+    official_title: Optional[str],
+    agenda_type: Optional[str] = None,
+) -> str:
+    """op agenda slug: ``"Tagesordnungspunkt 20"`` → ``top20``, ``"Zusatzpunkt 5"`` → ``zp5``.
+
+    Rules: detect the item KIND — an official title starting with
+    ``Zusatzpunkt`` → ``zp{n}``, otherwise ``top{n}`` — where ``{n}`` is the
+    FIRST integer in the title (identical extraction to
+    ``agenda_slug_from_top_id`` for byte-parity); anything else — including
+    ``agenda_type == "opening"`` — yields the empty string (the graceful
+    no-agenda fallback). Opening segments have NO DIP counterpart slug (DIP
+    yields ``""`` for redes outside any <tagesordnungspunkt>), so an op-side
+    ``"opening"`` slug would break cross-source dedup for opening-segment
+    speeches. ``agenda_type`` is kept in the signature for call-site
+    compatibility but no longer influences the slug.
+    """
+    if official_title:
+        match = _FIRST_INT_RE.search(official_title)
+        if match:
+            prefix = "zp" if _ZP_OFFICIAL_RE.match(official_title) else "top"
+            return f"{prefix}{int(match.group(1))}"
+    return ""
+
+
+def agenda_slug_from_top_id(top_id: Optional[str]) -> str:
+    """DIP agenda slug: ``top-id="20"`` → ``top20``, ``top-id="ZP5"`` → ``zp5``.
+
+    Detects the item KIND — a top-id whose first non-space character is ``Z``
+    (``"Z5"``/``"ZP5"``, Zusatzpunkt) → ``zp{n}``, otherwise ``top{n}`` — where
+    ``{n}`` is the FIRST integer in the top-id (identical extraction to
+    ``agenda_slug_from_official`` for byte-parity, tolerant of letter suffixes
+    like ``"20a"``). Empty / unparseable → the empty string (no-agenda fallback).
+    """
+    if top_id is None:
+        return ""
+    text = str(top_id).strip()
+    match = _FIRST_INT_RE.search(text)
+    if match:
+        prefix = "zp" if text[:1].upper() == "Z" else "top"
+        return f"{prefix}{int(match.group(1))}"
+    return ""
+
+
+def make_speech_key(
+    *,
+    ep: int,
+    session: int,
+    speaker_slug: Optional[str] = None,
+    agenda_slug: Optional[str] = None,
+    firstname: Optional[str] = None,
+    lastname: Optional[str] = None,
+    speaker_name: Optional[str] = None,
+    full_name: Optional[str] = None,
+    agenda: Optional[str] = None,
+    agenda_type: Optional[str] = None,
+    top_id: Optional[str] = None,
+) -> str:
+    """Build the shared ``de-{ep}-{session}-{speaker_slug}-{agenda_slug}`` key.
+
+    Two call surfaces, both deterministic and byte-identical for the same speech:
+      - pre-slugified: pass ``speaker_slug`` + ``agenda_slug`` directly;
+      - raw: pass op's ``firstname``/``lastname`` (or DIP's ``speaker_name`` /
+        ``full_name``) and an ``agenda`` official title / ``agenda_type`` /
+        ``top_id`` — this helper slugifies them via the shared functions above.
+    """
+    if speaker_slug is None:
+        speaker_slug = slugify_speaker(
+            firstname=firstname,
+            lastname=lastname,
+            full_name=full_name if full_name is not None else speaker_name,
+        )
+    if agenda_slug is None:
+        if top_id is not None:
+            agenda_slug = agenda_slug_from_top_id(top_id)
+        else:
+            agenda_slug = agenda_slug_from_official(agenda, agenda_type)
+
+    return f"de-{ep}-{session}-{speaker_slug}-{agenda_slug}"

--- a/ai-backend/tests/ingestion/connectors/bundestag_speeches/__init__.py
+++ b/ai-backend/tests/ingestion/connectors/bundestag_speeches/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0

--- a/ai-backend/tests/ingestion/connectors/bundestag_speeches/__init__.py
+++ b/ai-backend/tests/ingestion/connectors/bundestag_speeches/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0

--- a/ai-backend/tests/ingestion/connectors/bundestag_speeches/conftest.py
+++ b/ai-backend/tests/ingestion/connectors/bundestag_speeches/conftest.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Shared pytest fixtures for the bundestag_speeches connector test suite.
+
+Provides:
+  - protocol_xml: text content of the trimmed plenary protocol XML fixture
+  - mdb_xml_path: Path to the tiny MdB-Stammdaten XML fixture
+
+The fixtures load from the local `fixtures/` directory — no I/O guard
+needed as they are committed static files (not network or live-service
+dependent).
+
+Pattern mirrors tests/ingestion/connectors/abgeordnetenwatch/conftest.py:
+  _FIXTURES_DIR = Path(__file__).parent / "fixtures"
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# Protocol XML fixture loader
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def protocol_xml() -> str:
+    """Return the text content of the trimmed plenary protocol XML fixture.
+
+    The fixture contains:
+      - Two main <rede> nodes: one SPD speaker, one BÜNDNIS 90/DIE GRÜNEN merged-name
+      - One <rede> with a speaker ID starting with "999" (non-MdB, droppable)
+      - A <kommentar> node inside a speech body (must be skipped by the parser)
+
+    Used by: test_parser.py.
+    """
+    return (_FIXTURES_DIR / "protocol_sample.xml").read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# MdB Stammdaten XML path fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mdb_xml_path() -> Path:
+    """Return the Path to the tiny MdB-Stammdaten XML fixture.
+
+    The fixture contains 3 MDB records:
+      - ID 11004870 (SPD): party resolved via PARTEI_KURZ
+      - ID 11004220 (BÜNDNIS 90/DIE GRÜNEN): party resolved via PARTEI_KURZ
+      - ID 11003444 (CDU/CSU): PARTEI_KURZ is empty; party only resolves via
+        WAHLPERIODEN INSTITUTION with INSART_LANG="Fraktion/Gruppe" and WP=21
+
+    Used by: test_mdb.py.
+    """
+    return _FIXTURES_DIR / "mdb_sample.xml"

--- a/ai-backend/tests/ingestion/connectors/bundestag_speeches/conftest.py
+++ b/ai-backend/tests/ingestion/connectors/bundestag_speeches/conftest.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/tests/ingestion/connectors/bundestag_speeches/fixtures/mdb_sample.xml
+++ b/ai-backend/tests/ingestion/connectors/bundestag_speeches/fixtures/mdb_sample.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Tiny MdB-Stammdaten XML test fixture — wave 0 scaffold.
+
+  Contains 3 MDB records:
+    1. MDB ID 11004870 (Olaf Scholz): party resolved via BIOGRAFISCHE_ANGABEN/PARTEI_KURZ = "SPD"
+    2. MDB ID 11004220 (Annalena Baerbock): party also resolved via PARTEI_KURZ = "BÜNDNIS 90/DIE GRÜNEN"
+    3. MDB ID 11003444 (Test member): PARTEI_KURZ is empty — party ONLY resolves via
+       WAHLPERIODEN/WAHLPERIODE/INSTITUTIONEN/INSTITUTION where INSART_LANG = "Fraktion/Gruppe"
+       and INS_LANG = "CDU/CSU" (tests latest_fraction_party fallback)
+
+  Source: hand-crafted for unit tests (not real MdB data, representative structure only).
+-->
+<DOCUMENT>
+  <MDB>
+    <ID>11004870</ID>
+    <NAMEN>
+      <NAME>
+        <VORNAME>Olaf</VORNAME>
+        <NACHNAME>Scholz</NACHNAME>
+      </NAME>
+    </NAMEN>
+    <BIOGRAFISCHE_ANGABEN>
+      <PARTEI_KURZ>SPD</PARTEI_KURZ>
+    </BIOGRAFISCHE_ANGABEN>
+    <WAHLPERIODEN>
+      <WAHLPERIODE>
+        <WP>21</WP>
+        <INSTITUTIONEN>
+          <INSTITUTION>
+            <INSART_LANG>Fraktion/Gruppe</INSART_LANG>
+            <INS_LANG>SPD</INS_LANG>
+          </INSTITUTION>
+        </INSTITUTIONEN>
+      </WAHLPERIODE>
+    </WAHLPERIODEN>
+  </MDB>
+  <MDB>
+    <ID>11004220</ID>
+    <NAMEN>
+      <NAME>
+        <VORNAME>Annalena</VORNAME>
+        <NACHNAME>Baerbock</NACHNAME>
+      </NAME>
+    </NAMEN>
+    <BIOGRAFISCHE_ANGABEN>
+      <PARTEI_KURZ>BÜNDNIS 90/DIE GRÜNEN</PARTEI_KURZ>
+    </BIOGRAFISCHE_ANGABEN>
+    <WAHLPERIODEN>
+      <WAHLPERIODE>
+        <WP>20</WP>
+        <INSTITUTIONEN>
+          <INSTITUTION>
+            <INSART_LANG>Fraktion/Gruppe</INSART_LANG>
+            <INS_LANG>BÜNDNIS 90/DIE GRÜNEN</INS_LANG>
+          </INSTITUTION>
+        </INSTITUTIONEN>
+      </WAHLPERIODE>
+    </WAHLPERIODEN>
+  </MDB>
+  <MDB>
+    <ID>11003444</ID>
+    <NAMEN>
+      <NAME>
+        <VORNAME>Friedrich</VORNAME>
+        <NACHNAME>Merz</NACHNAME>
+      </NAME>
+    </NAMEN>
+    <BIOGRAFISCHE_ANGABEN>
+      <PARTEI_KURZ></PARTEI_KURZ>
+    </BIOGRAFISCHE_ANGABEN>
+    <WAHLPERIODEN>
+      <WAHLPERIODE>
+        <WP>19</WP>
+        <INSTITUTIONEN>
+          <INSTITUTION>
+            <INSART_LANG>Ausschuss</INSART_LANG>
+            <INS_LANG>Haushaltsausschuss</INS_LANG>
+          </INSTITUTION>
+        </INSTITUTIONEN>
+      </WAHLPERIODE>
+      <WAHLPERIODE>
+        <WP>21</WP>
+        <INSTITUTIONEN>
+          <INSTITUTION>
+            <INSART_LANG>Fraktion/Gruppe</INSART_LANG>
+            <INS_LANG>CDU/CSU</INS_LANG>
+          </INSTITUTION>
+        </INSTITUTIONEN>
+      </WAHLPERIODE>
+    </WAHLPERIODEN>
+  </MDB>
+</DOCUMENT>

--- a/ai-backend/tests/ingestion/connectors/bundestag_speeches/fixtures/protocol_sample.xml
+++ b/ai-backend/tests/ingestion/connectors/bundestag_speeches/fixtures/protocol_sample.xml
@@ -8,8 +8,13 @@
     - <rede id="ID215000200">: merged-name speaker whose structured <name> metadata
       is suspicious (merged first+last names) but whose redner.tail label
       "Annalena Baerbock (BÜNDNIS 90/DIE GRÜNEN)" is correct — parser uses tail
-    - <rede id="ID215000300">: non-MdB speaker with ID starting with "999" — must be
-      droppable by the connector (no MdB record, not a parliamentary member)
+    - <rede id="ID215000300">: non-MdB speaker with ID starting with "999" —
+      kept by the connector (government/Bundesrat speeches are real content);
+      party resolves via MdB name lookup or quarantines as "unbekannt"
+
+  Citation coordinates: the vorspann inhaltsverzeichnis carries one
+  <xref ref-type="rede"> per rede (printed page pnr + quadrant div), and the
+  root's start-seitennr anchors the printed→PDF page offset.
 
   Protocol attributes (trimmed, non-authoritative — for unit tests only):
     Datum: 2026-06-15
@@ -24,6 +29,14 @@
       merged first+last names ("AnnalenaBarb" + "ock"), while the correct label
       "Annalena Baerbock (BÜNDNIS 90/DIE GRÜNEN)" appears in redner.tail.
 -->
+<dbtplenarprotokoll wahlperiode="21" sitzung-nr="99" sitzung-datum="15.06.2026" start-seitennr="12000">
+<vorspann>
+  <inhaltsverzeichnis>
+    <ivz-eintrag><xref ref-type="rede" rid="ID215000100" pnr="12001" div="A"/></ivz-eintrag>
+    <ivz-eintrag><xref ref-type="rede" rid="ID215000200" pnr="12003" div="C"/></ivz-eintrag>
+    <ivz-eintrag><xref ref-type="rede" rid="ID215000300" pnr="12005" div="B"/></ivz-eintrag>
+  </inhaltsverzeichnis>
+</vorspann>
 <sitzungsverlauf>
   <sitzungstitel>99. Sitzung des Deutschen Bundestages, 15. Juni 2026</sitzungstitel>
   <rede id="ID215000100">
@@ -79,3 +92,4 @@
     </p>
   </rede>
 </sitzungsverlauf>
+</dbtplenarprotokoll>

--- a/ai-backend/tests/ingestion/connectors/bundestag_speeches/fixtures/protocol_sample.xml
+++ b/ai-backend/tests/ingestion/connectors/bundestag_speeches/fixtures/protocol_sample.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Trimmed plenary protocol XML test fixture — wave 0 scaffold.
+
+  Contains:
+    - <rede id="ID215000100">: normal speaker (SPD, valid MdB ID) with body paragraphs
+      and an inline <kommentar> that must be skipped
+    - <rede id="ID215000200">: merged-name speaker whose structured <name> metadata
+      is suspicious (merged first+last names) but whose redner.tail label
+      "Annalena Baerbock (BÜNDNIS 90/DIE GRÜNEN)" is correct — parser uses tail
+    - <rede id="ID215000300">: non-MdB speaker with ID starting with "999" — must be
+      droppable by the connector (no MdB record, not a parliamentary member)
+
+  Protocol attributes (trimmed, non-authoritative — for unit tests only):
+    Datum: 2026-06-15
+    Wahlperiode: 21
+    Sitzungsnr: 99
+    Protokoll-ID: 21/99
+
+  Fixture notes:
+    - The SPD speech uses the real DIP XML pattern: visible label in redner.tail
+      (text after </redner> inside <p klasse="redner">).
+    - The Baerbock speech uses the merged-name pattern: <name> has suspicious
+      merged first+last names ("AnnalenaBarb" + "ock"), while the correct label
+      "Annalena Baerbock (BÜNDNIS 90/DIE GRÜNEN)" appears in redner.tail.
+-->
+<sitzungsverlauf>
+  <sitzungstitel>99. Sitzung des Deutschen Bundestages, 15. Juni 2026</sitzungstitel>
+  <rede id="ID215000100">
+    <p klasse="redner">
+      <redner id="11004870">
+        <name>
+          <vorname>Olaf</vorname>
+          <nachname>Scholz</nachname>
+          <fraktion>SPD</fraktion>
+        </name>
+      </redner>Olaf Scholz (SPD):</p>
+    <p klasse="J">
+      Sehr geehrte Damen und Herren, wir diskutieren heute über die Zukunft der
+      Energiewende in Deutschland. Erneuerbare Energien sind der Schlüssel zu
+      unserer Klimapolitik.
+    </p>
+    <kommentar>(Beifall bei der SPD)</kommentar>
+    <p klasse="J">
+      Wir müssen investieren und gemeinsam handeln. Nur so können wir die
+      Klimaziele bis 2030 erreichen.
+    </p>
+  </rede>
+  <rede id="ID215000200">
+    <p klasse="redner">
+      <redner id="11004220">
+        <name>
+          <vorname>AnnalenaBarb</vorname>
+          <nachname>ock</nachname>
+          <fraktion>BÜNDNIS 90/DIE GRÜNEN</fraktion>
+        </name>
+      </redner>Annalena Baerbock (BÜNDNIS 90/DIE GRÜNEN):</p>
+    <p klasse="J">
+      Vielen Dank, Herr Präsident. Die Klimakrise erfordert sofortiges Handeln.
+      Wir brauchen eine ambitionierte Klimapolitik, die auch soziale Gerechtigkeit
+      sicherstellt.
+    </p>
+    <kommentar>(Zurufe von der AfD)</kommentar>
+    <p klasse="J">
+      Deshalb setzen wir auf eine ökologische Transformation der Wirtschaft.
+    </p>
+  </rede>
+  <rede id="ID215000300">
+    <p klasse="redner">
+      <redner id="99900001">
+        <name>
+          <vorname>Gast</vorname>
+          <nachname>Redner</nachname>
+          <fraktion>fraktionslos</fraktion>
+        </name>
+      </redner>Gast Redner (fraktionslos):</p>
+    <p klasse="J">
+      Als Sachverständiger möchte ich auf die technischen Aspekte hinweisen.
+    </p>
+  </rede>
+</sitzungsverlauf>

--- a/ai-backend/tests/ingestion/connectors/bundestag_speeches/test_corpus.py
+++ b/ai-backend/tests/ingestion/connectors/bundestag_speeches/test_corpus.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -508,6 +508,8 @@ def test_bulk_stamps_external_id_from_date() -> None:
     try:
         # Mock Qdrant and embeddings so we never touch the real services.
         mock_qdrant = MagicMock()
+        # The post-upsert orphan prune scrolls the footprint; nothing stored.
+        mock_qdrant.scroll.return_value = ([], None)
         mock_embed = MagicMock()
         # embed_documents must return a valid-dimension vector for _upsert_chunks.
         # Import EMBEDDING_DIM for correctness.
@@ -604,4 +606,115 @@ def test_dip_chunk_content_hash_present_and_change_sensitive() -> None:
     changed_records = build_chunk_records(changed_speech)
     assert changed_records[0].content_hash != records[0].content_hash, (
         "changing the chunk text must change content_hash"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Citation coordinates — page in title, #page anchor, provenance in hash
+# ---------------------------------------------------------------------------
+
+
+def _page_speech(**overrides: object) -> dict:
+    speech = {
+        "id": "IDPAGE1",
+        "text": "Eine Rede mit Seitenangabe im Protokoll.",
+        "date": "2026-06-15",
+        "party": "SPD",
+        "speaker_name": "Test Person",
+        "protocol_id": "21/99",
+        "protocol_api_id": "5555",
+        "pdf_url": "https://dserver.bundestag.de/btp/21/2199.pdf",
+        "wahlperiode": 21,
+        "xml_rede_id": "IDPAGE1",
+        "source_page": "12003",
+        "page_quadrant": "C",
+        "pdf_page": 4,
+    }
+    speech.update(overrides)
+    return speech
+
+
+def test_citation_carries_page_and_pdf_anchor() -> None:
+    """The printed page reaches the citation title, the PDF page reaches the
+    URL anchor, and both coordinates land in meta."""
+    records = build_chunk_records(_page_speech())
+    assert records, "expected at least one chunk"
+    rec = records[0]
+    assert rec.citation_title.endswith(", S. 12003)"), rec.citation_title
+    assert rec.citation_url == "https://dserver.bundestag.de/btp/21/2199.pdf#page=4"
+    assert rec.meta is not None
+    assert rec.meta.get("source_page") == "12003"
+    assert rec.meta.get("page_quadrant") == "C"
+
+
+def test_citation_without_pdf_page_keeps_plain_url() -> None:
+    """No derivable PDF page → no guessed anchor; printed page still cited."""
+    records = build_chunk_records(_page_speech(pdf_page=None))
+    rec = records[0]
+    assert rec.citation_url == "https://dserver.bundestag.de/btp/21/2199.pdf"
+    assert ", S. 12003)" in rec.citation_title
+
+
+def test_citation_change_changes_content_hash() -> None:
+    """A citation-only correction (page/URL) must change content_hash so a
+    refresh re-writes the stored point instead of keeping the stale citation."""
+    base = build_chunk_records(_page_speech())[0]
+    moved = build_chunk_records(_page_speech(source_page="12005", pdf_page=6))[0]
+    assert base.content_hash != moved.content_hash
+
+
+def test_string_wahlperiode_is_coerced_not_fatal() -> None:
+    """A bulk JSONL row can carry wahlperiode as a string — the mapper must
+    coerce it (and degrade garbage to None) instead of raising."""
+    ok = build_chunk_records(_page_speech(wahlperiode="21"))
+    assert ok and ok[0].wahlperiode == 21
+    degraded = build_chunk_records(_page_speech(wahlperiode="einundzwanzig"))
+    assert degraded and degraded[0].wahlperiode is None
+
+
+def test_bulk_prunes_shrunk_speech_orphans_after_upsert() -> None:
+    """A re-chunked speech that SHRINKS leaves no stale higher-index points:
+    the bulk flush deletes orphans only AFTER the replacement upsert."""
+    import json as _json
+    import tempfile
+    from pathlib import Path
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from src.ingestion.connectors.bundestag_speeches.bulk import ingest
+    from src.ingestion.ids import compute_chunk_id, compute_source_item_id
+
+    speech = _page_speech(text="Kurze Rede nach der Korrektur.")
+    siid = compute_source_item_id(
+        "parliamentary_speech", str(speech["id"]), source="dip"
+    )
+    kept_id = str(compute_chunk_id(siid, 0))
+    stale_id = str(compute_chunk_id(siid, 1))  # from the longer pre-correction text
+
+    calls: list[str] = []
+    mock_qdrant = MagicMock()
+    mock_qdrant.upsert.side_effect = lambda **kw: calls.append("upsert")
+    mock_qdrant.scroll.return_value = (
+        [
+            SimpleNamespace(id=kept_id, payload={"source_item_id": str(siid)}),
+            SimpleNamespace(id=stale_id, payload={"source_item_id": str(siid)}),
+        ],
+        None,
+    )
+    mock_qdrant.delete.side_effect = lambda **kw: calls.append("delete")
+    mock_embed = MagicMock()
+    mock_embed.embed_documents.side_effect = lambda texts: [[0.0] * 3072 for _ in texts]
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "speeches.jsonl"
+        path.write_text(_json.dumps(speech) + "\n", encoding="utf-8")
+        processed, chunks = ingest(path, mock_qdrant, mock_embed)
+
+    assert processed == 1 and chunks == 1
+    assert calls == ["upsert", "delete"], (
+        f"orphan delete must happen AFTER the replacement upsert, got {calls}"
+    )
+    deleted = mock_qdrant.delete.call_args.kwargs["points_selector"].points
+    assert deleted == [stale_id], (
+        f"only the stale higher-index point may be deleted, got {deleted}"
     )

--- a/ai-backend/tests/ingestion/connectors/bundestag_speeches/test_corpus.py
+++ b/ai-backend/tests/ingestion/connectors/bundestag_speeches/test_corpus.py
@@ -1,0 +1,607 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Tests for bundestag_speeches.mappers.corpus:
+  - build_chunk_records: ChunkRecord list from a speech dict
+  - chunk_text: tokenized splitting (port from tests/ingestion/test_ingest_speeches.py)
+  - party_to_slug: full PARTY_ALIASES label set → canonical slugs (TestPartyToSlug)
+  - external_id stamping: connector stamps YYYYMMDD on chunk via model_copy (test_external_id_stamp)
+
+NOTE on test_external_id_stamp:
+  The mapper's build_chunk_records DOES NOT set external_id (it defaults to None per the
+  legacy contract). external_id is stamped by the CONNECTOR's normalize() via model_copy
+  AFTER build_chunk_records returns. The test_external_id_stamp test therefore verifies
+  the Pydantic model_copy mechanics at the mapper level; the connector-level end-to-end
+  test lives in test_discover.py.
+
+NOTE on external_id legacy inversion:
+  The legacy test_ingest_speeches.py::test_external_id_is_none asserted external_id=None
+  (the old behaviour). In this phase, speech chunks MUST have external_id=YYYYMMDD stamped
+  by the connector. These tests expect the NEW behaviour:
+    - build_chunk_records itself leaves external_id=None (mapper is neutral)
+    - connector.normalize() stamps YYYYMMDD via model_copy (tested in test_discover.py)
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from src.ingestion.connectors.bundestag_speeches.mappers.corpus import (
+    build_chunk_records,
+    chunk_text,
+    party_to_slug,
+)
+
+from src.ingestion.schemas import AuthorityTier, ChunkRecord, SourceType
+
+
+# ---------------------------------------------------------------------------
+# TestPartyToSlug — full PARTY_ALIASES label set
+# ---------------------------------------------------------------------------
+
+
+class TestPartyToSlug:
+    """party_to_slug maps all known party label strings to canonical slugs."""
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            # Standard labels (from PARTY_ALIASES)
+            ("SPD", "spd"),
+            ("spd", "spd"),
+            ("CDU/CSU", "cdu"),
+            ("CDU", "cdu"),
+            # Standalone CSU is a DISTINCT tenant (aligned with AW + csu manifesto).
+            # Joint CDU/CSU label maps to "cdu" (Union fraction, not splittable from source).
+            ("CSU", "csu"),
+            ("csu", "csu"),
+            ("FDP", "fdp"),
+            ("fdp", "fdp"),
+            ("AfD", "afd"),
+            ("afd", "afd"),
+            ("BÜNDNIS 90/DIE GRÜNEN", "gruene"),
+            ("bündnis 90/die grünen", "gruene"),
+            # Soft-hyphen variant (U+00AD) — AW connector edge case
+            ("BÜNDNIS 90/DIE GRÜNEN", "gruene"),
+            ("DIE LINKE", "linke"),
+            ("die linke", "linke"),
+            ("BSW", "bsw"),
+            ("bsw", "bsw"),
+            ("fraktionslos", "fraktionslos"),
+            ("FRAKTIONSLOS", "fraktionslos"),
+        ],
+    )
+    def test_known_parties(self, raw: str, expected: str) -> None:
+        """Known party strings map to the expected canonical slug."""
+        assert party_to_slug(raw) == expected, (
+            f"party_to_slug({raw!r}) should return {expected!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "Completely Unknown Party",
+            "Piraten",
+            "DSU",
+            "",
+            "  ",
+        ],
+    )
+    def test_unknown_parties_return_unbekannt(self, raw: str) -> None:
+        """Unknown or empty party strings map to 'unbekannt'."""
+        assert party_to_slug(raw) == "unbekannt", (
+            f"party_to_slug({raw!r}) should return 'unbekannt'"
+        )
+
+    def test_none_returns_unbekannt(self) -> None:
+        """None party maps to 'unbekannt'."""
+        assert party_to_slug(None) == "unbekannt"  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# TestChunkText — splitting behaviour (ported from test_ingest_speeches.py)
+# ---------------------------------------------------------------------------
+
+
+class TestChunkText:
+    """chunk_text splits over-long text and returns short text as-is."""
+
+    def test_empty_text_returns_empty_list(self) -> None:
+        """Empty string yields no chunks."""
+        assert chunk_text("") == []
+
+    def test_whitespace_only_returns_empty_list(self) -> None:
+        """Whitespace-only string yields no chunks."""
+        assert chunk_text("   \n\t  ") == []
+
+    def test_short_text_single_chunk(self) -> None:
+        """Text under the size limit is returned as a single chunk equal to input."""
+        text = "Hello world. This is a short speech."
+        assert chunk_text(text) == [text]
+
+    def test_long_text_splits_into_multiple_nonempty_chunks(self) -> None:
+        """Text over the character limit splits into multiple non-empty chunks."""
+        text = " ".join(f"Satz Nummer {i} mit etwas Inhalt." for i in range(300))
+        result = chunk_text(text, chunk_size=200, chunk_overlap=20)
+        assert len(result) > 1
+        assert all(c.strip() for c in result)
+
+
+# ---------------------------------------------------------------------------
+# Sample speech dicts for build_chunk_records tests
+# ---------------------------------------------------------------------------
+
+_SAMPLE_SPEECH: dict = {
+    "xml_rede_id": "ID215000100",
+    "speaker_xml_id": "11004870",
+    "text": "Sehr geehrte Damen und Herren, ich spreche heute über die Energiewende.",
+    "date": "2021-09-15",
+    "party": "SPD",
+    "speaker_name": "Olaf Scholz",
+    "protocol_id": "21/99",
+    "pdf_url": "https://dserver.bundestag.de/btp/21/2100099.pdf",
+    "wahlperiode": 21,
+    "protocol_api_id": "api-proto-99",
+}
+
+_SAMPLE_SPEECH_NO_META: dict = {
+    "xml_rede_id": "ID215000199",
+    "speaker_xml_id": "11004870",
+    "text": "Sehr geehrte Damen und Herren, kurze Rede.",
+    "date": "2021-09-15",
+    "party": "SPD",
+    "speaker_name": "Olaf Scholz",
+    "protocol_id": "21/99",
+    "pdf_url": "https://dserver.bundestag.de/btp/21/2100099.pdf",
+}
+
+
+# ---------------------------------------------------------------------------
+# TestBuildChunkRecords — valid ChunkRecord from speech dict (ported from test_ingest_speeches.py)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildChunkRecords:
+    """build_chunk_records produces valid, frozen ChunkRecords."""
+
+    def test_returns_list_of_chunk_records(self) -> None:
+        """build_chunk_records must return a list of ChunkRecord instances."""
+        result = build_chunk_records(_SAMPLE_SPEECH)
+        assert isinstance(result, list)
+        assert len(result) >= 1
+        for rec in result:
+            assert isinstance(rec, ChunkRecord)
+
+    def test_party_slug_mapped(self) -> None:
+        """party_id is the canonical slug for the speech party."""
+        result = build_chunk_records(_SAMPLE_SPEECH)
+        assert result[0].party_id == "spd"
+
+    def test_source_type_parliamentary_speech(self) -> None:
+        """source_type must be PARLIAMENTARY_SPEECH."""
+        result = build_chunk_records(_SAMPLE_SPEECH)
+        assert result[0].source_type == SourceType.PARLIAMENTARY_SPEECH
+
+    def test_authority_tier_factual_record(self) -> None:
+        """authority_tier must be FACTUAL_RECORD (unified with op — a plenary
+        speech is a factual parliamentary record regardless of transport)."""
+        result = build_chunk_records(_SAMPLE_SPEECH)
+        assert result[0].authority_tier == AuthorityTier.FACTUAL_RECORD
+
+    def test_region_is_de(self) -> None:
+        """region must be 'DE'."""
+        result = build_chunk_records(_SAMPLE_SPEECH)
+        assert result[0].region == "DE"
+
+    def test_publish_date_parsed(self) -> None:
+        """publish_date must equal the speech date."""
+        result = build_chunk_records(_SAMPLE_SPEECH)
+        assert result[0].publish_date == date(2021, 9, 15)
+
+    def test_citation_url_set(self) -> None:
+        """citation_url must equal speech pdf_url."""
+        result = build_chunk_records(_SAMPLE_SPEECH)
+        assert (
+            result[0].citation_url == "https://dserver.bundestag.de/btp/21/2100099.pdf"
+        )
+
+    def test_citation_title_contains_speaker_and_date(self) -> None:
+        """citation_title must include speaker_name, date, and protocol_id."""
+        result = build_chunk_records(_SAMPLE_SPEECH)
+        title = result[0].citation_title or ""
+        assert "Olaf Scholz" in title
+        assert "2021-09-15" in title
+        assert "21/99" in title
+
+    def test_party_ids_is_none(self) -> None:
+        """party_ids must be None for speech (not vote)."""
+        result = build_chunk_records(_SAMPLE_SPEECH)
+        for rec in result:
+            assert rec.party_ids is None
+
+    def test_empty_text_returns_no_chunks(self) -> None:
+        """Speeches with empty/whitespace-only text yield an empty list."""
+        speech_empty = {**_SAMPLE_SPEECH, "text": ""}
+        assert build_chunk_records(speech_empty) == []
+
+        speech_ws = {**_SAMPLE_SPEECH, "text": "   \n  "}
+        assert build_chunk_records(speech_ws) == []
+
+    def test_chunk_index_sequential(self) -> None:
+        """chunk_index values must be 0, 1, 2, ... for multi-chunk speeches."""
+        long_text = " ".join([f"token{i}" for i in range(3000)])
+        long_speech = {**_SAMPLE_SPEECH, "text": long_text}
+        records = build_chunk_records(long_speech)
+        for expected_index, rec in enumerate(records):
+            assert rec.chunk_index == expected_index
+
+    def test_deterministic_source_item_id(self) -> None:
+        """Same speech id always produces the same source_item_id (UUID5 determinism)."""
+        r1 = build_chunk_records(_SAMPLE_SPEECH)
+        r2 = build_chunk_records(_SAMPLE_SPEECH)
+        assert r1[0].source_item_id == r2[0].source_item_id
+
+    def test_chunk_key_format(self) -> None:
+        """chunk_key must follow the '{source_item_id}:{chunk_index:04d}' format."""
+        result = build_chunk_records(_SAMPLE_SPEECH)
+        for rec in result:
+            expected_key = f"{rec.source_item_id}:{rec.chunk_index:04d}"
+            assert rec.chunk_key == expected_key
+
+    def test_record_is_frozen(self) -> None:
+        """ChunkRecord must be frozen (immutable)."""
+        result = build_chunk_records(_SAMPLE_SPEECH)
+        rec = result[0]
+        with pytest.raises(Exception):  # ValidationError or TypeError
+            rec.party_id = "mutated"  # type: ignore[misc]
+
+    def test_wahlperiode_stamped_from_speech(self) -> None:
+        """wahlperiode is set from the speech dict when present."""
+        result = build_chunk_records(_SAMPLE_SPEECH)
+        for rec in result:
+            assert rec.wahlperiode == 21
+
+    def test_wahlperiode_none_when_absent(self) -> None:
+        """wahlperiode is None when not present in speech dict."""
+        result = build_chunk_records(_SAMPLE_SPEECH_NO_META)
+        for rec in result:
+            assert rec.wahlperiode is None
+
+    def test_speech_chunk_dump_has_no_vote_keys(self) -> None:
+        """Speech chunk's exclude_none dump must not contain vote envelope keys."""
+        result = build_chunk_records(_SAMPLE_SPEECH_NO_META)
+        for rec in result:
+            dumped = rec.model_dump(mode="json", exclude_none=True)
+            assert "vote_results" not in dumped
+            assert "motion_outcome" not in dumped
+            assert "party_ids" not in dumped
+            # NOTE: external_id may be absent from dump since build_chunk_records
+            # leaves it None; the connector stamps it via model_copy in normalize()
+            assert "external_id" not in dumped
+
+
+# ---------------------------------------------------------------------------
+# test_external_id_stamp — connector normalize() stamps YYYYMMDD
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# TestDipSpeechKeyAndSource — shared speech_key + source='dip'
+# ---------------------------------------------------------------------------
+
+
+class TestDipSpeechKeyAndSource:
+    """DIP ChunkRecords carry source='dip' and a shared, op-parity speech_key."""
+
+    def test_source_is_dip(self) -> None:
+        """Every DIP chunk carries source == 'dip' (discriminator)."""
+        for rec in build_chunk_records(_SAMPLE_SPEECH):
+            assert rec.source == "dip"
+
+    def test_authority_tier_matches_op(self) -> None:
+        """DIP authority_tier is FACTUAL_RECORD, matching the op mapper."""
+        for rec in build_chunk_records(_SAMPLE_SPEECH):
+            assert rec.authority_tier == AuthorityTier.FACTUAL_RECORD
+
+    def test_speech_key_shape(self) -> None:
+        """speech_key follows de-{wp}-{session}-{slug}-{agenda_slug} (empty agenda ok)."""
+        rec = build_chunk_records(_SAMPLE_SPEECH)[0]
+        assert rec.speech_key == "de-21-99-olaf-scholz-"
+
+    def test_speech_key_with_agenda(self) -> None:
+        """agenda_top_id threads into the agenda component (top-id 20 → top20)."""
+        speech = {**_SAMPLE_SPEECH, "agenda_top_id": "20"}
+        rec = build_chunk_records(speech)[0]
+        assert rec.speech_key == "de-21-99-olaf-scholz-top20"
+
+    def test_op_dip_parity_via_mapper(self) -> None:
+        """DIP mapper key == op helper key for the SAME real speech.
+
+        DIP feeds a merged speaker_name with an academic title + a top-id; op feeds
+        discrete firstname/lastname + an official agenda title. Both must derive the
+        identical byte string.
+        """
+        from src.ingestion.speech_key import make_speech_key
+
+        dip_speech = {
+            **_SAMPLE_SPEECH,
+            "wahlperiode": 20,
+            "protocol_id": "20/101",
+            "speaker_name": "Dr. Mareike Lotte Wulf",
+            "agenda_top_id": "20",
+        }
+        dip_key = build_chunk_records(dip_speech)[0].speech_key
+        op_key = make_speech_key(
+            ep=20,
+            session=101,
+            firstname="Mareike Lotte",
+            lastname="Wulf",
+            agenda="Tagesordnungspunkt 20",
+        )
+        assert dip_key == op_key == "de-20-101-mareike-lotte-wulf-top20"
+
+    def test_speech_key_none_on_unparseable_session(self) -> None:
+        """Unparseable protocol_id/session → speech_key None (no mismatched key)."""
+        speech = {**_SAMPLE_SPEECH, "protocol_id": "internal-5678"}
+        rec = build_chunk_records(speech)[0]
+        assert rec.speech_key is None
+
+    def test_speech_key_none_on_unparseable_wahlperiode(self) -> None:
+        """Missing/unparseable wahlperiode → speech_key None."""
+        speech = {k: v for k, v in _SAMPLE_SPEECH.items() if k != "wahlperiode"}
+        rec = build_chunk_records(speech)[0]
+        assert rec.speech_key is None
+
+
+# ---------------------------------------------------------------------------
+# TestNormalizePartyCsu — CSU survives normalize_party as a distinct label
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizePartyCsu:
+    """normalize_party and is_known_party treat CSU as a standalone canonical label."""
+
+    def test_normalize_party_csu_returns_csu(self) -> None:
+        """normalize_party('CSU') must return 'CSU', not 'CDU/CSU'."""
+        from src.ingestion.connectors.bundestag_speeches.utils import normalize_party
+
+        assert normalize_party("CSU") == "CSU", (
+            "normalize_party('CSU') must return 'CSU' — CSU is a distinct tenant"
+        )
+
+    def test_normalize_party_cdu_returns_cdu(self) -> None:
+        """normalize_party('CDU') must return 'CDU' as its own canonical label."""
+        from src.ingestion.connectors.bundestag_speeches.utils import normalize_party
+
+        assert normalize_party("CDU") == "CDU", (
+            "normalize_party('CDU') must return 'CDU' — standalone CDU has its own label"
+        )
+
+    def test_normalize_party_joint_union_stays_cdu_csu(self) -> None:
+        """normalize_party('CDU/CSU') must return 'CDU/CSU' (joint Union fraktion label)."""
+        from src.ingestion.connectors.bundestag_speeches.utils import normalize_party
+
+        assert normalize_party("CDU/CSU") == "CDU/CSU", (
+            "normalize_party('CDU/CSU') must keep the joint Union fraktion label"
+        )
+
+    def test_is_known_party_csu(self) -> None:
+        """is_known_party('CSU') must return True after adding CSU as a VALID_PARTIES value."""
+        from src.ingestion.connectors.bundestag_speeches.utils import is_known_party
+
+        assert is_known_party("CSU") is True, (
+            "is_known_party('CSU') must be True — 'CSU' must be in VALID_PARTIES"
+        )
+
+    def test_is_known_party_cdu(self) -> None:
+        """is_known_party('CDU') must return True."""
+        from src.ingestion.connectors.bundestag_speeches.utils import is_known_party
+
+        assert is_known_party("CDU") is True, "is_known_party('CDU') must be True"
+
+    def test_is_known_party_joint_union(self) -> None:
+        """is_known_party('CDU/CSU') must remain True (joint Union fraktion)."""
+        from src.ingestion.connectors.bundestag_speeches.utils import is_known_party
+
+        assert is_known_party("CDU/CSU") is True, (
+            "is_known_party('CDU/CSU') must remain True"
+        )
+
+    @pytest.mark.parametrize(
+        "party",
+        ["SPD", "AfD", "DIE LINKE", "BSW", "FRAKTIONSLOS"],
+    )
+    def test_non_union_parties_still_known(self, party: str) -> None:
+        """Non-Union parties must still be recognized after the CSU alias change."""
+        from src.ingestion.connectors.bundestag_speeches.utils import (
+            is_known_party,
+            normalize_party,
+        )
+
+        assert is_known_party(party) is True, (
+            f"is_known_party({party!r}) must still be True"
+        )
+        # normalize_party must return a non-None canonical label
+        assert normalize_party(party) is not None, (
+            f"normalize_party({party!r}) must return a canonical label, not None"
+        )
+
+    def test_party_to_slug_csu_distinct(self) -> None:
+        """party_to_slug('CSU') == 'csu' (already in _PARTY_SLUG_MAP — verify not changed)."""
+        assert party_to_slug("CSU") == "csu"
+
+    def test_party_to_slug_cdu_is_cdu(self) -> None:
+        """party_to_slug('CDU') == 'cdu'."""
+        assert party_to_slug("CDU") == "cdu"
+
+    def test_party_to_slug_joint_union_is_cdu(self) -> None:
+        """party_to_slug('CDU/CSU') == 'cdu' (joint Union label maps to cdu slug)."""
+        assert party_to_slug("CDU/CSU") == "cdu"
+
+
+def test_external_id_stamp() -> None:
+    """Connector normalize() stamps external_id=YYYYMMDD on every chunk via model_copy.
+
+    NOTE: This test is intentionally placed here. If the connector is not yet
+    importable, the module-level ImportError guard above handles it.
+
+    For now: verify that a ChunkRecord produced by build_chunk_records (external_id=None)
+    can be patched to YYYYMMDD via model_copy — confirming the Pydantic mechanics work.
+    """
+    records = build_chunk_records(_SAMPLE_SPEECH)
+    assert len(records) >= 1
+
+    # Simulate what connector.normalize() does: stamp external_id=YYYYMMDD via model_copy
+    protocol_datum = "2026-06-15"
+    external_id = int(protocol_datum.replace("-", ""))  # 20260615
+
+    patched = [c.model_copy(update={"external_id": external_id}) for c in records]
+
+    for rec in patched:
+        assert rec.external_id == 20260615, (
+            f"external_id must be YYYYMMDD int 20260615, got {rec.external_id!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# bulk ingest stamps external_id=YYYYMMDD on backfill records
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_stamps_external_id_from_date() -> None:
+    """bulk.ingest() stamps external_id=YYYYMMDD on each chunk (regression test).
+
+    build_chunk_records leaves external_id=None (mapper neutrality).
+    The bulk backfill path must derive YYYYMMDD from the speech date and
+    stamp it via model_copy so get_cursor('parliamentary_speech') sees the
+    backfill and the first live run does not re-embed everything.
+    """
+    from unittest.mock import MagicMock
+
+    # Import the ingest function from bulk.py
+    from src.ingestion.connectors.bundestag_speeches.bulk import ingest
+    import json
+    import tempfile
+    from pathlib import Path
+
+    # Build a minimal speech JSONL (one speech with a known date)
+    speech = {
+        "id": "BULK-TEST-001",
+        "text": "Dies ist ein Test-Rede für die Prüfung der YYYYMMDD-Stempelung.",
+        "date": "2021-09-15",
+        "party": "SPD",
+        "speaker_name": "Test Redner",
+        "protocol_id": "20/1",
+        "pdf_url": None,
+        "wahlperiode": 20,
+    }
+    jsonl_content = json.dumps(speech) + "\n"
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+        f.write(jsonl_content)
+        tmp_path = Path(f.name)
+
+    try:
+        # Mock Qdrant and embeddings so we never touch the real services.
+        mock_qdrant = MagicMock()
+        mock_embed = MagicMock()
+        # embed_documents must return a valid-dimension vector for _upsert_chunks.
+        # Import EMBEDDING_DIM for correctness.
+        from src.ingestion.setup_collection import EMBEDDING_DIM
+
+        mock_embed.embed_documents.return_value = [[0.0] * EMBEDDING_DIM]
+
+        # Capture the chunks passed to _upsert_chunks via the qdrant.upsert call.
+        upserted_points: list = []
+
+        def _capture_upsert(collection_name, points, wait=True):
+            upserted_points.extend(points)
+
+        mock_qdrant.upsert.side_effect = _capture_upsert
+
+        processed, chunks = ingest(tmp_path, mock_qdrant, mock_embed, limit=None)
+
+        assert processed == 1, f"Expected 1 speech processed, got {processed}"
+        assert chunks >= 1, f"Expected at least 1 chunk, got {chunks}"
+        assert len(upserted_points) >= 1, "Expected at least one upserted point"
+
+        # The payload of each upserted point must carry external_id = 20210915 (YYYYMMDD).
+        for point in upserted_points:
+            payload = point.payload
+            assert payload.get("external_id") == 20210915, (
+                f"bulk chunk must have external_id=20210915 (YYYYMMDD), "
+                f"got {payload.get('external_id')!r}"
+            )
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def test_build_chunk_records_skips_missing_date() -> None:
+    """build_chunk_records returns [] on missing/unparseable date instead of fabricating."""
+    speech_no_date = {**_SAMPLE_SPEECH, "date": ""}
+    result = build_chunk_records(speech_no_date)
+    assert result == [], (
+        f"build_chunk_records must return [] for missing date, got {result!r}"
+    )
+
+    speech_bad_date = {**_SAMPLE_SPEECH, "date": "not-a-date"}
+    result2 = build_chunk_records(speech_bad_date)
+    assert result2 == [], (
+        f"build_chunk_records must return [] for unparseable date, got {result2!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# DipClient.pages() stops at the hard page cap
+# ---------------------------------------------------------------------------
+
+
+def test_dip_client_pages_stops_at_max_pages() -> None:
+    """DipClient.pages() stops after _MAX_PAGES pages instead of looping forever."""
+    from unittest.mock import patch
+    from src.ingestion.connectors.bundestag_speeches.client import DipClient
+    from src.ingestion.connectors.bundestag_speeches.constants import _MAX_PAGES
+
+    client = DipClient(api_key="test-key")
+
+    page_count = 0
+
+    def _always_has_next_cursor(endpoint, params=None):
+        nonlocal page_count
+        page_count += 1
+        # Return a cursor that always changes — simulates infinite pagination.
+        return {"documents": [], "cursor": f"cursor-{page_count}"}
+
+    with patch.object(client, "get", side_effect=_always_has_next_cursor):
+        pages = list(client.pages("/test-endpoint"))
+
+    assert len(pages) == _MAX_PAGES, (
+        f"DipClient.pages() must stop after {_MAX_PAGES} pages, got {len(pages)} pages"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (d) content_hash — DIP chunks must be change-aware
+# ---------------------------------------------------------------------------
+
+
+def test_dip_chunk_content_hash_present_and_change_sensitive() -> None:
+    """(d) DIP speech chunks stamp a per-chunk content_hash so an upstream
+    re-chunk or correction re-writes via run.py's change-aware guard."""
+    records = build_chunk_records(_SAMPLE_SPEECH)
+    assert records, "sample speech must produce records"
+    assert all(r.content_hash is not None for r in records), (
+        "every DIP chunk must stamp content_hash"
+    )
+
+    changed_speech = dict(
+        _SAMPLE_SPEECH, text=_SAMPLE_SPEECH["text"] + " Nachtrag zur Korrektur."
+    )
+    changed_records = build_chunk_records(changed_speech)
+    assert changed_records[0].content_hash != records[0].content_hash, (
+        "changing the chunk text must change content_hash"
+    )

--- a/ai-backend/tests/ingestion/connectors/bundestag_speeches/test_discover.py
+++ b/ai-backend/tests/ingestion/connectors/bundestag_speeches/test_discover.py
@@ -1,0 +1,354 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Tests for BundestagSpeechesConnector.discover() and the empty-protocol skip guard.
+
+Covers:
+  - discover(None): returns ALL protocol IDs sorted ascending (oldest-first)
+  - discover(since=20260601): applies f.datum.start floor; filters protocols before that date
+  - DIP DESC input → ascending output: regression guard
+  - test_empty_protocol_skips: normalize() raises ValueError for a protocol with zero
+    usable speeches so run_connector skip-and-continues without advancing cursor
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.ingestion.connectors.bundestag_speeches.connector import (
+    BundestagSpeechesConnector,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake DIP client (mirrors abgeordnetenwatch test _stub_client idiom)
+# ---------------------------------------------------------------------------
+
+
+class _FakeDipClient:
+    """Minimal DipClient stand-in for unit tests.
+
+    pages() yields each dict from the provided list in order.
+    DIP returns results DESCENDING by default; test inputs simulate that
+    to verify the connector re-sorts them ASCENDING.
+    """
+
+    def __init__(self, pages: list[dict]) -> None:
+        self._pages = pages
+
+    def pages(self, endpoint: str, params: dict) -> Any:  # noqa: ANN401
+        yield from self._pages
+
+
+def _make_connector_with_fake_client(pages: list[dict]) -> BundestagSpeechesConnector:
+    """Create a BundestagSpeechesConnector whose DipClient is replaced by _FakeDipClient."""
+    conn = object.__new__(BundestagSpeechesConnector)
+    # Bypass __init__ to avoid DIP_API_KEY env requirement in tests
+    conn._wahlperiode = 21  # type: ignore[attr-defined]
+    conn._client = _FakeDipClient(pages)  # type: ignore[attr-defined]
+    conn._protocols: dict = {}  # type: ignore[attr-defined]
+    # Pre-seed an (empty) lookup so discover() skips ensure_mdb_lookup: these
+    # tests exercise cursor/sort, not party resolution, and must not hit the network.
+    conn._mdb_lookup = {"by_id": {}, "by_name": {}}  # type: ignore[attr-defined]
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# TestDiscover — cursor, filtering, and ascending re-sort
+# ---------------------------------------------------------------------------
+
+# DIP returns newest-first (DESC). These fixtures simulate that.
+_DESC_PAGE = {
+    "documents": [
+        {"id": "200", "datum": "2026-06-15"},  # newest
+        {"id": "100", "datum": "2026-05-01"},  # older
+        {"id": "50", "datum": "2026-01-10"},  # oldest
+    ]
+}
+
+
+class TestDiscover:
+    """BundestagSpeechesConnector.discover() re-sorts DIP DESC output to ASC."""
+
+    def test_discover_none_returns_all_ascending(self) -> None:
+        """discover(None) returns all protocol IDs sorted ascending (oldest-first)."""
+        conn = _make_connector_with_fake_client([_DESC_PAGE])
+        ids = conn.discover(since=None)
+        assert ids == ["50", "100", "200"], (
+            f"discover(None) must return ascending IDs, got: {ids}"
+        )
+
+    def test_discover_resorts_ascending_from_dip_desc_input(self) -> None:
+        """DIP DESC input is re-sorted to ASC output (regression guard)."""
+        # Provide two pages, each with DESC-ordered documents
+        pages = [
+            {
+                "documents": [
+                    {"id": "2", "datum": "2026-06-15"},
+                    {"id": "1", "datum": "2026-05-01"},
+                ]
+            },
+            {"documents": [{"id": "3", "datum": "2026-06-20"}]},
+        ]
+        conn = _make_connector_with_fake_client(pages)
+        ids = conn.discover(since=None)
+        # Must come back ascending by (datum, id): id "1" < "2" < "3"
+        assert ids == ["1", "2", "3"], (
+            f"discover() must re-sort DIP DESC to ascending; got: {ids}"
+        )
+
+    def test_discover_with_since_applies_lookback_floor(self) -> None:
+        """discover(since=20260601) floors at since − LOOKBACK_DAYS (2026-04-02),
+        NOT at the raw since date — a protocol that transiently failed below the
+        max-external_id watermark must be re-discoverable within the window.
+
+        With the fake page: id "200" (2026-06-15) and id "100" (2026-05-01, inside
+        the 60-day lookback) remain; id "50" (2026-01-10, outside) is filtered.
+        """
+        conn = _make_connector_with_fake_client([_DESC_PAGE])
+        ids = conn.discover(since=20260601)
+        assert isinstance(ids, list)
+        assert "200" in ids
+        assert "100" in ids, (
+            "a protocol dated within the lookback window (since − LOOKBACK_DAYS) "
+            "must be re-discovered even though it is below the since watermark"
+        )
+        assert "50" not in ids, "protocols outside the lookback window stay excluded"
+        # Every returned protocol respects the LOOKBACK floor of 2026-04-02.
+        for pid in ids:
+            protocol = conn._protocols.get(pid, {})  # type: ignore[attr-defined]
+            datum = protocol.get("datum", "")
+            if datum:
+                assert datum >= "2026-04-02", (
+                    f"Protocol {pid} with datum {datum!r} is before the lookback floor"
+                )
+
+    def test_lookback_re_discovers_failed_protocol(self) -> None:
+        """(a) Regression: a protocol that failed on run 1 (below the resulting
+        max external_id) is returned by discover() on run 2 via the lookback."""
+        pages = [
+            {
+                "documents": [
+                    {
+                        "id": "900",
+                        "datum": "2026-06-01",
+                    },  # succeeded run 1 → cursor 20260601
+                    {"id": "899", "datum": "2026-05-20"},  # transiently FAILED run 1
+                ]
+            }
+        ]
+        conn = _make_connector_with_fake_client(pages)
+        ids = conn.discover(since=20260601)
+        assert "899" in ids, (
+            "a failed protocol dated within LOOKBACK_DAYS of the cursor must be "
+            "re-discovered on the next run"
+        )
+
+    def test_discover_caches_protocols(self) -> None:
+        """discover() populates self._protocols with the fetched protocol dicts."""
+        conn = _make_connector_with_fake_client([_DESC_PAGE])
+        ids = conn.discover(since=None)
+        # _protocols must be populated with each id
+        for pid in ids:
+            assert pid in conn._protocols  # type: ignore[attr-defined]
+
+    def test_discover_returns_list(self) -> None:
+        """discover() always returns a list, even for an empty DIP response."""
+        conn = _make_connector_with_fake_client([{"documents": []}])
+        ids = conn.discover(since=None)
+        assert isinstance(ids, list)
+        assert ids == []
+
+
+# ---------------------------------------------------------------------------
+# test_empty_protocol_skips — skip-and-warn via ValueError
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# TestRegistry — bundestag_speeches registered in CONNECTOR_FACTORIES
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    """bundestag_speeches is registered in CONNECTOR_FACTORIES."""
+
+    def test_bundestag_speeches_in_registry(self) -> None:
+        """bundestag_speeches must appear in CONNECTOR_FACTORIES.
+
+        NOTE: This test asserts membership ONLY — it does NOT invoke the factory.
+        Calling the factory constructs BundestagSpeechesConnector which calls
+        _require_dip_key(), which raises RuntimeError when DIP_API_KEY is unset.
+        Membership test stays green in CI without a DIP key set.
+        """
+        from src.ingestion.registry import CONNECTOR_FACTORIES
+
+        assert "bundestag_speeches" in CONNECTOR_FACTORIES, (
+            "bundestag_speeches must be registered in CONNECTOR_FACTORIES"
+        )
+
+    def test_registry_import_has_no_side_effects(self) -> None:
+        """Importing registry.py must not construct any connector.
+
+        The deferred-import factory pattern ensures that importing the module
+        does not trigger DIP_API_KEY lookup or any network calls.
+        """
+        import importlib
+        import sys
+
+        # Remove cached registry module to force a fresh import
+        sys.modules.pop("src.ingestion.registry", None)
+        # This import must succeed even when DIP_API_KEY is unset
+        registry_mod = importlib.import_module("src.ingestion.registry")
+        assert hasattr(registry_mod, "CONNECTOR_FACTORIES")
+        # bundestag_speeches is a key — the factory itself is not called
+        assert "bundestag_speeches" in registry_mod.CONNECTOR_FACTORIES
+
+
+# ---------------------------------------------------------------------------
+# TestCsuDisambiguation — Union/CDU/CSU fraktion → per-speaker party_id
+# ---------------------------------------------------------------------------
+
+
+class TestCsuDisambiguation:
+    """Connector refines 'CDU/CSU' fraktion speeches to csu/cdu per MdB speaker."""
+
+    # Minimal MdB lookup: one CSU record, one CDU/CSU record (joint-Union MdB)
+    _MDB_LOOKUP = {
+        "by_id": {
+            "11000001": {
+                "id": "11000001",
+                "names": ["Franz Mayer"],
+                "party": "CSU",
+            },
+            "11000002": {
+                "id": "11000002",
+                "names": ["Klaus Müller"],
+                "party": "CDU/CSU",
+            },
+        },
+        "by_name": {},
+    }
+
+    def _make_raw(self, speeches: list[dict]) -> dict:
+        """Build a normalize()-compatible raw dict with the mini MdB lookup."""
+        return {
+            "protocol": {
+                "id": "77777",
+                "datum": "2026-06-01",
+                "wahlperiode": 21,
+                "fundstelle": {"pdf_url": None},
+            },
+            "speeches": speeches,
+            "mdb_lookup": self._MDB_LOOKUP,
+        }
+
+    def test_union_speaker_resolving_to_csu_yields_csu_party_id(self) -> None:
+        """Speech with <fraktion> CDU/CSU whose MdB resolves to CSU → party_id='csu'."""
+        conn = _make_connector_with_fake_client([])
+        conn._mdb_lookup = self._MDB_LOOKUP  # type: ignore[attr-defined]
+        speeches = [
+            {
+                "speaker_xml_id": "11000001",  # CSU member
+                "speaker_name": "Franz Mayer",
+                "party": "CDU/CSU",  # fraktion tag (joint Union)
+                "text": "Ich spreche fuer die CSU.",
+                "xml_rede_id": "ID77001",
+            }
+        ]
+        raw = self._make_raw(speeches)
+        records = conn.normalize(raw)
+        assert len(records) >= 1
+        assert all(r.party_id == "csu" for r in records), (
+            f"Expected party_id='csu' for all chunks, got: {[r.party_id for r in records]}"
+        )
+
+    def test_union_speaker_resolving_to_cdu_stays_cdu(self) -> None:
+        """Speech with <fraktion> CDU/CSU whose MdB resolves to CDU/CSU → party_id='cdu'."""
+        conn = _make_connector_with_fake_client([])
+        conn._mdb_lookup = self._MDB_LOOKUP  # type: ignore[attr-defined]
+        speeches = [
+            {
+                "speaker_xml_id": "11000002",  # CDU/CSU member (not CSU-only)
+                "speaker_name": "Klaus Müller",
+                "party": "CDU/CSU",  # fraktion tag
+                "text": "Ich spreche fuer die Union.",
+                "xml_rede_id": "ID77002",
+            }
+        ]
+        raw = self._make_raw(speeches)
+        records = conn.normalize(raw)
+        assert len(records) >= 1
+        assert all(r.party_id == "cdu" for r in records), (
+            f"Expected party_id='cdu', got: {[r.party_id for r in records]}"
+        )
+
+    def test_non_union_speaker_unaffected_by_csu_refinement(self) -> None:
+        """SPD speaker is not touched by CSU disambiguation; party_id stays 'spd'."""
+        conn = _make_connector_with_fake_client([])
+        conn._mdb_lookup = self._MDB_LOOKUP  # type: ignore[attr-defined]
+        speeches = [
+            {
+                "speaker_xml_id": "11000003",  # not in MDB lookup at all
+                "speaker_name": "Hans Schmidt",
+                "party": "SPD",
+                "text": "Die SPD spricht fuer Gerechtigkeit.",
+                "xml_rede_id": "ID77003",
+            }
+        ]
+        raw = self._make_raw(speeches)
+        records = conn.normalize(raw)
+        assert len(records) >= 1
+        assert all(r.party_id == "spd" for r in records), (
+            f"Expected party_id='spd', got: {[r.party_id for r in records]}"
+        )
+
+    def test_union_speaker_with_no_mdb_match_stays_cdu(self) -> None:
+        """Union speaker with no MdB lookup match stays party_id='cdu' (no crash)."""
+        conn = _make_connector_with_fake_client([])
+        conn._mdb_lookup = self._MDB_LOOKUP  # type: ignore[attr-defined]
+        speeches = [
+            {
+                "speaker_xml_id": "11009999",  # not in MDB lookup
+                "speaker_name": "Unbekannter Redner",
+                "party": "CDU/CSU",
+                "text": "Meine Damen und Herren.",
+                "xml_rede_id": "ID77004",
+            }
+        ]
+        raw = self._make_raw(speeches)
+        records = conn.normalize(raw)
+        assert len(records) >= 1
+        assert all(r.party_id == "cdu" for r in records), (
+            f"Expected party_id='cdu' when MdB has no match, got: {[r.party_id for r in records]}"
+        )
+
+
+def test_empty_protocol_skips() -> None:
+    """normalize() raises ValueError for a protocol with zero usable speeches.
+
+    Verifies the skip-and-warn contract: run_connector catches ValueError,
+    logs a WARNING, and does NOT advance the cursor for empty/garbage protocols.
+
+    The raw dict passed to normalize() simulates a protocol whose speech list
+    is empty (e.g. no <rede> nodes parsed, or all speeches had no text).
+    """
+    conn = _make_connector_with_fake_client([])
+
+    # A raw payload with zero usable speeches
+    empty_raw: dict = {
+        "protocol": {"id": "99999", "datum": "2026-06-15", "wahlperiode": 21},
+        "speeches": [],
+        "mdb_lookup": {"by_id": {}, "by_name": {}},
+    }
+
+    with pytest.raises(ValueError, match="zero") as exc_info:
+        conn.normalize(empty_raw)
+
+    assert (
+        "zero" in str(exc_info.value).lower() or "speech" in str(exc_info.value).lower()
+    ), "ValueError message must mention 'zero' or 'speech' to aid skip-and-warn logging"

--- a/ai-backend/tests/ingestion/connectors/bundestag_speeches/test_discover.py
+++ b/ai-backend/tests/ingestion/connectors/bundestag_speeches/test_discover.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -7,8 +7,11 @@ Tests for BundestagSpeechesConnector.discover() and the empty-protocol skip guar
 
 Covers:
   - discover(None): returns ALL protocol IDs sorted ascending (oldest-first)
-  - discover(since=20260601): applies f.datum.start floor; filters protocols before that date
+  - set-difference discovery: ingested protocols excluded, never-stored ones
+    re-surface regardless of age, the runner cursor is ignored
+  - update sweep: recently-`aktualisiert` ingested protocols re-surface
   - DIP DESC input → ascending output: regression guard
+  - government (999…) speakers kept with name-lookup / quarantine attribution
   - test_empty_protocol_skips: normalize() raises ValueError for a protocol with zero
     usable speeches so run_connector skip-and-continues without advancing cursor
 """
@@ -42,6 +45,25 @@ class _FakeDipClient:
 
     def pages(self, endpoint: str, params: dict) -> Any:  # noqa: ANN401
         yield from self._pages
+
+
+class _FakeStore:
+    """Fake Qdrant client serving stored DIP parent keys for set-difference tests."""
+
+    def __init__(self, ingested_protocol_ids: list[str]) -> None:
+        self._ids = ingested_protocol_ids
+
+    def scroll(self, **kwargs: object) -> tuple:
+        from types import SimpleNamespace
+
+        points = [
+            SimpleNamespace(
+                id=f"pt-{pid}",
+                payload={"source_parent_key": f"parliamentary_speech:dip:{pid}"},
+            )
+            for pid in self._ids
+        ]
+        return (points, None)
 
 
 def _make_connector_with_fake_client(pages: list[dict]) -> BundestagSpeechesConnector:
@@ -101,51 +123,66 @@ class TestDiscover:
             f"discover() must re-sort DIP DESC to ascending; got: {ids}"
         )
 
-    def test_discover_with_since_applies_lookback_floor(self) -> None:
-        """discover(since=20260601) floors at since − LOOKBACK_DAYS (2026-04-02),
-        NOT at the raw since date — a protocol that transiently failed below the
-        max-external_id watermark must be re-discoverable within the window.
-
-        With the fake page: id "200" (2026-06-15) and id "100" (2026-05-01, inside
-        the 60-day lookback) remain; id "50" (2026-01-10, outside) is filtered.
-        """
+    def test_discover_ignores_since_cursor(self) -> None:
+        """The runner-derived cursor must NOT filter discovery: a cross-source
+        or cross-Wahlperiode max(external_id) once starved DIP backfills (a
+        stored 2026-07 op cursor made a WP20 run discover nothing). With
+        set-difference, a high since value changes nothing."""
         conn = _make_connector_with_fake_client([_DESC_PAGE])
-        ids = conn.discover(since=20260601)
-        assert isinstance(ids, list)
-        assert "200" in ids
-        assert "100" in ids, (
-            "a protocol dated within the lookback window (since − LOOKBACK_DAYS) "
-            "must be re-discovered even though it is below the since watermark"
+        ids = conn.discover(since=20260710)
+        assert ids == ["50", "100", "200"], (
+            f"set-difference discovery must ignore since entirely, got: {ids}"
         )
-        assert "50" not in ids, "protocols outside the lookback window stay excluded"
-        # Every returned protocol respects the LOOKBACK floor of 2026-04-02.
-        for pid in ids:
-            protocol = conn._protocols.get(pid, {})  # type: ignore[attr-defined]
-            datum = protocol.get("datum", "")
-            if datum:
-                assert datum >= "2026-04-02", (
-                    f"Protocol {pid} with datum {datum!r} is before the lookback floor"
-                )
 
-    def test_lookback_re_discovers_failed_protocol(self) -> None:
-        """(a) Regression: a protocol that failed on run 1 (below the resulting
-        max external_id) is returned by discover() on run 2 via the lookback."""
+    def test_set_difference_excludes_ingested_and_re_surfaces_failures(self) -> None:
+        """Stored protocols drop out of discovery; a protocol that FAILED on an
+        earlier run (never stored) re-surfaces regardless of how old it is —
+        the failure mode of the old 60-day lookback was permanent loss."""
+        conn = _make_connector_with_fake_client([_DESC_PAGE])
+        conn.bind_store(
+            _FakeStore(ingested_protocol_ids=["200"]), "wahlchat_chunks_test"
+        )
+        ids = conn.discover(since=None)
+        assert "200" not in ids, "an ingested protocol must not be re-discovered"
+        assert "50" in ids and "100" in ids, (
+            "never-stored protocols must re-surface regardless of age "
+            f"(no lookback cutoff); got: {ids}"
+        )
+
+    def test_update_sweep_re_surfaces_recently_updated_protocol(self) -> None:
+        """An ingested protocol whose DIP `aktualisiert` timestamp is recent is
+        re-discovered so upstream corrections propagate; one updated long ago
+        stays excluded."""
+        from datetime import date, timedelta
+
+        recent = (date.today() - timedelta(days=3)).isoformat()
         pages = [
             {
                 "documents": [
                     {
-                        "id": "900",
-                        "datum": "2026-06-01",
-                    },  # succeeded run 1 → cursor 20260601
-                    {"id": "899", "datum": "2026-05-20"},  # transiently FAILED run 1
+                        "id": "700",
+                        "datum": "2026-01-15",
+                        "aktualisiert": f"{recent}T09:00:00+02:00",
+                    },
+                    {
+                        "id": "701",
+                        "datum": "2026-01-20",
+                        "aktualisiert": "2026-01-21T09:00:00+02:00",
+                    },
                 ]
             }
         ]
         conn = _make_connector_with_fake_client(pages)
-        ids = conn.discover(since=20260601)
-        assert "899" in ids, (
-            "a failed protocol dated within LOOKBACK_DAYS of the cursor must be "
-            "re-discovered on the next run"
+        conn.bind_store(
+            _FakeStore(ingested_protocol_ids=["700", "701"]), "wahlchat_chunks_test"
+        )
+        ids = conn.discover(since=None)
+        assert "700" in ids, (
+            "a recently-updated ingested protocol must be re-surfaced "
+            "(corrections sweep)"
+        )
+        assert "701" not in ids, (
+            "an ingested protocol without a recent update stays excluded"
         )
 
     def test_discover_caches_protocols(self) -> None:
@@ -352,3 +389,85 @@ def test_empty_protocol_skips() -> None:
     assert (
         "zero" in str(exc_info.value).lower() or "speech" in str(exc_info.value).lower()
     ), "ValueError message must mention 'zero' or 'speech' to aid skip-and-warn logging"
+
+
+class TestGovernmentSpeakersKept:
+    """Non-MdB speakers (999… ids) are real content — kept, never dropped.
+
+    The 999… range covers federal/state ministers, state secretaries,
+    Ministerpräsidenten, and Bundesrat members, not just procedural chairs;
+    dropping the range removed entire government speeches from the corpus.
+    """
+
+    def _make_raw(self, speeches: list[dict], mdb_lookup: dict) -> dict:
+        return {
+            "protocol": {
+                "id": "88888",
+                "datum": "2026-06-01",
+                "wahlperiode": 21,
+                "dokumentnummer": "21/88",
+            },
+            "speeches": speeches,
+            "mdb_lookup": mdb_lookup,
+        }
+
+    def test_minister_who_is_mdb_resolves_party_by_name(self) -> None:
+        """A minister speaking under a 999… id who IS an MdB resolves to their
+        real party via the name lookup."""
+        from src.ingestion.connectors.bundestag_speeches.utils import (
+            normalize_name_for_lookup,
+        )
+
+        conn = _make_connector_with_fake_client([])
+        name_key = normalize_name_for_lookup("Erika Beispiel")
+        mdb_lookup = {
+            "by_id": {},
+            "by_name": {
+                name_key: {
+                    "id": "11002222",
+                    "names": ["Erika Beispiel"],
+                    "party": "SPD",
+                }
+            },
+        }
+        conn._mdb_lookup = mdb_lookup  # type: ignore[attr-defined]
+        speeches = [
+            {
+                "speaker_xml_id": "99900123",
+                "speaker_name": "Erika Beispiel",
+                "party": None,  # government speakers carry no <fraktion>
+                "text": "Als Bundesministerin erkläre ich die Position der Regierung.",
+                "xml_rede_id": "ID88801",
+            }
+        ]
+        records = conn.normalize(self._make_raw(speeches, mdb_lookup))
+        assert len(records) >= 1, "a 999… government speech must be KEPT"
+        assert all(r.party_id == "spd" for r in records), (
+            f"minister who is an MdB must resolve via name lookup, "
+            f"got: {[r.party_id for r in records]}"
+        )
+
+    def test_non_mdb_government_speaker_quarantines_not_dropped(self) -> None:
+        """A genuinely non-MdB speaker (e.g. a Ministerpräsident) is kept with
+        party_id 'unbekannt' instead of being silently removed."""
+        conn = _make_connector_with_fake_client([])
+        mdb_lookup: dict = {"by_id": {}, "by_name": {}}
+        conn._mdb_lookup = mdb_lookup  # type: ignore[attr-defined]
+        speeches = [
+            {
+                "speaker_xml_id": "99900456",
+                "speaker_name": "Alexander Schweitzer",
+                "party": None,
+                "text": "Als Ministerpräsident von Rheinland-Pfalz möchte ich betonen, "
+                "dass die Länder eng eingebunden werden müssen.",
+                "xml_rede_id": "ID88802",
+            }
+        ]
+        records = conn.normalize(self._make_raw(speeches, mdb_lookup))
+        assert len(records) >= 1, (
+            "a non-MdB government speech must be KEPT (was previously dropped)"
+        )
+        assert all(r.party_id == "unbekannt" for r in records), (
+            "unresolvable government speakers quarantine as 'unbekannt' "
+            f"(drift signal), got: {[r.party_id for r in records]}"
+        )

--- a/ai-backend/tests/ingestion/connectors/bundestag_speeches/test_mdb.py
+++ b/ai-backend/tests/ingestion/connectors/bundestag_speeches/test_mdb.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Tests for bundestag_speeches.mdb:
+  - load_mdb_lookup: parses the tiny MdB-Stammdaten XML into {by_id, by_name} dicts
+  - ensure_mdb_lookup: live-run loader — fetches on miss, fails loud on empty
+  - download_mdb_stammdaten: extracts the OpenData ZIP; 404 fails fast
+  - mdb_party_for_speech: resolves party by speaker_xml_id, fallback by name
+  - mdb_record_for_speaker_name: looks up MdB record by normalized name
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from src.ingestion.connectors.bundestag_speeches import mdb as mdb_module
+from src.ingestion.connectors.bundestag_speeches.mdb import (
+    StammdatenUnavailableError,
+    download_mdb_stammdaten,
+    ensure_mdb_lookup,
+    load_mdb_lookup,
+    mdb_party_for_speech,
+    mdb_record_for_speaker_name,
+)
+
+
+class _FakeResponse:
+    """Minimal httpx.Response stand-in for the download path."""
+
+    def __init__(self, status_code: int, content: bytes = b"") -> None:
+        self.status_code = status_code
+        self.content = content
+
+    def raise_for_status(self) -> None:
+        # 5xx would raise here in real httpx; the tests only drive 200 / 404.
+        return None
+
+
+# ---------------------------------------------------------------------------
+# TestLoadMdbLookup — fixture parsing
+# ---------------------------------------------------------------------------
+
+
+class TestLoadMdbLookup:
+    """load_mdb_lookup parses the MdB-Stammdaten XML into lookup dicts."""
+
+    def test_returns_dict_with_keys(self, mdb_xml_path: Path) -> None:
+        """load_mdb_lookup returns a dict with 'by_id' and 'by_name' keys."""
+        result = load_mdb_lookup(mdb_xml_path)
+        assert isinstance(result, dict)
+        assert "by_id" in result
+        assert "by_name" in result
+
+    def test_by_id_contains_scholz(self, mdb_xml_path: Path) -> None:
+        """by_id lookup contains Scholz (ID 11004870)."""
+        result = load_mdb_lookup(mdb_xml_path)
+        assert "11004870" in result["by_id"], "Scholz MdB record not found by ID"
+
+    def test_by_id_contains_baerbock(self, mdb_xml_path: Path) -> None:
+        """by_id lookup contains Baerbock (ID 11004220)."""
+        result = load_mdb_lookup(mdb_xml_path)
+        assert "11004220" in result["by_id"], "Baerbock MdB record not found by ID"
+
+    def test_scholz_party_spd(self, mdb_xml_path: Path) -> None:
+        """Scholz party resolves to 'SPD' via PARTEI_KURZ."""
+        result = load_mdb_lookup(mdb_xml_path)
+        record = result["by_id"]["11004870"]
+        assert record["party"] == "SPD"
+
+    def test_baerbock_party_gruene(self, mdb_xml_path: Path) -> None:
+        """Baerbock party resolves to 'BÜNDNIS 90/DIE GRÜNEN' via PARTEI_KURZ."""
+        result = load_mdb_lookup(mdb_xml_path)
+        record = result["by_id"]["11004220"]
+        assert record["party"] == "BÜNDNIS 90/DIE GRÜNEN"
+
+    def test_merz_party_via_wahlperioden(self, mdb_xml_path: Path) -> None:
+        """Merz (ID 11003444): PARTEI_KURZ empty → party resolved via WAHLPERIODEN Fraktion/Gruppe."""
+        result = load_mdb_lookup(mdb_xml_path)
+        assert "11003444" in result["by_id"], "Merz MdB record not found by ID"
+        record = result["by_id"]["11003444"]
+        # Party must be resolved from WAHLPERIODE WP=21 INSTITUTION INS_LANG=CDU/CSU
+        assert record["party"] is not None, (
+            "Party must resolve via WAHLPERIODEN fallback"
+        )
+        assert "CDU" in record["party"] or record["party"] == "CDU/CSU"
+
+    def test_missing_file_returns_empty_lookups(self, tmp_path: Path) -> None:
+        """load_mdb_lookup returns empty lookups (not an error) when the file is absent."""
+        missing = tmp_path / "nonexistent.xml"
+        result = load_mdb_lookup(missing)
+        assert result == {"by_id": {}, "by_name": {}}, (
+            "Missing MdB file must return empty lookups, not raise"
+        )
+
+    def test_by_name_lookup_populated(self, mdb_xml_path: Path) -> None:
+        """by_name lookup contains at least one entry (unambiguous name→record mapping)."""
+        result = load_mdb_lookup(mdb_xml_path)
+        assert len(result["by_name"]) >= 1, "by_name must contain at least one entry"
+
+
+# ---------------------------------------------------------------------------
+# TestMdbPartyForSpeech — party resolution by id + name fallback
+# ---------------------------------------------------------------------------
+
+
+class TestMdbPartyForSpeech:
+    """mdb_party_for_speech resolves party from lookup by id, then by normalized name."""
+
+    def test_party_by_id(self, mdb_xml_path: Path) -> None:
+        """Resolves party 'SPD' for Scholz by speaker_xml_id."""
+        lookup = load_mdb_lookup(mdb_xml_path)
+        speech = {"speaker_xml_id": "11004870", "speaker_name": "Olaf Scholz"}
+        assert mdb_party_for_speech(speech, lookup) == "SPD"
+
+    def test_party_by_name_fallback(self, mdb_xml_path: Path) -> None:
+        """Resolves party by normalized name when speaker_xml_id is not in lookup."""
+        lookup = load_mdb_lookup(mdb_xml_path)
+        # Use an id that is NOT in the fixture, but use the real name
+        speech = {"speaker_xml_id": "UNKNOWN_ID", "speaker_name": "Annalena Baerbock"}
+        result = mdb_party_for_speech(speech, lookup)
+        # Party should resolve via by_name lookup
+        assert result == "BÜNDNIS 90/DIE GRÜNEN"
+
+    def test_unknown_speaker_returns_none(self, mdb_xml_path: Path) -> None:
+        """Returns None for a speaker not in the lookup (neither by id nor name)."""
+        lookup = load_mdb_lookup(mdb_xml_path)
+        speech = {"speaker_xml_id": "UNKNOWN", "speaker_name": "Unknown Person"}
+        assert mdb_party_for_speech(speech, lookup) is None
+
+    def test_empty_lookup_returns_none(self) -> None:
+        """Returns None for any speaker when lookup is empty."""
+        empty_lookup: dict = {"by_id": {}, "by_name": {}}
+        speech = {"speaker_xml_id": "11004870", "speaker_name": "Olaf Scholz"}
+        assert mdb_party_for_speech(speech, empty_lookup) is None
+
+
+# ---------------------------------------------------------------------------
+# TestMdbRecordForSpeakerName — record lookup by normalized name
+# ---------------------------------------------------------------------------
+
+
+class TestMdbRecordForSpeakerName:
+    """mdb_record_for_speaker_name looks up MdB record by normalized speaker name."""
+
+    def test_known_name_returns_record(self, mdb_xml_path: Path) -> None:
+        """Returns an MdB record dict for a known speaker name."""
+        lookup = load_mdb_lookup(mdb_xml_path)
+        speech = {"speaker_name": "Olaf Scholz"}
+        record = mdb_record_for_speaker_name(speech, lookup)
+        assert record is not None
+        assert isinstance(record, dict)
+        assert "id" in record
+
+    def test_unknown_name_returns_none(self, mdb_xml_path: Path) -> None:
+        """Returns None for an unknown speaker name."""
+        lookup = load_mdb_lookup(mdb_xml_path)
+        speech = {"speaker_name": "Unknown Speaker"}
+        assert mdb_record_for_speaker_name(speech, lookup) is None
+
+    def test_empty_name_returns_none(self, mdb_xml_path: Path) -> None:
+        """Returns None for an empty speaker name."""
+        lookup = load_mdb_lookup(mdb_xml_path)
+        speech = {"speaker_name": ""}
+        assert mdb_record_for_speaker_name(speech, lookup) is None
+
+
+# ---------------------------------------------------------------------------
+# TestEnsureMdbLookup — live-run loader (fail-loud on empty, no silent degrade)
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureMdbLookup:
+    """ensure_mdb_lookup requires a non-empty lookup for the live speech path."""
+
+    def test_present_file_returns_lookup(self, mdb_xml_path: Path) -> None:
+        """A present, non-empty file loads without a download attempt."""
+        result = ensure_mdb_lookup(mdb_xml_path, download=False)
+        assert result["by_id"], "expected a populated lookup from the fixture"
+
+    def test_missing_file_no_download_raises(self, tmp_path: Path) -> None:
+        """Absent file with download disabled fails loud rather than degrading."""
+        with pytest.raises(StammdatenUnavailableError):
+            ensure_mdb_lookup(tmp_path / "nonexistent.xml", download=False)
+
+
+# ---------------------------------------------------------------------------
+# TestDownloadMdbStammdaten — ZIP extraction + fail-fast on a rotated blob
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadMdbStammdaten:
+    """download_mdb_stammdaten extracts the OpenData ZIP; a 404 fails fast."""
+
+    def test_extracts_xml_member(
+        self, mdb_xml_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A 200 ZIP response is extracted to dest and is loadable."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.write(mdb_xml_path, arcname="MDB_STAMMDATEN.XML")
+
+        monkeypatch.setattr(
+            mdb_module.httpx, "get", lambda *a, **k: _FakeResponse(200, buf.getvalue())
+        )
+        dest = tmp_path / "MDB_STAMMDATEN.XML"
+        download_mdb_stammdaten(dest)
+        assert dest.exists()
+        assert load_mdb_lookup(dest)["by_id"], "extracted file must be loadable"
+
+    def test_404_raises_without_retry(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A 404 (rotated blob) is non-retryable and fails loud immediately."""
+        calls = {"n": 0}
+
+        def _get(*_a, **_k) -> _FakeResponse:
+            calls["n"] += 1
+            return _FakeResponse(404)
+
+        monkeypatch.setattr(mdb_module.httpx, "get", _get)
+        with pytest.raises(StammdatenUnavailableError):
+            download_mdb_stammdaten(tmp_path / "out.xml")
+        assert calls["n"] == 1, "404 must not be retried"

--- a/ai-backend/tests/ingestion/connectors/bundestag_speeches/test_mdb.py
+++ b/ai-backend/tests/ingestion/connectors/bundestag_speeches/test_mdb.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/tests/ingestion/connectors/bundestag_speeches/test_parser.py
+++ b/ai-backend/tests/ingestion/connectors/bundestag_speeches/test_parser.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Tests for bundestag_speeches.parser.parse_speeches_from_xml.
+
+Covers:
+  - Normal speaker extraction (SPD, ID, name, party from XML <fraktion>)
+  - Kommentar nodes skipped (not included in speech body text)
+  - Merged-name speaker override from redner.tail visible label
+  - Non-MdB speaker (ID starting with "999") extractable but flaggable
+  - Billion-laughs / entity-expansion XML raises (defusedxml hardening)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.ingestion.connectors.bundestag_speeches.parser import (
+    parse_speeches_from_xml,
+)
+
+
+# ---------------------------------------------------------------------------
+# TestParserBasic — normal speaker, text extraction, kommentar skip
+# ---------------------------------------------------------------------------
+
+
+class TestParserBasic:
+    """parse_speeches_from_xml extracts speaker/party/text from valid XML."""
+
+    def test_returns_list(self, protocol_xml: str) -> None:
+        """parse_speeches_from_xml returns a list of speech dicts."""
+        result = parse_speeches_from_xml(protocol_xml)
+        assert isinstance(result, list)
+
+    def test_expected_speech_count(self, protocol_xml: str) -> None:
+        """Protocol fixture has 3 <rede> nodes → 3 speech dicts returned."""
+        result = parse_speeches_from_xml(protocol_xml)
+        assert len(result) == 3
+
+    def test_spd_speaker_name(self, protocol_xml: str) -> None:
+        """First speech (Scholz / SPD) extracts correct speaker name."""
+        result = parse_speeches_from_xml(protocol_xml)
+        spd_speech = next(
+            (s for s in result if s.get("speaker_xml_id") == "11004870"), None
+        )
+        assert spd_speech is not None, "SPD speech (id=11004870) not found"
+        assert "Scholz" in spd_speech.get("speaker_name", "")
+
+    def test_spd_speaker_party(self, protocol_xml: str) -> None:
+        """First speech (Scholz / SPD) extracts correct party."""
+        result = parse_speeches_from_xml(protocol_xml)
+        spd_speech = next(
+            (s for s in result if s.get("speaker_xml_id") == "11004870"), None
+        )
+        assert spd_speech is not None
+        assert spd_speech.get("party") == "SPD"
+
+    def test_spd_speech_text_nonempty(self, protocol_xml: str) -> None:
+        """First speech body text is non-empty."""
+        result = parse_speeches_from_xml(protocol_xml)
+        spd_speech = next(
+            (s for s in result if s.get("speaker_xml_id") == "11004870"), None
+        )
+        assert spd_speech is not None
+        assert spd_speech.get("text"), "SPD speech text must not be empty"
+
+    def test_kommentar_excluded_from_text(self, protocol_xml: str) -> None:
+        """<kommentar> content (e.g. '(Beifall bei der SPD)') must not appear in speech text."""
+        result = parse_speeches_from_xml(protocol_xml)
+        spd_speech = next(
+            (s for s in result if s.get("speaker_xml_id") == "11004870"), None
+        )
+        assert spd_speech is not None
+        text = spd_speech.get("text", "")
+        assert "Beifall" not in text, "Kommentar text must be excluded from speech body"
+
+    def test_xml_rede_id_set(self, protocol_xml: str) -> None:
+        """xml_rede_id must be extracted from the <rede id=...> attribute."""
+        result = parse_speeches_from_xml(protocol_xml)
+        spd_speech = next(
+            (s for s in result if s.get("speaker_xml_id") == "11004870"), None
+        )
+        assert spd_speech is not None
+        assert spd_speech.get("xml_rede_id") == "ID215000100"
+
+
+# ---------------------------------------------------------------------------
+# TestMergedNameSpeaker — merged structured name overridden by redner.tail
+# ---------------------------------------------------------------------------
+
+
+class TestMergedNameSpeaker:
+    """Merged-name speaker (suspicious structured metadata) uses redner.tail label."""
+
+    def test_merged_name_speaker_found(self, protocol_xml: str) -> None:
+        """Baerbock speech (id=11004220) is present in the output."""
+        result = parse_speeches_from_xml(protocol_xml)
+        speech = next(
+            (s for s in result if s.get("speaker_xml_id") == "11004220"), None
+        )
+        assert speech is not None, "Baerbock speech (id=11004220) not found"
+
+    def test_merged_name_overridden_by_tail(self, protocol_xml: str) -> None:
+        """Merged structured name (AnnalenaBarb+ock) is corrected via redner.tail label."""
+        result = parse_speeches_from_xml(protocol_xml)
+        speech = next(
+            (s for s in result if s.get("speaker_xml_id") == "11004220"), None
+        )
+        assert speech is not None
+        name = speech.get("speaker_name", "")
+        # After tail override, the merged artifact 'AnnalenaBarb' must not appear
+        assert "AnnalenaBarb" not in name, (
+            f"Merged name artifact must be overridden by tail label; got: {name!r}"
+        )
+
+    def test_merged_name_party_resolved(self, protocol_xml: str) -> None:
+        """Party for merged-name speaker resolves to 'BÜNDNIS 90/DIE GRÜNEN'."""
+        result = parse_speeches_from_xml(protocol_xml)
+        speech = next(
+            (s for s in result if s.get("speaker_xml_id") == "11004220"), None
+        )
+        assert speech is not None
+        assert speech.get("party") == "BÜNDNIS 90/DIE GRÜNEN"
+
+
+# ---------------------------------------------------------------------------
+# TestNonMdbSpeaker — speaker with 999... ID
+# ---------------------------------------------------------------------------
+
+
+class TestNonMdbSpeaker:
+    """Non-MdB speaker (ID starting with '999') is parseable but flaggable."""
+
+    def test_non_mdb_speaker_present(self, protocol_xml: str) -> None:
+        """Speech with 999... speaker ID is present in the parser output."""
+        result = parse_speeches_from_xml(protocol_xml)
+        speech = next(
+            (s for s in result if (s.get("speaker_xml_id") or "").startswith("999")),
+            None,
+        )
+        assert speech is not None, "Non-MdB speech (id starting with 999) not found"
+
+    def test_non_mdb_speaker_id_prefix(self, protocol_xml: str) -> None:
+        """Non-MdB speaker_xml_id starts with '999'."""
+        result = parse_speeches_from_xml(protocol_xml)
+        speech = next(
+            (s for s in result if (s.get("speaker_xml_id") or "").startswith("999")),
+            None,
+        )
+        assert speech is not None
+        assert speech["speaker_xml_id"].startswith("999")
+
+
+# ---------------------------------------------------------------------------
+# TestAgendaTopIdMapping — multi-TOP / ZP / outside-any-TOP agenda resolution
+# (parser-level coverage for the agenda map the speech_key depends on)
+# ---------------------------------------------------------------------------
+
+_MULTI_TOP_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<sitzungsverlauf>
+  <sitzungstitel>101. Sitzung des Deutschen Bundestages</sitzungstitel>
+  <rede id="R-OPEN">
+    <p klasse="redner">
+      <redner id="11000010">
+        <name><vorname>Erste</vorname><nachname>Rednerin</nachname><fraktion>SPD</fraktion></name>
+      </redner>Erste Rednerin (SPD):</p>
+    <p klasse="J">Eroeffnungsrede ausserhalb jedes Tagesordnungspunkts.</p>
+  </rede>
+  <tagesordnungspunkt top-id="20">
+    <rede id="R-T20">
+      <p klasse="redner">
+        <redner id="11000011">
+          <name><vorname>Zweiter</vorname><nachname>Redner</nachname><fraktion>SPD</fraktion></name>
+        </redner>Zweiter Redner (SPD):</p>
+      <p klasse="J">Rede unter Tagesordnungspunkt 20.</p>
+    </rede>
+  </tagesordnungspunkt>
+  <tagesordnungspunkt top-id="21">
+    <rede id="R-T21">
+      <p klasse="redner">
+        <redner id="11000012">
+          <name><vorname>Dritte</vorname><nachname>Rednerin</nachname><fraktion>FDP</fraktion></name>
+        </redner>Dritte Rednerin (FDP):</p>
+      <p klasse="J">Rede unter Tagesordnungspunkt 21.</p>
+    </rede>
+  </tagesordnungspunkt>
+  <tagesordnungspunkt top-id="ZP5">
+    <rede id="R-ZP5">
+      <p klasse="redner">
+        <redner id="11000013">
+          <name><vorname>Vierter</vorname><nachname>Redner</nachname><fraktion>AfD</fraktion></name>
+        </redner>Vierter Redner (AfD):</p>
+      <p klasse="J">Rede unter Zusatzpunkt 5.</p>
+    </rede>
+  </tagesordnungspunkt>
+</sitzungsverlauf>
+"""
+
+
+class TestAgendaTopIdMapping:
+    """agenda_top_id resolves per enclosing <tagesordnungspunkt>, incl. ZP and none."""
+
+    def test_agenda_top_id_mapping(self) -> None:
+        """Multiple TOPs, a Zusatzpunkt, and a rede outside any TOP map correctly."""
+        result = parse_speeches_from_xml(_MULTI_TOP_XML)
+        agenda_by_rede = {s["xml_rede_id"]: s.get("agenda_top_id") for s in result}
+        assert agenda_by_rede == {
+            "R-OPEN": None,  # outside any tagesordnungspunkt → no-agenda fallback
+            "R-T20": "20",
+            "R-T21": "21",
+            "R-ZP5": "ZP5",  # Zusatzpunkt keeps its distinct top-id
+        }
+
+
+# ---------------------------------------------------------------------------
+# TestDefusedXmlHardening — billion-laughs regression guard
+# ---------------------------------------------------------------------------
+
+
+class TestDefusedXmlHardening:
+    """defusedxml blocks entity-expansion / billion-laughs attacks on remote XML."""
+
+    def test_billion_laughs_raises(self) -> None:
+        """A billion-laughs payload raises defusedxml.EntitiesForbidden, not OOM."""
+        billion_laughs = (
+            '<?xml version="1.0"?>'
+            "<!DOCTYPE lolz ["
+            '  <!ENTITY lol "lol">'
+            '  <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">'
+            '  <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">'
+            "]>"
+            "<root>&lol3;</root>"
+        )
+        import defusedxml
+
+        with pytest.raises(defusedxml.EntitiesForbidden):
+            parse_speeches_from_xml(billion_laughs)

--- a/ai-backend/tests/ingestion/connectors/bundestag_speeches/test_parser.py
+++ b/ai-backend/tests/ingestion/connectors/bundestag_speeches/test_parser.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -238,3 +238,46 @@ class TestDefusedXmlHardening:
 
         with pytest.raises(defusedxml.EntitiesForbidden):
             parse_speeches_from_xml(billion_laughs)
+
+
+# ---------------------------------------------------------------------------
+# TestCitationCoordinates — TOC xref page map + PDF page derivation
+# ---------------------------------------------------------------------------
+
+
+class TestCitationCoordinates:
+    """Every rede with a TOC xref carries printed page, quadrant, and PDF page."""
+
+    def test_pages_and_quadrants_mapped(self, protocol_xml: str) -> None:
+        result = parse_speeches_from_xml(protocol_xml)
+        by_id = {s["xml_rede_id"]: s for s in result}
+        assert by_id["ID215000100"]["source_page"] == "12001"
+        assert by_id["ID215000100"]["page_quadrant"] == "A"
+        assert by_id["ID215000200"]["source_page"] == "12003"
+        assert by_id["ID215000200"]["page_quadrant"] == "C"
+
+    def test_pdf_page_derived_from_start_seitennr(self, protocol_xml: str) -> None:
+        """pdf_page = printed page − start-seitennr + 1 (root start-seitennr=12000)."""
+        result = parse_speeches_from_xml(protocol_xml)
+        by_id = {s["xml_rede_id"]: s for s in result}
+        assert by_id["ID215000100"]["pdf_page"] == 2
+        assert by_id["ID215000300"]["pdf_page"] == 6
+
+    def test_missing_start_seitennr_yields_no_pdf_page(self) -> None:
+        """Without start-seitennr the PDF offset is unknowable — pdf_page must
+        be None (a deep link must not guess), while the printed page stays."""
+        xml = (
+            "<dbtplenarprotokoll>"
+            "<vorspann><inhaltsverzeichnis>"
+            '<ivz-eintrag><xref ref-type="rede" rid="ID1" pnr="500" div="D"/></ivz-eintrag>'
+            "</inhaltsverzeichnis></vorspann>"
+            '<sitzungsverlauf><rede id="ID1">'
+            '<p klasse="redner"><redner id="11001111"><name>'
+            "<vorname>Test</vorname><nachname>Person</nachname>"
+            "<fraktion>SPD</fraktion></name></redner>Test Person (SPD):</p>"
+            '<p klasse="J">Inhalt der Rede.</p>'
+            "</rede></sitzungsverlauf></dbtplenarprotokoll>"
+        )
+        result = parse_speeches_from_xml(xml)
+        assert result[0]["source_page"] == "500"
+        assert result[0]["pdf_page"] is None

--- a/ai-backend/tests/ingestion/test_resurrection_guard.py
+++ b/ai-backend/tests/ingestion/test_resurrection_guard.py
@@ -1,0 +1,340 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Resurrection-guard integration test — fake Qdrant.
+
+The DIP connector must consult the shared indexed `speech_key` BEFORE inserting
+and skip any speech already superseded by op — durable even across a full DIP
+backfill / cursor reset (`since=None`). Otherwise a cursor reset would
+re-insert the very duplicates op just deleted.
+"""
+
+from __future__ import annotations
+
+
+class _SeededQdrant:
+    """Fake Qdrant whose scroll() returns one op-owned point for speech_key X."""
+
+    def __init__(self, superseded_key: str) -> None:
+        self._key = superseded_key
+        self.upserted_keys: list[str] = []
+
+    def scroll(self, *a, **k):  # noqa: ANN002, ANN003, ANN201
+        import types
+
+        point = types.SimpleNamespace(payload={"speech_key": self._key, "source": "op"})
+        return ([point], None)
+
+    def upsert(self, *a, **k) -> None:  # noqa: ANN002, ANN003
+        # Record any speech_key that reached upsert (a guard failure).
+        for p in k.get("points") or (a[1] if len(a) > 1 else []):
+            payload = getattr(p, "payload", {}) or {}
+            if payload.get("speech_key"):
+                self.upserted_keys.append(payload["speech_key"])
+
+
+def test_dip_skips_op_superseded_speech_even_on_cursor_reset() -> None:
+    """DIP skips inserting a speech whose speech_key is already op-owned.
+
+    Simulate a cursor reset (`since=None`): even a full backfill must NOT
+    resurrect the op-superseded speech.
+    """
+    from src.ingestion.connectors.bundestag_speeches.connector import (
+        is_op_superseded as guard,
+    )
+
+    superseded_key = "de-20-101-mareike-lotte-wulf-top20"
+    qdrant = _SeededQdrant(superseded_key)
+
+    # The guard, given the shared key, must report the speech as op-superseded
+    # (so DIP normalize/insert skips it) regardless of the incremental cursor.
+    result = guard(qdrant, "wahlchat_chunks_dev", superseded_key)
+    # Accept either a boolean "is superseded" or a set/list of superseded keys.
+    if isinstance(result, bool):
+        assert result is True, "DIP must treat the op-superseded speech as skip"
+    else:
+        assert superseded_key in set(result), (
+            "op-superseded speech_key must appear in the guard's skip set"
+        )
+    assert superseded_key not in qdrant.upserted_keys, (
+        "DIP must not re-insert an op-superseded speech even on cursor reset (since=None)"
+    )
+
+
+class _ConditionalQdrant:
+    """Fake Qdrant returning an op point only for a specific superseded speech_key.
+
+    The op point carries the op speech's TEXT so the precise (text-matching)
+    resurrection guard recognises it as the SAME speech as the DIP row being
+    inserted (a bare speech_key match is no longer sufficient)."""
+
+    def __init__(self, superseded_key: str, superseded_text: str) -> None:
+        self._key = superseded_key
+        self._text = superseded_text
+
+    def scroll(self, *a, **k):  # noqa: ANN002, ANN003, ANN201
+        import types
+
+        flt = k.get("scroll_filter")
+        wanted = None
+        for cond in getattr(flt, "must", None) or []:
+            if getattr(cond, "key", None) == "speech_key":
+                wanted = getattr(getattr(cond, "match", None), "value", None)
+        if wanted == self._key:
+            point = types.SimpleNamespace(
+                payload={
+                    "speech_key": self._key,
+                    "source": "op",
+                    "source_item_id": "op-superseded",
+                    "text": self._text,
+                }
+            )
+            return ([point], None)
+        return ([], None)
+
+
+def test_dip_normalize_skips_op_superseded_speech() -> None:
+    """End-to-end: connector.normalize() drops the op-superseded speech, keeps others.
+
+    Builds a connector via object.__new__ (bypassing DIP_API_KEY), injects a fake
+    Qdrant that reports ONE speech_key as op-owned, and asserts normalize() emits
+    chunks ONLY for the non-superseded speech — even with a full-backfill raw.
+    """
+    from src.ingestion.connectors.bundestag_speeches.connector import (
+        BundestagSpeechesConnector,
+    )
+    from src.ingestion.connectors.bundestag_speeches.mappers import corpus
+
+    superseded_key = "de-21-99-superseded-speaker-"
+    keep_key = "de-21-99-fresh-speaker-"
+    superseded_text = "Diese Rede wurde von op abgeloest."
+
+    conn = object.__new__(BundestagSpeechesConnector)
+    conn._mdb_lookup = {"by_id": {}, "by_name": {}}
+    conn._qdrant = _ConditionalQdrant(superseded_key, superseded_text)
+    conn._qdrant_lazy_enabled = False
+    conn._collection_name = "wahlchat_chunks_dev"
+
+    raw = {
+        "protocol": {
+            "id": "5678",
+            "dokumentnummer": "21/99",
+            "datum": "2026-06-01",
+            "wahlperiode": 21,
+            "fundstelle": {"pdf_url": None},
+        },
+        "speeches": [
+            {
+                "speaker_xml_id": "11000001",
+                "speaker_name": "Superseded Speaker",
+                "party": "SPD",
+                "text": "Diese Rede wurde von op abgeloest.",
+                "xml_rede_id": "ID99001",
+            },
+            {
+                "speaker_xml_id": "11000002",
+                "speaker_name": "Fresh Speaker",
+                "party": "SPD",
+                "text": "Diese Rede ist nur bei DIP vorhanden.",
+                "xml_rede_id": "ID99002",
+            },
+        ],
+        "mdb_lookup": {"by_id": {}, "by_name": {}},
+    }
+
+    # Sanity: the two speeches produce the expected shared keys.
+    assert (
+        corpus.compute_speech_key(
+            {
+                "wahlperiode": 21,
+                "protocol_id": "21/99",
+                "speaker_name": "Superseded Speaker",
+                "agenda_top_id": None,
+            }
+        )
+        == superseded_key
+    )
+    assert (
+        corpus.compute_speech_key(
+            {
+                "wahlperiode": 21,
+                "protocol_id": "21/99",
+                "speaker_name": "Fresh Speaker",
+                "agenda_top_id": None,
+            }
+        )
+        == keep_key
+    )
+
+    records = conn.normalize(raw)
+    keys = {r.speech_key for r in records}
+    assert superseded_key not in keys, (
+        "op-superseded speech must be skipped by normalize()"
+    )
+    assert keep_key in keys, "non-superseded DIP speech must still be inserted"
+    assert all(r.source == "dip" for r in records)
+
+
+class _MultiChunkQdrant:
+    """Fake Qdrant serving one op speech as TWO chunks, deliberately out of order."""
+
+    def __init__(self, key: str, parts: list[tuple[int, str]]) -> None:
+        self._key = key
+        self._parts = parts
+        self._served = False
+
+    def scroll(self, *a, **k):  # noqa: ANN002, ANN003, ANN201
+        import types
+
+        if self._served:
+            return ([], None)
+        self._served = True
+        points = [
+            types.SimpleNamespace(
+                payload={
+                    "speech_key": self._key,
+                    "source": "op",
+                    "source_item_id": "op-multichunk",
+                    "text": text,
+                    "chunk_index": idx,
+                }
+            )
+            for idx, text in self._parts
+        ]
+        return (points, None)
+
+
+def test_is_op_superseded_joins_multichunk_op_speech_in_chunk_order() -> None:
+    """Regression: a 2-chunk op speech scrolled in REVERSE chunk order must
+    still match the DIP twin's full text — joined by chunk_index, never scroll
+    order ("B+A" vs "A+B" scores ≈0.5 < 0.85 → silent resurrection)."""
+    from src.ingestion.connectors.bundestag_speeches.connector import is_op_superseded
+
+    key = "de-20-101-mareike-lotte-wulf-top20"
+    part_a = "Sehr geehrte Frau Praesidentin! Liebe Kolleginnen und Kollegen im Saal!"
+    part_b = "Wir staerken die Aus- und Weiterbildungsfoerderung in diesem ganzen Land."
+    # Scroll serves chunk_index=1 FIRST.
+    qdrant = _MultiChunkQdrant(key, [(1, part_b), (0, part_a)])
+
+    assert (
+        is_op_superseded(
+            qdrant, "wahlchat_chunks_dev", key, dip_text=f"{part_a} {part_b}"
+        )
+        is True
+    ), "in-order join must recognise the same speech despite scroll order"
+
+
+def test_is_op_superseded_empty_folded_dip_text_inserts_fail_safe() -> None:
+    """A dip_text that folds to EMPTY after normalization is unverifiable —
+    the guard must return False (insert; fail-safe), consistent with its posture
+    everywhere else. Bare key existence is NOT proof of the same speech."""
+    from src.ingestion.connectors.bundestag_speeches.connector import is_op_superseded
+
+    key = "de-20-101-mareike-lotte-wulf-top20"
+    qdrant = _ConditionalQdrant(key, "Eine ganz normale Rede mit Text.")
+
+    # "!!! ---" folds to "" → unverifiable → insert.
+    assert (
+        is_op_superseded(qdrant, "wahlchat_chunks_dev", key, dip_text="!!! ---")
+        is False
+    )
+
+
+def test_normalize_returns_empty_when_all_speeches_op_superseded() -> None:
+    """A protocol whose EVERY usable speech is op-superseded is a clean
+    no-op — normalize() returns [] (and reports the skipped siids) instead of
+    raising 'zero usable speeches' into failed_ids on every run for 60 days."""
+    from src.ingestion.connectors.bundestag_speeches.connector import (
+        BundestagSpeechesConnector,
+    )
+
+    class _AllSupersededQdrant:
+        """Fake Qdrant reporting EVERY speech_key as op-owned with matching text."""
+
+        def __init__(self, text_by_any: str) -> None:
+            self._text = text_by_any
+
+        def scroll(self, *a, **k):  # noqa: ANN002, ANN003, ANN201
+            import types
+
+            point = types.SimpleNamespace(
+                payload={
+                    "source": "op",
+                    "source_item_id": "op-x",
+                    "text": self._text,
+                    "chunk_index": 0,
+                }
+            )
+            return ([point], None)
+
+    speech_text = "Diese Rede wurde vollstaendig von op abgedeckt."
+    conn = object.__new__(BundestagSpeechesConnector)
+    conn._mdb_lookup = {"by_id": {}, "by_name": {}}
+    conn._qdrant = _AllSupersededQdrant(speech_text)
+    conn._qdrant_lazy_enabled = False
+    conn._collection_name = "wahlchat_chunks_dev"
+
+    raw = {
+        "protocol": {
+            "id": "4242",
+            "dokumentnummer": "21/42",
+            "datum": "2026-06-01",
+            "wahlperiode": 21,
+            "fundstelle": {"pdf_url": None},
+        },
+        "speeches": [
+            {
+                "speaker_xml_id": "11000001",
+                "speaker_name": "Voll Abgedeckt",
+                "party": "SPD",
+                "text": speech_text,
+                "xml_rede_id": "ID42001",
+            }
+        ],
+        "mdb_lookup": {"by_id": {}, "by_name": {}},
+    }
+
+    records = conn.normalize(raw)
+
+    assert records == [], (
+        "fully-op-covered protocol must be a clean no-op, not an error"
+    )
+    assert len(conn.last_superseded_siids) == 1, (
+        "the skipped siid must be reported for the stranded-twin cleanup"
+    )
+
+
+def test_is_op_superseded_precise_rejects_distinct_same_key_speech() -> None:
+    """An op point under the key whose TEXT differs (a distinct speech a
+    speaker gave under the same agenda item) must NOT mark this DIP speech as
+    superseded — otherwise the DIP text of a speech op never aligned is lost."""
+    from src.ingestion.connectors.bundestag_speeches.connector import is_op_superseded
+
+    key = "de-20-101-mareike-lotte-wulf-top20"
+    # op holds a DIFFERENT speech under the same (non-unique) key.
+    qdrant = _ConditionalQdrant(
+        key, "Ein voellig anderer Redebeitrag zum Thema Verkehr."
+    )
+
+    # The DIP speech we're about to insert has different text → not superseded.
+    assert (
+        is_op_superseded(
+            qdrant,
+            "wahlchat_chunks_dev",
+            key,
+            dip_text="Zur Kinderarmut in Deutschland.",
+        )
+        is False
+    )
+    # The same speech (matching text) IS superseded.
+    assert (
+        is_op_superseded(
+            qdrant,
+            "wahlchat_chunks_dev",
+            key,
+            dip_text="Ein voellig anderer Redebeitrag zum Thema Verkehr.",
+        )
+        is True
+    )

--- a/ai-backend/tests/ingestion/test_resurrection_guard.py
+++ b/ai-backend/tests/ingestion/test_resurrection_guard.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/tests/ingestion/test_run.py
+++ b/ai-backend/tests/ingestion/test_run.py
@@ -1,0 +1,584 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+run_connector / get_cursor behaviour tests.
+
+Covers the source-scoped cursor (op and DIP keep ISOLATED `max(external_id)`
+cursors despite sharing source_type "parliamentary_speech"), the batch-window
+stall guard, and the full-parent-footprint orphan reconciliation.
+"""
+
+from __future__ import annotations
+
+import types
+from datetime import date
+from typing import Optional
+from unittest.mock import MagicMock
+
+from src.ingestion.connector import BaseConnector
+from src.ingestion.ids import (
+    compute_chunk_id,
+    compute_source_item_id,
+    make_chunk_key,
+)
+from src.ingestion.run import get_cursor, run_connector
+from src.ingestion.schemas import AuthorityTier, ChunkRecord, SourceType
+
+
+class _CursorQdrant:
+    """Fake Qdrant recording the scroll_filter and returning a per-source max."""
+
+    def __init__(self, by_source: dict[str, int]) -> None:
+        self._by_source = by_source
+        self.last_filter = None
+
+    def scroll(
+        self,
+        *,
+        collection_name,
+        scroll_filter,
+        order_by,
+        limit,
+        with_payload,
+        with_vectors,
+    ):  # noqa: ANN001, ANN003
+        self.last_filter = scroll_filter
+        # Determine which source the filter scoped to, if any.
+        source = None
+        for cond in getattr(scroll_filter, "must", []) or []:
+            if getattr(cond, "key", None) == "source":
+                source = cond.match.value
+        ext = self._by_source.get(source)
+        if ext is None:
+            return ([], None)
+        point = types.SimpleNamespace(payload={"external_id": ext})
+        return ([point], None)
+
+
+def test_source_scoped_cursor() -> None:
+    """op vs dip max(external_id) is isolated by the `source` param."""
+    qdrant = _CursorQdrant({"op": 20230601, "dip": 20260615})
+
+    op_cursor = get_cursor(
+        qdrant, "wahlchat_chunks_dev", "parliamentary_speech", source="op"
+    )
+    dip_cursor = get_cursor(
+        qdrant, "wahlchat_chunks_dev", "parliamentary_speech", source="dip"
+    )
+
+    assert op_cursor == 20230601, f"op cursor must be isolated; got {op_cursor}"
+    assert dip_cursor == 20260615, f"dip cursor must be isolated; got {dip_cursor}"
+    assert op_cursor != dip_cursor, "op and dip cursors must not cross-pollinate"
+
+    # The scroll filter for a source-scoped call carries a `source` FieldCondition.
+    must_keys = {getattr(c, "key", None) for c in (qdrant.last_filter.must or [])}
+    assert "source" in must_keys and "source_type" in must_keys
+
+
+class _CursorFilterRecorder:
+    """Fake Qdrant recording the scroll_filter of every order_by (cursor) scroll."""
+
+    def __init__(self) -> None:
+        self.cursor_filters: list = []
+
+    def scroll(self, **kwargs):  # noqa: ANN003, ANN201
+        if kwargs.get("order_by") is not None:
+            self.cursor_filters.append(kwargs.get("scroll_filter"))
+        return ([], None)
+
+
+def _cursor_filter_keys(flt) -> set:  # noqa: ANN001
+    return {getattr(c, "key", None) for c in (getattr(flt, "must", []) or [])}
+
+
+def test_runner_honors_cursor_source_none() -> None:
+    """A connector with cursor_source=None gets an UNSCOPED cursor read even
+    though it stamps a `source` — the DIP floor must span both speech sources
+    (op supersede-deletes dip points, so a dip-scoped max walks backward)."""
+    from unittest.mock import MagicMock as _MM
+
+    class _DipLikeStub(_ChunksStub):
+        source: str = "dip"
+        cursor_source = None  # class attr shadows the BaseConnector property
+
+    qdrant = _CursorFilterRecorder()
+    run_connector(_DipLikeStub({}), qdrant, _MM(), batch_size=1)
+
+    assert qdrant.cursor_filters, "get_cursor must have been consulted"
+    assert "source" not in _cursor_filter_keys(qdrant.cursor_filters[0]), (
+        "cursor_source=None must drop the source condition from the cursor scroll"
+    )
+
+
+def test_runner_defaults_cursor_source_to_source() -> None:
+    """Without an override, the cursor stays scoped to the connector's source
+    (op keeps its independent source-scoped cursor)."""
+    from unittest.mock import MagicMock as _MM
+
+    class _OpLikeStub(_ChunksStub):
+        source: str = "op"
+
+    qdrant = _CursorFilterRecorder()
+    run_connector(_OpLikeStub({}), qdrant, _MM(), batch_size=1)
+
+    assert "source" in _cursor_filter_keys(qdrant.cursor_filters[0]), (
+        "the BaseConnector default scopes the cursor to the connector's source"
+    )
+
+
+# ---------------------------------------------------------------------------
+# run_connector batch-stall + multi-source_item_id orphan-cleanup regressions
+# ---------------------------------------------------------------------------
+
+_DIM = 3072
+
+
+def _chunk(
+    item_id: str,
+    chunk_index: int,
+    text: str,
+    content_hash: Optional[str] = None,
+) -> ChunkRecord:
+    source_item_id = compute_source_item_id("vote_record", item_id)
+    return ChunkRecord(
+        chunk_key=make_chunk_key(source_item_id, chunk_index),
+        source_item_id=source_item_id,
+        chunk_index=chunk_index,
+        text=text,
+        party_id="spd",
+        region="DE",
+        authority_tier=AuthorityTier.FACTUAL_RECORD,
+        source_type=SourceType.VOTE_RECORD,
+        publish_date=date(2024, 1, 15),
+        content_hash=content_hash,
+    )
+
+
+def test_base_connector_declares_source_type_contract() -> None:
+    """The ABC itself declares the required `source_type` attribute (annotation,
+    no default) and the optional `source` discriminator (default None)."""
+    assert "source_type" in BaseConnector.__annotations__, (
+        "BaseConnector must declare source_type as a documented required attribute"
+    )
+    assert not hasattr(BaseConnector, "source_type") or isinstance(
+        BaseConnector.source_type, str
+    ), "source_type must have NO non-str default on the ABC"
+    assert BaseConnector.source is None, (
+        "the optional source discriminator defaults to None"
+    )
+
+
+class _ChunksStub(BaseConnector):
+    """Stub connector returning a pre-baked chunks list per external_id.
+
+    Declares the required `source_type` class attribute (the ABC now documents
+    it as mandatory; the runner reads it without a type: ignore)."""
+
+    source_type: str = SourceType.VOTE_RECORD.value
+
+    def __init__(self, chunks_by_id: dict[str, list[ChunkRecord]]) -> None:
+        self._chunks_by_id = chunks_by_id
+
+    def discover(self, since: Optional[int]) -> list[str]:
+        return sorted(self._chunks_by_id)
+
+    def fetch(self, external_id: str) -> dict:
+        return {"external_id": external_id}
+
+    def normalize(self, raw: dict) -> list[ChunkRecord]:
+        return self._chunks_by_id[raw["external_id"]]
+
+
+class _FootprintQdrant:
+    """Fake QdrantClient serving BOTH get_cursor's order_by scroll and the
+    already-present guard's source_item_id footprint scroll; records deletes."""
+
+    def __init__(self, existing: Optional[dict[str, dict]] = None) -> None:
+        # existing: point_id(str) → payload dict with source_item_id (+ content_hash).
+        self.existing = dict(existing or {})
+        self.deletes: list[dict] = []
+        self.upserts: list[dict] = []
+
+    def scroll(self, **kwargs):  # noqa: ANN003, ANN201
+        if kwargs.get("order_by") is not None:
+            return ([], None)  # get_cursor → no prior points → since=None
+        flt = kwargs.get("scroll_filter")
+        siids: set[str] = set()
+        parent_keys: set[str] = set()
+        for cond in getattr(flt, "must", []) or []:
+            key = getattr(cond, "key", None)
+            match = cond.match
+            if key == "source_item_id":
+                values = getattr(match, "any", None)
+                if values is None:
+                    values = [getattr(match, "value", None)]
+                siids.update(str(v) for v in values)
+            elif key == "source_parent_key":
+                parent_keys.add(str(getattr(match, "value", None)))
+        points = [
+            types.SimpleNamespace(id=pid, payload=payload)
+            for pid, payload in self.existing.items()
+            if str(payload.get("source_item_id")) in siids
+            or str(payload.get("source_parent_key")) in parent_keys
+        ]
+        return (points, None)
+
+    def delete(self, **kwargs) -> None:  # noqa: ANN003
+        self.deletes.append(kwargs)
+
+    def upsert(self, **kwargs) -> None:  # noqa: ANN003
+        self.upserts.append(kwargs)
+
+
+def _mock_embed() -> MagicMock:
+    mock = MagicMock()
+    mock.embed_documents.side_effect = lambda texts: [[0.0] * _DIM for _ in texts]
+    return mock
+
+
+def _existing_payload(chunk: ChunkRecord) -> tuple[str, dict]:
+    pid = str(compute_chunk_id(chunk.source_item_id, chunk.chunk_index))
+    return pid, {
+        "source_item_id": str(chunk.source_item_id),
+        "content_hash": chunk.content_hash,
+    }
+
+
+def test_all_present_first_batch_does_not_stall() -> None:
+    """(b) A store where the first N discovered ids are already present must still
+    advance to and process new items — present items must not consume the
+    batch_size budget (no permanent batch-window stall)."""
+    present_a = [_chunk("1", 0, "alt A", content_hash="h-a")]
+    present_b = [_chunk("2", 0, "alt B", content_hash="h-b")]
+    new_c = [_chunk("3", 0, "neu C", content_hash="h-c")]
+
+    existing: dict[str, dict] = {}
+    for c in present_a + present_b:
+        pid, payload = _existing_payload(c)
+        existing[pid] = payload
+
+    connector = _ChunksStub({"1": present_a, "2": present_b, "3": new_c})
+    qdrant = _FootprintQdrant(existing)
+    embed = _mock_embed()
+
+    # batch_size=1: under the OLD stall behavior the run would consume its budget
+    # on already-present item "1" and NEVER reach "3".
+    report = run_connector(connector, qdrant, embed, batch_size=1)
+
+    assert len(qdrant.upserts) == 1, "the NEW item must be reached and upserted"
+    assert report.chunks_upserted == 1
+    assert report.processed == 1, "only the item that did work counts toward the budget"
+    assert report.present_skips == 2, (
+        "present-and-unchanged items are counted separately"
+    )
+    assert report.remaining == 0, "all discovered ids were consumed"
+
+
+def test_batch_budget_counts_only_worked_items() -> None:
+    """(b) batch_size caps the number of items that DO WORK; remaining reflects
+    the unconsumed tail of discovered ids."""
+    present = [_chunk("1", 0, "alt", content_hash="h-1")]
+    new_2 = [_chunk("2", 0, "neu 2", content_hash="h-2")]
+    new_3 = [_chunk("3", 0, "neu 3", content_hash="h-3")]
+    new_4 = [_chunk("4", 0, "neu 4", content_hash="h-4")]
+
+    pid, payload = _existing_payload(present[0])
+    connector = _ChunksStub({"1": present, "2": new_2, "3": new_3, "4": new_4})
+    qdrant = _FootprintQdrant({pid: payload})
+    embed = _mock_embed()
+
+    report = run_connector(connector, qdrant, embed, batch_size=2)
+
+    assert report.processed == 2, "budget consumed by the two NEW items only"
+    assert report.present_skips == 1
+    assert len(qdrant.upserts) == 2
+    assert report.remaining == 1, "id '4' was never reached → remaining tail is 1"
+
+
+def _deleted_point_ids(delete_call: dict) -> set[str]:
+    """Extract the point ids from a PointIdsList delete call."""
+    selector = delete_call["points_selector"]
+    points = getattr(selector, "points", None)
+    assert points is not None, (
+        f"delete must use PointIdsList (orphan ids only), got {selector!r}"
+    )
+    return {str(p) for p in points}
+
+
+def test_multi_source_item_id_orphan_delete() -> None:
+    """(c) An item whose chunks span source_item_ids A and B must delete the
+    orphan under siid B — and ONLY that orphan (PointIdsList of
+    existing − new; surviving ids are overwritten in place by the upsert)."""
+    chunk_a = _chunk("speech-A", 0, "Rede A", content_hash="h-a")
+    chunk_b = _chunk("speech-B", 0, "Rede B", content_hash="h-b")
+
+    # An orphaned point under siid B (a chunk the new normalize no longer produces).
+    orphan_pid = str(compute_chunk_id(chunk_b.source_item_id, 1))
+    existing = {
+        orphan_pid: {
+            "source_item_id": str(chunk_b.source_item_id),
+            "content_hash": "h-stale",
+        }
+    }
+
+    connector = _ChunksStub({"p1": [chunk_a, chunk_b]})
+    qdrant = _FootprintQdrant(existing)
+    embed = _mock_embed()
+
+    report = run_connector(connector, qdrant, embed, batch_size=10)
+
+    assert len(qdrant.deletes) == 1, "orphan cleanup must delete the stale point"
+    assert _deleted_point_ids(qdrant.deletes[0]) == {orphan_pid}, (
+        "ONLY the orphan point id may be deleted — never the whole footprint"
+    )
+    assert len(qdrant.upserts) == 1
+    assert report.chunks_upserted == 2
+
+
+def test_disappeared_child_reconciled_via_parent_footprint() -> None:
+    """(c) A child that vanishes ENTIRELY from a multi-child parent must be deleted.
+
+    Parent p1 previously produced speeches A+B; the new normalize() yields ONLY A.
+    B's source_item_id appears in no new chunk, so a source_item_id-only footprint
+    would never scan it and B would stay retrievable forever. The parent-scoped
+    scope (source_parent_key) sees the full old footprint and deletes B."""
+    chunk_a = _chunk("speech-A", 0, "Rede A", content_hash="h-a")
+    chunk_b = _chunk("speech-B", 0, "Rede B", content_hash="h-b")
+
+    # Prior run ingested BOTH A and B under parent p1 (runner stamps this key).
+    parent_key = "vote_record:p1"
+    existing = {}
+    for c in (chunk_a, chunk_b):
+        pid = str(compute_chunk_id(c.source_item_id, c.chunk_index))
+        existing[pid] = {
+            "source_item_id": str(c.source_item_id),
+            "content_hash": c.content_hash,
+            "source_parent_key": parent_key,
+        }
+
+    # New normalize for p1 emits ONLY A — B has disappeared upstream.
+    connector = _ChunksStub({"p1": [chunk_a]})
+    qdrant = _FootprintQdrant(existing)
+    embed = _mock_embed()
+
+    run_connector(connector, qdrant, embed, batch_size=10)
+
+    b_pid = str(compute_chunk_id(chunk_b.source_item_id, 0))
+    assert len(qdrant.deletes) == 1, (
+        "the vanished child must trigger exactly one delete"
+    )
+    assert _deleted_point_ids(qdrant.deletes[0]) == {b_pid}, (
+        "ONLY B's orphaned point may be deleted; A survives (overwritten in place)"
+    )
+
+
+def test_shrink_in_place_removes_stale_chunk() -> None:
+    """(c) An item that previously stored 3 chunks and now yields 2 (all present,
+    content unchanged) must STILL take the rewrite branch and delete ONLY the
+    stale 3rd chunk's point id so it stops being retrievable."""
+    kept_0 = _chunk("item-S", 0, "Teil 1", content_hash="h-0")
+    kept_1 = _chunk("item-S", 1, "Teil 2", content_hash="h-1")
+    existing: dict[str, dict] = {}
+    for c in (kept_0, kept_1):
+        pid, payload = _existing_payload(c)
+        existing[pid] = payload
+    # The stale 3rd chunk still stored under the SAME source_item_id.
+    stale_pid = str(compute_chunk_id(kept_0.source_item_id, 2))
+    existing[stale_pid] = {
+        "source_item_id": str(kept_0.source_item_id),
+        "content_hash": "h-2",
+    }
+
+    connector = _ChunksStub({"s1": [kept_0, kept_1]})
+    qdrant = _FootprintQdrant(existing)
+    embed = _mock_embed()
+
+    report = run_connector(connector, qdrant, embed, batch_size=10)
+
+    assert len(qdrant.deletes) == 1, (
+        "3→2 shrink-in-place must delete the stale chunk_index=2 point"
+    )
+    assert _deleted_point_ids(qdrant.deletes[0]) == {stale_pid}, (
+        "only the orphan id is deleted; the surviving 2 ids are upsert-overwritten"
+    )
+    assert len(qdrant.upserts) == 1, "the surviving 2 chunks must be re-upserted"
+    assert report.chunks_upserted == 2
+    assert report.processed == 1
+    assert report.present_skips == 0, (
+        "an orphaned footprint is NOT a clean present-skip"
+    )
+
+
+def test_rewrite_preserves_grafted_transcript_pdf_url() -> None:
+    """Regression: a rewrite (content changed) must carry a previously grafted
+    meta.transcript_pdf_url into the new payloads — the fresh mapper output never
+    emits it and the donating DIP twin is already deleted, so without this every
+    op re-alignment cycle strips the merge result."""
+    pdf_url = "https://dserver.bundestag.de/btp/20/2000101.pdf"
+    new_chunk = _chunk("speech-G", 0, "neu ausgerichteter Text", content_hash="h-new")
+    pid = str(compute_chunk_id(new_chunk.source_item_id, 0))
+    existing = {
+        pid: {
+            "source_item_id": str(new_chunk.source_item_id),
+            "content_hash": "h-old",  # content changed → rewrite fires
+            "meta": {"transcript_pdf_url": pdf_url},
+        }
+    }
+
+    connector = _ChunksStub({"g1": [new_chunk]})
+    qdrant = _FootprintQdrant(existing)
+    embed = _mock_embed()
+
+    run_connector(connector, qdrant, embed, batch_size=10)
+
+    assert len(qdrant.upserts) == 1
+    upserted = qdrant.upserts[0]["points"][0]
+    assert (upserted.payload.get("meta") or {}).get("transcript_pdf_url") == pdf_url, (
+        "the grafted transcript PDF must survive the rewrite"
+    )
+
+
+def test_rewrite_does_not_overwrite_new_chunks_own_pdf() -> None:
+    """A new payload that ALREADY carries meta.transcript_pdf_url keeps its
+    own value — the preserved graft applies only where the field is absent."""
+    own_pdf = "https://dserver.bundestag.de/btp/21/OWN.pdf"
+    stale_pdf = "https://dserver.bundestag.de/btp/20/STALE.pdf"
+    base = _chunk("speech-H", 0, "Text", content_hash="h-new")
+    new_chunk = base.model_copy(update={"meta": {"transcript_pdf_url": own_pdf}})
+    pid = str(compute_chunk_id(new_chunk.source_item_id, 0))
+    existing = {
+        pid: {
+            "source_item_id": str(new_chunk.source_item_id),
+            "content_hash": "h-old",
+            "meta": {"transcript_pdf_url": stale_pdf},
+        }
+    }
+
+    connector = _ChunksStub({"h1": [new_chunk]})
+    qdrant = _FootprintQdrant(existing)
+    embed = _mock_embed()
+
+    run_connector(connector, qdrant, embed, batch_size=10)
+
+    upserted = qdrant.upserts[0]["points"][0]
+    assert (upserted.payload.get("meta") or {}).get("transcript_pdf_url") == own_pdf
+
+
+class _SkipReportingStub(_ChunksStub):
+    """Stub whose normalize() reports op-superseded skipped siids (plumbing)."""
+
+    def __init__(self, chunks_by_id: dict, superseded_siids: list[str]) -> None:
+        super().__init__(chunks_by_id)
+        self._superseded_siids = superseded_siids
+
+    def normalize(self, raw: dict) -> list[ChunkRecord]:
+        self.last_superseded_siids = tuple(self._superseded_siids)
+        return super().normalize(raw)
+
+
+def test_runner_deletes_stranded_twins_reported_by_normalize() -> None:
+    """Mitigation: siids a connector's normalize() skipped as op-superseded
+    are cleaned up by the runner — a stranded DIP twin from an interleaved
+    concurrent DIP+op run appears in no new-chunk/orphan filter otherwise."""
+    stranded_siid = "11111111-2222-3333-4444-555555555555"
+    connector = _SkipReportingStub({"p1": []}, [stranded_siid])
+    qdrant = _FootprintQdrant({})
+    embed = _mock_embed()
+
+    run_connector(connector, qdrant, embed, batch_size=10)
+
+    assert len(qdrant.deletes) == 1, "the stranded twin's siid must be deleted"
+    delete_filter = qdrant.deletes[0]["points_selector"].filter
+    matched: set[str] = set()
+    for cond in delete_filter.must:
+        if cond.key == "source_item_id":
+            values = getattr(cond.match, "any", None) or [cond.match.value]
+            matched.update(str(v) for v in values)
+    assert matched == {stranded_siid}
+    assert not qdrant.upserts, "an empty-chunks item still upserts nothing"
+
+
+def test_embed_failure_leaves_existing_footprint_intact() -> None:
+    """Loss-window regression: when the embed call fails mid-item, NOTHING may
+    have been deleted — the old delete-before-embed order left the item absent
+    until (or beyond) lookback expiry."""
+    changed = [_chunk("item-C", 0, "korrigierter Text", content_hash="h-new")]
+    pid = str(compute_chunk_id(changed[0].source_item_id, 0))
+    existing = {
+        pid: {
+            "source_item_id": str(changed[0].source_item_id),
+            "content_hash": "h-old",  # content changed → rewrite branch fires
+        }
+    }
+
+    connector = _ChunksStub({"c1": changed})
+    qdrant = _FootprintQdrant(existing)
+    embed = MagicMock()
+    embed.embed_documents.side_effect = RuntimeError("OpenAI down")
+
+    # Neutralize tenacity's exponential backoff so the test stays fast.
+    from unittest.mock import patch
+
+    with patch(
+        "src.ingestion.run._embed_texts", side_effect=RuntimeError("OpenAI down")
+    ):
+        report = run_connector(connector, qdrant, embed, batch_size=10)
+
+    assert report.failed_ids == ("c1",), "the item is skip-and-warned, not lost"
+    assert not qdrant.deletes, "embed must run BEFORE any delete (no loss window)"
+    assert not qdrant.upserts
+
+
+def test_no_orphans_all_present_unchanged_skips() -> None:
+    """(c) Control: all present + unchanged + no orphans → clean skip, no delete."""
+    kept = [_chunk("item-U", 0, "Teil 1", content_hash="h-u")]
+    pid, payload = _existing_payload(kept[0])
+
+    connector = _ChunksStub({"u1": kept})
+    qdrant = _FootprintQdrant({pid: payload})
+    embed = _mock_embed()
+
+    report = run_connector(connector, qdrant, embed, batch_size=10)
+
+    assert not qdrant.deletes
+    assert not qdrant.upserts
+    embed.embed_documents.assert_not_called()
+    assert report.present_skips == 1
+    assert report.processed == 0
+
+
+# ---------------------------------------------------------------------------
+# (e) QDRANT_API_KEY plumbed into every QdrantClient construction
+# ---------------------------------------------------------------------------
+
+
+def test_dip_resurrection_guard_client_plumbs_api_key(monkeypatch) -> None:
+    """(e) The DIP resurrection-guard client forwards QDRANT_API_KEY to QdrantClient
+    — behavioural: patch the client constructor and assert the api_key it receives.
+    (The run.py __main__ client shares the same wiring but lives in an
+    `if __name__ == '__main__'` block, exercised at deploy/integration, not here.)"""
+    import qdrant_client
+
+    from src.ingestion.connectors.bundestag_speeches.connector import (
+        BundestagSpeechesConnector,
+    )
+
+    captured: dict = {}
+
+    class _FakeClient:
+        def __init__(self, **kwargs) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(qdrant_client, "QdrantClient", _FakeClient)
+    monkeypatch.setenv("QDRANT_API_KEY", "secret-key")
+
+    conn = BundestagSpeechesConnector.__new__(BundestagSpeechesConnector)
+    conn._qdrant = None
+    conn._qdrant_lazy_enabled = True  # enable the production lazy-construct path
+    conn._get_qdrant()
+
+    assert captured.get("api_key") == "secret-key", (
+        "DIP resurrection-guard client must forward QDRANT_API_KEY"
+    )

--- a/ai-backend/tests/ingestion/test_run.py
+++ b/ai-backend/tests/ingestion/test_run.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/tests/ingestion/test_speech_key.py
+++ b/ai-backend/tests/ingestion/test_speech_key.py
@@ -1,0 +1,288 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Golden op/DIP parity test for the shared speech_key helper.
+
+The shared module does not exist yet. The top-level
+`pytest.importorskip(...)` makes this whole file SKIP cleanly until
+`src.ingestion.speech_key` lands, at which point the real
+assertions run.
+
+Covers:
+  - test_op_dip_parity: the SAME real speaker fed two ways — op's discrete
+    firstname+lastname vs DIP's merged `speaker_name` carrying an academic
+    title — must produce BYTE-IDENTICAL keys of shape
+    `de-20-101-<slug>-top20`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# SKIP until the shared speech_key helper exists.
+speech_key = pytest.importorskip(
+    "src.ingestion.speech_key",
+    reason="shared speech_key helper not yet implemented",
+)
+
+
+def _make_key(**kwargs) -> str:
+    """Call make_speech_key tolerant of the exact keyword surface."""
+    fn = getattr(speech_key, "make_speech_key")
+    return fn(**kwargs)
+
+
+def test_op_dip_parity() -> None:
+    """Identical speech_key from op (discrete names) and DIP (merged name+title).
+
+    Same real speaker (Mareike Lotte Wulf, CDU/CSU), same session 101 / EP 20,
+    same agenda "Tagesordnungspunkt 20" → both sources must derive the identical
+    key `de-20-101-mareike-lotte-wulf-top20`.
+    """
+    op_key = _make_key(
+        ep=20,
+        session=101,
+        firstname="Mareike Lotte",
+        lastname="Wulf",
+        agenda="Tagesordnungspunkt 20",
+    )
+    dip_key = _make_key(
+        ep=20,
+        session=101,
+        speaker_name="Dr. Mareike Lotte Wulf",  # DIP merged string w/ academic title
+        agenda="Tagesordnungspunkt 20",
+    )
+
+    assert op_key == dip_key, (
+        f"op and DIP must derive byte-identical speech_key; got op={op_key!r} dip={dip_key!r}"
+    )
+    assert op_key == "de-20-101-mareike-lotte-wulf-top20", (
+        f"unexpected speech_key shape: {op_key!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# NFC pre-normalization — NFD input must not bypass the umlaut expansion
+# ---------------------------------------------------------------------------
+
+
+def test_nfd_and_nfc_names_produce_identical_slug() -> None:
+    """'Körig' as NFD (o + combining diaeresis) must slugify identically to
+    NFC 'Körig' — both expand ö→oe → 'koerig' (previously NFD folded to 'korig',
+    a silent cross-source dedup miss)."""
+    import unicodedata
+
+    slugify = getattr(speech_key, "slugify_speaker")
+    nfc_name = unicodedata.normalize("NFC", "Körig")
+    nfd_name = unicodedata.normalize("NFD", "Körig")
+    assert nfc_name != nfd_name, (
+        "sanity: the two normal forms must differ codepoint-wise"
+    )
+    assert slugify(full_name=nfd_name) == slugify(full_name=nfc_name) == "koerig"
+
+
+# ---------------------------------------------------------------------------
+# Compound academic titles — DIP merged name vs op discrete names parity
+# ---------------------------------------------------------------------------
+
+
+def test_compound_title_dr_h_c_parity() -> None:
+    """DIP 'Dr. h. c. Thomas Sattelberger' == op discrete names — the h/c
+    fragments of the compound title must be dropped."""
+    dip_key = _make_key(
+        ep=20,
+        session=101,
+        speaker_name="Dr. h. c. Thomas Sattelberger",
+        agenda="Tagesordnungspunkt 20",
+    )
+    op_key = _make_key(
+        ep=20,
+        session=101,
+        firstname="Thomas",
+        lastname="Sattelberger",
+        agenda="Tagesordnungspunkt 20",
+    )
+    assert dip_key == op_key == "de-20-101-thomas-sattelberger-top20"
+
+
+def test_compound_title_dr_ing_parity() -> None:
+    """DIP 'Dr.-Ing. Klara Beispiel' == op discrete names ('ing' dropped)."""
+    dip_key = _make_key(
+        ep=21,
+        session=5,
+        speaker_name="Dr.-Ing. Klara Beispiel",
+        agenda="Tagesordnungspunkt 3",
+    )
+    op_key = _make_key(
+        ep=21,
+        session=5,
+        firstname="Klara",
+        lastname="Beispiel",
+        agenda="Tagesordnungspunkt 3",
+    )
+    assert dip_key == op_key == "de-21-5-klara-beispiel-top3"
+
+
+# ---------------------------------------------------------------------------
+# Name particles — DIP (namenszusatz unparsed) vs op (particle in lastname)
+# ---------------------------------------------------------------------------
+
+
+def test_name_particle_von_parity() -> None:
+    """DIP merged 'Beatrix Storch' (parser never reads <namenszusatz>) and op
+    firstname='Beatrix' lastname='von Storch' must derive one identical key —
+    the particle is dropped source-independently."""
+    dip_key = _make_key(
+        ep=20,
+        session=101,
+        speaker_name="Beatrix Storch",
+        agenda="Tagesordnungspunkt 20",
+    )
+    op_key = _make_key(
+        ep=20,
+        session=101,
+        firstname="Beatrix",
+        lastname="von Storch",
+        agenda="Tagesordnungspunkt 20",
+    )
+    assert dip_key == op_key == "de-20-101-beatrix-storch-top20"
+
+
+# ---------------------------------------------------------------------------
+# Umlaut/ß + title/particle parity via BOTH make_speech_key call surfaces
+# (raw names vs pre-slugified speaker_slug/agenda_slug)
+# ---------------------------------------------------------------------------
+
+
+def test_umlaut_and_eszett_parity_via_both_call_surfaces() -> None:
+    """'Jörg Groß' must derive the same key from the raw surface (firstname/
+    lastname) and the pre-slugified surface (speaker_slug/agenda_slug):
+    ö→oe, ß→ss are never dropped on either path."""
+    slugify = getattr(speech_key, "slugify_speaker")
+    assert slugify(full_name="Müller") == slugify(lastname="Müller") == "mueller"
+
+    raw_key = _make_key(
+        ep=20,
+        session=9,
+        firstname="Jörg",
+        lastname="Groß",
+        agenda="Tagesordnungspunkt 2",
+    )
+    pre_key = _make_key(
+        ep=20,
+        session=9,
+        speaker_slug=slugify(full_name="Jörg Groß"),
+        agenda_slug="top2",
+    )
+    assert raw_key == pre_key == "de-20-9-joerg-gross-top2"
+
+
+def test_title_and_particle_parity_via_both_call_surfaces() -> None:
+    """Compound title + name particle stripped identically on both surfaces:
+    DIP merged 'Dr. h. c. Beatrix Storch' == op pre-slugified 'von Storch'."""
+    slugify = getattr(speech_key, "slugify_speaker")
+    dip_key = _make_key(
+        ep=20,
+        session=101,
+        speaker_name="Dr. h. c. Beatrix Storch",
+        top_id="20",
+    )
+    op_key = _make_key(
+        ep=20,
+        session=101,
+        speaker_slug=slugify(firstname="Beatrix", lastname="von Storch"),
+        agenda_slug="top20",
+    )
+    assert dip_key == op_key == "de-20-101-beatrix-storch-top20"
+
+
+# ---------------------------------------------------------------------------
+# Opening segments have no DIP counterpart → empty agenda slug on both sides
+# ---------------------------------------------------------------------------
+
+
+def test_opening_agenda_maps_to_empty_slug() -> None:
+    """op agenda_type='opening' must yield '' (DIP redes outside any
+    <tagesordnungspunkt> also yield ''), so opening-segment speeches dedup."""
+    _agenda = getattr(speech_key, "agenda_slug_from_official")
+    assert _agenda(None, "opening") == ""
+    op_key = _make_key(
+        ep=20,
+        session=101,
+        firstname="A",
+        lastname="B",
+        agenda=None,
+        agenda_type="opening",
+    )
+    dip_key = _make_key(ep=20, session=101, speaker_name="A B", top_id=None)
+    assert op_key == dip_key == "de-20-101-a-b-"
+
+
+# ---------------------------------------------------------------------------
+# Agenda-slug op/DIP parity + Zusatzpunkt/Tagesordnungspunkt distinction
+# ---------------------------------------------------------------------------
+
+_agenda_from_official = getattr(speech_key, "agenda_slug_from_official")
+_agenda_from_top_id = getattr(speech_key, "agenda_slug_from_top_id")
+
+
+def test_agenda_slug_zusatzpunkt_parity() -> None:
+    """``Zusatzpunkt 5`` (op) and ``ZP5`` (DIP top-id) both → ``zp5``."""
+    assert _agenda_from_official("Zusatzpunkt 5") == "zp5"
+    assert _agenda_from_top_id("ZP5") == "zp5"
+    assert _agenda_from_top_id("Z5") == "zp5"
+    # And the full key agrees on both sides for the same Zusatzpunkt speech.
+    op_key = _make_key(
+        ep=20, session=101, firstname="A", lastname="B", agenda="Zusatzpunkt 5"
+    )
+    dip_key = _make_key(ep=20, session=101, speaker_name="A B", top_id="ZP5")
+    assert op_key == dip_key == "de-20-101-a-b-zp5"
+
+
+def test_agenda_slug_tagesordnungspunkt_parity() -> None:
+    """``Tagesordnungspunkt 5`` (op) and ``5`` (DIP top-id) both → ``top5``."""
+    assert _agenda_from_official("Tagesordnungspunkt 5") == "top5"
+    assert _agenda_from_top_id("5") == "top5"
+    op_key = _make_key(
+        ep=20, session=101, firstname="A", lastname="B", agenda="Tagesordnungspunkt 5"
+    )
+    dip_key = _make_key(ep=20, session=101, speaker_name="A B", top_id="5")
+    assert op_key == dip_key == "de-20-101-a-b-top5"
+
+
+def test_agenda_slug_letter_suffix_parity() -> None:
+    """Letter-suffixed / combined item matches on both sides (first integer).
+
+    op ``"Tagesordnungspunkt 20 a"`` and DIP top-id ``"20a"`` must both → ``top20``
+    (previously op used the TRAILING integer and produced an empty agenda → a
+    missed dedup, the exact failure this phase exists to prevent).
+    """
+    assert _agenda_from_official("Tagesordnungspunkt 20 a") == "top20"
+    assert _agenda_from_top_id("20a") == "top20"
+    op_key = _make_key(
+        ep=20,
+        session=101,
+        firstname="A",
+        lastname="B",
+        agenda="Tagesordnungspunkt 20 a",
+    )
+    dip_key = _make_key(ep=20, session=101, speaker_name="A B", top_id="20a")
+    assert op_key == dip_key == "de-20-101-a-b-top20"
+
+
+def test_zusatzpunkt_and_tagesordnungspunkt_do_not_collide() -> None:
+    """ZP5 and TOP5 must produce DIFFERENT keys.
+
+    Guards against the destructive supersede-delete: if a speaker speaks under
+    both ZP5 and TOP5 in one session, the two distinct speeches must NOT share a
+    speech_key (else superseding the op TOP5 copy would delete the ZP5 DIP chunk).
+    """
+    assert _agenda_from_top_id("ZP5") != _agenda_from_top_id("5")
+    assert _agenda_from_official("Zusatzpunkt 5") != _agenda_from_official(
+        "Tagesordnungspunkt 5"
+    )
+    zp_key = _make_key(ep=20, session=101, speaker_name="A B", top_id="ZP5")
+    top_key = _make_key(ep=20, session=101, speaker_name="A B", top_id="5")
+    assert zp_key != top_key

--- a/ai-backend/tests/ingestion/test_speech_key.py
+++ b/ai-backend/tests/ingestion/test_speech_key.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -286,3 +286,17 @@ def test_zusatzpunkt_and_tagesordnungspunkt_do_not_collide() -> None:
     zp_key = _make_key(ep=20, session=101, speaker_name="A B", top_id="ZP5")
     top_key = _make_key(ep=20, session=101, speaker_name="A B", top_id="5")
     assert zp_key != top_key
+
+
+def test_opening_segment_never_gets_numeric_slug() -> None:
+    """agenda_type == "opening" must ALWAYS yield the empty slug, even when the
+    title contains a number ("Eröffnung der 90. Sitzung" must not become
+    top90): DIP yields "" for redes outside any <tagesordnungspunkt>, so any
+    op-side opening slug breaks cross-source dedup."""
+    from src.ingestion.speech_key import agenda_slug_from_official
+
+    assert agenda_slug_from_official("Eröffnung der 90. Sitzung", "opening") == ""
+    assert agenda_slug_from_official("Sitzungseröffnung", "opening") == ""
+    # Non-opening titles keep the numeric extraction.
+    assert agenda_slug_from_official("Tagesordnungspunkt 20", None) == "top20"
+    assert agenda_slug_from_official("Zusatzpunkt 5", "agenda_item") == "zp5"

--- a/ai-backend/uv.lock
+++ b/ai-backend/uv.lock
@@ -1677,6 +1677,7 @@ dependencies = [
     { name = "defusedxml" },
     { name = "fastapi" },
     { name = "firebase-admin" },
+    { name = "httpx" },
     { name = "langchain" },
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
@@ -1691,6 +1692,7 @@ dependencies = [
     { name = "qdrant-client" },
     { name = "requests" },
     { name = "sse-starlette" },
+    { name = "tenacity" },
     { name = "trafilatura" },
     { name = "uvicorn" },
     { name = "xxhash" },
@@ -1698,7 +1700,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "httpx" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -1712,6 +1713,7 @@ requires-dist = [
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "fastapi", specifier = ">=0.136.3" },
     { name = "firebase-admin", specifier = ">=7.4.0,<7.5" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "langchain", specifier = ">=1.3.4" },
     { name = "langchain-core", specifier = ">=1.4.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.0" },
@@ -1726,6 +1728,7 @@ requires-dist = [
     { name = "qdrant-client", specifier = ">=1.18.0,<1.19" },
     { name = "requests", specifier = ">=2.34.2" },
     { name = "sse-starlette", specifier = ">=3.4.4" },
+    { name = "tenacity", specifier = ">=8.2" },
     { name = "trafilatura", specifier = ">=2.1.0" },
     { name = "uvicorn", specifier = ">=0.34.0" },
     { name = "xxhash", specifier = ">=3.5.0" },
@@ -1733,7 +1736,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "httpx", specifier = ">=0.27" },
     { name = "mypy", specifier = ">=1.12.0" },
     { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pytest", specifier = ">=8.3" },


### PR DESCRIPTION
V2 stack 4/9 — Bundestag plenary speeches from the DIP API (`parliamentary_speech`, `source="dip"`).

- **Protocol XML parser** for plenary transcripts, with speaker→party resolution via the official MdB master data (Stammdaten).
- **Speech chunking** (~1000-char boundary-aware) and PDF citations pointing at the original Bundestag transcript.
- **`speech_key` / `speech_dedup`** — the shared speech-identity infrastructure that the openparliament.tv connector (next-but-one PR) uses to dedupe against DIP.
- The runner's cross-connector tests land here too (`test_run.py` exercises the runner against this connector, including the disappeared-child parent-footprint reconciliation).

Scope note: speeches are deliberately capped at WP20/21 — earlier protocols have formats the parser can't ingest reliably — and there is no Landtag speech source, so this content is federal-only by nature.

This PR comes before manifestos (a swap vs. the originally proposed order) because the manifesto test suite contains the cross-connector slug-parity guard that asserts against this connector's party-slug map.

Verified: ruff, mypy, 330 tests, GDPR wall guard.
