### PR TITLE
V2 stack 5/9: Party manifestos connector

### DIFF
--- a/ai-backend/src/ingestion/connectors/manifestos/__init__.py
+++ b/ai-backend/src/ingestion/connectors/manifestos/__init__.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""Manifesto connector package — party Wahlprogramme → party_manifesto corpus.
+
+Source: the Abgeordnetenwatch ``election-program`` API (reuses the shared
+``AWClient`` from the abgeordnetenwatch connector package).
+
+Single-store shape: produces ChunkRecord list directly from
+normalize() — embed + upsert are owned by the runner (run.py).
+
+Citations point at the original source URL (the AW ``file`` PDF URL or the link
+URI) — wahl.chat does not store or re-serve the files, so there is no local PDF
+storage and no Firestore source-doc.
+
+Package structure (mirrors connectors/abgeordnetenwatch/):
+  connector.py        — ManifestoConnector(BaseConnector): discover/fetch/normalize
+                        + shared I/O helpers (_fetch_period_date, load_program_pages)
+  bulk.py             — standalone bulk CLI: the ingest() loop with --dry-run /
+                        --ids / --limit flags.
+                        Runs via `python -m src.ingestion.connectors.manifestos.bulk`.
+  mappers/
+    corpus.py         — pure transforms (slug/region/wahlperiode/chunk/build,
+                        plus trafilatura main-content extraction), no I/O
+
+Two entrypoints, one data path:
+  - The generic runner (run.py --connector manifestos) drives the BaseConnector
+    interface (Qdrant-cursor embed path).
+  - bulk.py is the bespoke local-dev workflow (--dry-run / --ids / --limit).
+  Both share connector.py's I/O helpers and mappers/corpus.py's transforms.
+"""

--- a/ai-backend/src/ingestion/connectors/manifestos/__init__.py
+++ b/ai-backend/src/ingestion/connectors/manifestos/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/src/ingestion/connectors/manifestos/bulk.py
+++ b/ai-backend/src/ingestion/connectors/manifestos/bulk.py
@@ -1,0 +1,381 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Standalone bulk CLI for ingesting party manifestos (Wahlprogramme) from the
+Abgeordnetenwatch ``election-program`` API into ``wahlchat_chunks_{ENV}``.
+
+This is the bespoke local-dev entrypoint that the generic runner (run.py) cannot
+express: it adds the --dry-run / --ids / --limit flags on top of the same data
+path as ManifestoConnector.  The connector's interface methods are driven by
+run.py for the standard cursor-based embed path; this script reuses the
+connector's shared I/O helpers (determine_source, load_program_pages,
+_fetch_period_date) and the pure mappers so there is a single fetch/parse +
+record-build implementation.
+
+Source rule (locked design):
+  1. If ``link[0].uri`` is non-null  -> scrape HTML main content (trafilatura).
+  2. Elif ``file`` (PDF url) non-null -> download + parse the PDF in-memory.
+  3. Else skip the program.
+
+citation_url points at the original source URL in both cases — wahl.chat does
+not re-serve or store the files (no local storage, no Firestore source-doc).
+
+Scope: by default ALL programs are ingested. Pass ``--since YYYY-MM-DD`` (or set
+``MANIFESTO_SINCE``) to floor by parliament_period ``election_date``; the operator
+chooses the window and the CLI carries no built-in cut-off.
+
+Usage (local dev):
+    cd ai-backend
+    uv run python -m src.ingestion.connectors.manifestos.bulk --dry-run --limit 5
+    uv run python -m src.ingestion.connectors.manifestos.bulk --ids 598,599,600
+    uv run python -m src.ingestion.connectors.manifestos.bulk --since 2020-01-01
+    QDRANT_URL=http://localhost:6333 ENV=dev uv run python -m src.ingestion.connectors.manifestos.bulk
+
+Re-running REWRITES each processed program's footprint: the flush deletes the
+program's existing chunks by source_item_id (wait=True) before upserting the
+fresh ones, so a shrunk/replaced PDF leaves no stale higher-index chunks behind.
+Deterministic chunk UUIDs (via compute_chunk_id) keep unchanged chunks at the
+same point IDs; everything flushed IS re-embedded (this bespoke CLI has no
+content-hash skip — use run.py + MANIFESTO_REFRESH for the cheap reconcile).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from datetime import date as date_type
+from typing import Optional
+
+from langchain_core.embeddings import Embeddings
+from qdrant_client import QdrantClient
+
+from src.ingestion.connectors.manifestos.connector import (
+    _fetch_period_date,
+    determine_source,
+    load_program_pages,
+    resolve_since_floor,
+)
+from src.ingestion.connectors.manifestos.mappers.corpus import (
+    SourceKind,
+    build_manifesto_records,
+    chunk_pages,
+    party_to_slug,
+)
+from src.embeddings import get_embeddings
+from src.ingestion.run import _embed_texts, _upsert_chunks
+from src.ingestion.schemas import ChunkRecord
+from src.ingestion.setup_collection import COLLECTION_NAME
+
+logger = logging.getLogger(__name__)
+
+_BATCH_SIZE = 100  # chunks per embed+upsert batch
+
+
+# =============================================================================
+# MAIN INGEST LOOP
+# =============================================================================
+
+
+def ingest(
+    qdrant: QdrantClient,
+    embed: Embeddings,
+    limit: Optional[int] = None,
+    ids: Optional[list[int]] = None,
+    dry_run: bool = False,
+    since: Optional[date_type] = None,
+) -> tuple[int, int]:
+    """Fetch manifesto programs from AW, embed, and upsert into Qdrant.
+
+    Args:
+        qdrant:  Initialised QdrantClient.
+        embed:   Initialised embeddings client (from get_embeddings()).
+        limit:   Max programs to process (None = all passing the date filter).
+        ids:     Specific AW program IDs to process (overrides limit).
+        dry_run: If True, skip embed/upsert; fetch, parse, and print per-program
+                 stats (party, period, source_kind, pages, chars, chunks).
+        since:   Optional election-date floor; programs whose parliament_period
+                 election_date is strictly before it are skipped. When None
+                 (default) NO floor is applied and every program is in scope.
+
+    Returns:
+        Tuple of (programs_processed, chunks_upserted).
+    """
+    from src.ingestion.connectors.abgeordnetenwatch.client import AWClient  # noqa: PLC0415
+
+    client = AWClient()
+    period_date_cache: dict[int, Optional[str]] = {}
+
+    print("Discovering election-program records from AW API ...")
+    all_programs: list[dict] = client.get_all("election-program", {})
+    print(f"  Found {len(all_programs)} total programs")
+
+    # Filter to requested IDs if specified
+    if ids:
+        id_set = set(ids)
+        all_programs = [p for p in all_programs if p.get("id") in id_set]
+        print(f"  After --ids filter: {len(all_programs)} programs")
+
+    # Resolve election_date per program and apply the optional floor. With no
+    # floor (since is None) every program is kept — the CLI has no built-in cut-off.
+    eligible_programs: list[tuple[dict, str]] = []  # (program, date_iso)
+
+    for program in all_programs:
+        period_obj = program.get("parliament_period") or {}
+        period_id = period_obj.get("id")
+        if not period_id:
+            continue
+        date_iso = _fetch_period_date(client, int(period_id), period_date_cache)
+        if not date_iso:
+            continue
+        try:
+            election_date = date_type.fromisoformat(date_iso)
+        except (ValueError, TypeError):
+            continue
+        if since is not None and election_date < since:
+            continue
+        eligible_programs.append((program, date_iso))
+
+    _floor_label = f">= {since.isoformat()}" if since is not None else "no floor"
+    print(f"  After date filter ({_floor_label}): {len(eligible_programs)} programs")
+
+    if limit is not None and not ids:
+        eligible_programs = eligible_programs[:limit]
+        print(f"  After --limit {limit}: {len(eligible_programs)} programs")
+
+    programs_processed = 0
+    chunks_total = 0
+    batch: list[ChunkRecord] = []
+
+    def _flush(b: list[ChunkRecord]) -> int:
+        if not b or dry_run:
+            return 0
+        from qdrant_client import models as qdrant_models  # noqa: PLC0415
+
+        # Embed FIRST — an embed failure leaves the existing footprint intact
+        # (no delete-before-embed loss window; mirrors run.py's ordering).
+        vectors = _embed_texts(embed, [c.text for c in b])
+
+        # Rewrite semantics (mirrors run.py's footprint guard) — delete each
+        # program's EXISTING footprint by source_item_id before upserting, one
+        # delete per program with wait=True, so a re-run against a shrunk PDF
+        # (fewer chunks than stored) leaves no stale higher-index chunks
+        # retrievable forever.
+        siids = sorted({str(c.source_item_id) for c in b})
+        for siid in siids:
+            qdrant.delete(
+                collection_name=COLLECTION_NAME,
+                points_selector=qdrant_models.FilterSelector(
+                    filter=qdrant_models.Filter(
+                        must=[
+                            qdrant_models.FieldCondition(
+                                key="source_item_id",
+                                match=qdrant_models.MatchValue(value=siid),
+                            )
+                        ]
+                    )
+                ),
+                wait=True,
+            )
+
+        _upsert_chunks(qdrant, COLLECTION_NAME, b, vectors)
+        return len(b)
+
+    for program, period_date_iso in eligible_programs:
+        program_id: int = program["id"]
+        party_label: str = (program.get("party") or {}).get("label") or ""
+        period_label: str = (program.get("parliament_period") or {}).get("label") or ""
+
+        # Determine source_kind / source_url (locked source rule)
+        try:
+            source_kind, source_url = determine_source(program)
+        except ValueError:
+            print(f"  SKIP program {program_id} ({party_label}): no link or file")
+            continue
+
+        party_slug = party_to_slug(party_label)
+
+        # --- Fetch and parse ---
+        try:
+            content = load_program_pages(source_kind, source_url)
+        except ValueError as exc:
+            print(f"  SKIP program {program_id} ({party_label}): {exc}")
+            continue
+
+        pages_list: list[tuple[int, str]] = content["pages"]
+        total_pages: Optional[int] = content["total_pages"]
+
+        # --- Chunk ---
+        chunk_tuples = chunk_pages(pages_list)
+        if not chunk_tuples:
+            print(
+                f"  SKIP program {program_id} ({party_label}): no text after chunking"
+            )
+            continue
+
+        # Convert chunk_pages output to the format expected by build_manifesto_records.
+        # For HTML source, null out page numbers per spec.
+        if source_kind == SourceKind.LINK:
+            build_chunks: list[tuple[str, Optional[int], Optional[int]]] = [
+                (text, None, None) for text, _ps, _pe in chunk_tuples
+            ]
+        else:
+            build_chunks = list(chunk_tuples)
+
+        # --- Count characters for dry-run report (chunking is character-based) ---
+        total_chars = sum(len(t) for t, _, _ in build_chunks)
+
+        if dry_run:
+            print(
+                f"  DRY-RUN program {program_id}: party={party_slug!r} "
+                f"period={period_label!r} source_kind={source_kind!r} "
+                f"pages={total_pages} chars={total_chars} chunks={len(build_chunks)}"
+            )
+            programs_processed += 1
+            chunks_total += len(build_chunks)
+            continue
+
+        # --- Build records ---
+        records = build_manifesto_records(
+            program=program,
+            period_date_iso=period_date_iso,
+            chunks=build_chunks,
+            source_kind=source_kind,
+            source_url=source_url,
+            total_pages=total_pages,
+        )
+
+        if not records:
+            print(f"  SKIP program {program_id} ({party_label}): no records built")
+            continue
+
+        # --- Batch embed + upsert ---
+        batch.extend(records)
+        chunks_total += len(records)
+        print(
+            f"  program {program_id}: party={party_slug!r} "
+            f"period={period_label!r} source={source_kind} chunks={len(records)}"
+        )
+
+        if len(batch) >= _BATCH_SIZE:
+            _flush(batch)
+            batch = []
+
+        programs_processed += 1
+
+    # Flush remaining
+    _flush(batch)
+
+    return programs_processed, chunks_total
+
+
+# =============================================================================
+# __main__ entrypoint
+# =============================================================================
+
+if __name__ == "__main__":
+    # Load ai-backend/.env if present.
+    from pathlib import Path  # noqa: PLC0415
+
+    from dotenv import load_dotenv  # noqa: PLC0415
+
+    _env_path = Path(__file__).resolve().parents[4] / ".env"
+    if _env_path.exists():
+        # .env is the source of truth for local dev — let it win over any stale
+        # value inherited from the shell.
+        load_dotenv(_env_path, override=True)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Ingest party manifestos from the Abgeordnetenwatch election-program API "
+            "into the Qdrant wahlchat_chunks_{ENV} collection."
+        ),
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Process at most N programs passing the 2020 filter.",
+    )
+    parser.add_argument(
+        "--ids",
+        type=str,
+        default=None,
+        metavar="ID1,ID2,...",
+        help="Comma-separated AW election-program IDs to process (for smoke testing).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help=(
+            "Fetch and parse programs but skip embed + upsert. "
+            "Prints per-program stats (party, period, source_kind, pages, chars, chunks)."
+        ),
+    )
+    parser.add_argument(
+        "--since",
+        type=str,
+        default=None,
+        metavar="YYYY-MM-DD",
+        help=(
+            "Only ingest programs whose parliament_period election_date is on or "
+            "after this ISO date. Overrides MANIFESTO_SINCE. Default: no floor "
+            "(ingest all)."
+        ),
+    )
+    args = parser.parse_args()
+
+    # --since wins over MANIFESTO_SINCE; both default to no floor. An invalid
+    # value raises here (loud misconfiguration) before any AW/OpenAI work.
+    try:
+        since_floor = resolve_since_floor(args.since)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    specific_ids: Optional[list[int]] = None
+    if args.ids:
+        try:
+            specific_ids = [int(x.strip()) for x in args.ids.split(",") if x.strip()]
+        except ValueError:
+            print(
+                "ERROR: --ids must be a comma-separated list of integers",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    qdrant_url = os.getenv("QDRANT_URL", "http://localhost:6333")
+    _qdrant = QdrantClient(url=qdrant_url)
+    # Corpus passages → RETRIEVAL_DOCUMENT (matches the ingestion runner + the
+    # RETRIEVAL_QUERY side in retrieve.py; ignored for OpenAI).
+    _embed = get_embeddings(task_type="RETRIEVAL_DOCUMENT")
+
+    print(
+        f"Ingesting manifestos (dry_run={args.dry_run}, "
+        f"limit={args.limit}, ids={specific_ids}, "
+        f"since={since_floor.isoformat() if since_floor else None}) ..."
+    )
+    try:
+        processed, chunks = ingest(
+            _qdrant,
+            _embed,
+            limit=args.limit,
+            ids=specific_ids,
+            dry_run=args.dry_run,
+            since=since_floor,
+        )
+    except Exception:  # noqa: BLE001
+        import traceback  # noqa: PLC0415
+
+        print("ERROR: ingest failed:", file=sys.stderr)
+        traceback.print_exc()
+        sys.exit(1)
+
+    print(f"Done. programs_processed={processed}  chunks_upserted={chunks}")

--- a/ai-backend/src/ingestion/connectors/manifestos/bulk.py
+++ b/ai-backend/src/ingestion/connectors/manifestos/bulk.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -14,10 +14,11 @@ connector's shared I/O helpers (determine_source, load_program_pages,
 _fetch_period_date) and the pure mappers so there is a single fetch/parse +
 record-build implementation.
 
-Source rule (locked design):
+Source rule (locked design, with fallback):
   1. If ``link[0].uri`` is non-null  -> scrape HTML main content (trafilatura).
-  2. Elif ``file`` (PDF url) non-null -> download + parse the PDF in-memory.
-  3. Else skip the program.
+  2. If that fails or no link exists, and ``file`` (PDF url) is non-null ->
+     download + parse the PDF in-memory.
+  3. Only when every candidate fails is the program skipped.
 
 citation_url points at the original source URL in both cases — wahl.chat does
 not re-serve or store the files (no local storage, no Firestore source-doc).
@@ -33,12 +34,13 @@ Usage (local dev):
     uv run python -m src.ingestion.connectors.manifestos.bulk --since 2020-01-01
     QDRANT_URL=http://localhost:6333 ENV=dev uv run python -m src.ingestion.connectors.manifestos.bulk
 
-Re-running REWRITES each processed program's footprint: the flush deletes the
-program's existing chunks by source_item_id (wait=True) before upserting the
-fresh ones, so a shrunk/replaced PDF leaves no stale higher-index chunks behind.
-Deterministic chunk UUIDs (via compute_chunk_id) keep unchanged chunks at the
-same point IDs; everything flushed IS re-embedded (this bespoke CLI has no
-content-hash skip — use run.py + MANIFESTO_REFRESH for the cheap reconcile).
+Re-running REWRITES each processed program's footprint replacement-safely:
+embed → upsert the fresh chunks (deterministic point IDs overwrite in place,
+wait=True) → only THEN delete orphaned point ids the new output no longer
+produces. The old footprint is never removed before its replacement is
+durable, so a Qdrant failure mid-flush cannot leave a program absent.
+Everything flushed IS re-embedded (this bespoke CLI has no content-hash skip —
+use run.py + MANIFESTO_REFRESH for the cheap reconcile).
 """
 
 from __future__ import annotations
@@ -48,14 +50,28 @@ import logging
 import os
 import sys
 from datetime import date as date_type
+from pathlib import Path
 from typing import Optional
+
+# CLI startup ONLY: load ai-backend/.env BEFORE the imports below — embeddings
+# and setup_collection freeze EMBEDDING_MODEL / EMBEDDING_DIM / COLLECTION_NAME
+# from the environment at import time, so a later load_dotenv() configures
+# nothing. override=False keeps explicitly-exported shell env (QDRANT_URL,
+# ENV, …) authoritative — a `make run-manifestos QDRANT_URL=… ENV=prod`
+# invocation must never be silently redirected to the local .env store.
+if __name__ == "__main__":
+    from dotenv import load_dotenv
+
+    _env_path = Path(__file__).resolve().parents[4] / ".env"
+    if _env_path.exists():
+        load_dotenv(_env_path, override=False)
 
 from langchain_core.embeddings import Embeddings
 from qdrant_client import QdrantClient
 
 from src.ingestion.connectors.manifestos.connector import (
     _fetch_period_date,
-    determine_source,
+    determine_source_candidates,
     load_program_pages,
     resolve_since_floor,
 )
@@ -66,9 +82,10 @@ from src.ingestion.connectors.manifestos.mappers.corpus import (
     party_to_slug,
 )
 from src.embeddings import get_embeddings
+from src.ingestion.ids import compute_chunk_id
 from src.ingestion.run import _embed_texts, _upsert_chunks
 from src.ingestion.schemas import ChunkRecord
-from src.ingestion.setup_collection import COLLECTION_NAME
+from src.ingestion.setup_collection import COLLECTION_NAME, check_fingerprint
 
 logger = logging.getLogger(__name__)
 
@@ -155,33 +172,57 @@ def ingest(
             return 0
         from qdrant_client import models as qdrant_models  # noqa: PLC0415
 
-        # Embed FIRST — an embed failure leaves the existing footprint intact
-        # (no delete-before-embed loss window; mirrors run.py's ordering).
+        # Replacement-safe commit order — the program must never be absent:
+        #   1. EMBED first (the failure-prone external call; the old footprint
+        #      stays intact if it fails).
+        #   2. UPSERT the fresh chunks (deterministic point IDs overwrite the
+        #      surviving ids in place, wait=True). A 317-chunk program spans
+        #      multiple upsert requests; even if a later slice fails, nothing
+        #      has been deleted yet.
+        #   3. Only after ALL writes succeeded: delete the orphaned point ids
+        #      (stored footprint minus the new output) so a shrunk/replaced
+        #      PDF leaves no stale higher-index chunks behind.
         vectors = _embed_texts(embed, [c.text for c in b])
 
-        # Rewrite semantics (mirrors run.py's footprint guard) — delete each
-        # program's EXISTING footprint by source_item_id before upserting, one
-        # delete per program with wait=True, so a re-run against a shrunk PDF
-        # (fewer chunks than stored) leaves no stale higher-index chunks
-        # retrievable forever.
-        siids = sorted({str(c.source_item_id) for c in b})
-        for siid in siids:
-            qdrant.delete(
-                collection_name=COLLECTION_NAME,
-                points_selector=qdrant_models.FilterSelector(
-                    filter=qdrant_models.Filter(
-                        must=[
-                            qdrant_models.FieldCondition(
-                                key="source_item_id",
-                                match=qdrant_models.MatchValue(value=siid),
-                            )
-                        ]
-                    )
-                ),
-                wait=True,
+        new_ids_by_siid: dict[str, set[str]] = {}
+        for c in b:
+            new_ids_by_siid.setdefault(str(c.source_item_id), set()).add(
+                str(compute_chunk_id(c.source_item_id, c.chunk_index))
             )
 
         _upsert_chunks(qdrant, COLLECTION_NAME, b, vectors)
+
+        orphans: list[str] = []
+        scroll_filter = qdrant_models.Filter(
+            must=[
+                qdrant_models.FieldCondition(
+                    key="source_item_id",
+                    match=qdrant_models.MatchAny(any=sorted(new_ids_by_siid)),
+                )
+            ]
+        )
+        next_offset = None
+        while True:
+            points, next_offset = qdrant.scroll(
+                collection_name=COLLECTION_NAME,
+                scroll_filter=scroll_filter,
+                limit=1000,
+                offset=next_offset,
+                with_payload=["source_item_id"],
+                with_vectors=False,
+            )
+            for p in points:
+                siid = str((p.payload or {}).get("source_item_id"))
+                if str(p.id) not in new_ids_by_siid.get(siid, set()):
+                    orphans.append(str(p.id))
+            if next_offset is None:
+                break
+        if orphans:
+            qdrant.delete(
+                collection_name=COLLECTION_NAME,
+                points_selector=qdrant_models.PointIdsList(points=sorted(orphans)),
+                wait=True,
+            )
         return len(b)
 
     for program, period_date_iso in eligible_programs:
@@ -189,20 +230,30 @@ def ingest(
         party_label: str = (program.get("party") or {}).get("label") or ""
         period_label: str = (program.get("parliament_period") or {}).get("label") or ""
 
-        # Determine source_kind / source_url (locked source rule)
+        # Ordered source candidates (locked source rule with PDF fallback).
         try:
-            source_kind, source_url = determine_source(program)
+            candidates = determine_source_candidates(program)
         except ValueError:
             print(f"  SKIP program {program_id} ({party_label}): no link or file")
             continue
 
         party_slug = party_to_slug(party_label)
 
-        # --- Fetch and parse ---
-        try:
-            content = load_program_pages(source_kind, source_url)
-        except ValueError as exc:
-            print(f"  SKIP program {program_id} ({party_label}): {exc}")
+        # --- Fetch and parse (first working candidate wins) ---
+        content: Optional[dict] = None
+        source_kind: SourceKind = candidates[0][0]
+        source_url: str = candidates[0][1]
+        failures: list[str] = []
+        for source_kind, source_url in candidates:
+            try:
+                content = load_program_pages(source_kind, source_url)
+                break
+            except ValueError as exc:
+                failures.append(f"{source_kind}: {exc}")
+        if content is None:
+            print(
+                f"  SKIP program {program_id} ({party_label}): " + "; ".join(failures)
+            )
             continue
 
         pages_list: list[tuple[int, str]] = content["pages"]
@@ -277,17 +328,6 @@ def ingest(
 # =============================================================================
 
 if __name__ == "__main__":
-    # Load ai-backend/.env if present.
-    from pathlib import Path  # noqa: PLC0415
-
-    from dotenv import load_dotenv  # noqa: PLC0415
-
-    _env_path = Path(__file__).resolve().parents[4] / ".env"
-    if _env_path.exists():
-        # .env is the source of truth for local dev — let it win over any stale
-        # value inherited from the shell.
-        load_dotenv(_env_path, override=True)
-
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
     parser = argparse.ArgumentParser(
@@ -352,10 +392,14 @@ if __name__ == "__main__":
             sys.exit(1)
 
     qdrant_url = os.getenv("QDRANT_URL", "http://localhost:6333")
-    _qdrant = QdrantClient(url=qdrant_url)
+    _qdrant = QdrantClient(url=qdrant_url, api_key=os.getenv("QDRANT_API_KEY"))
     # Corpus passages → RETRIEVAL_DOCUMENT (matches the ingestion runner + the
     # RETRIEVAL_QUERY side in retrieve.py; ignored for OpenAI).
     _embed = get_embeddings(task_type="RETRIEVAL_DOCUMENT")
+    # Refuse to write into a collection whose fingerprint contradicts the
+    # current provider/model configuration (skipped on --dry-run: no writes).
+    if not args.dry_run:
+        check_fingerprint(_qdrant, COLLECTION_NAME)
 
     print(
         f"Ingesting manifestos (dry_run={args.dry_run}, "

--- a/ai-backend/src/ingestion/connectors/manifestos/connector.py
+++ b/ai-backend/src/ingestion/connectors/manifestos/connector.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -12,10 +12,13 @@ for "party_manifesto" and passed to discover().
 
 Source: the Abgeordnetenwatch ``election-program`` API (reuses ``AWClient``).
 
-Source rule (locked design):
+Source rule (locked design, with fallback):
   1. If ``link[0].uri`` is non-null  -> scrape HTML main content (trafilatura).
-  2. Elif ``file`` (PDF url) non-null -> download + parse the PDF in-memory.
-  3. Else skip the program.
+  2. If that fails (dead link, too-short extraction) or no link exists, and
+     ``file`` (PDF url) is non-null -> download + parse the PDF in-memory.
+  3. Only when EVERY candidate fails is the program skipped — the live
+     catalogue has programs whose archived HTML viewer 404s while the PDF
+     still resolves, so a single-source pick silently lost documents.
 
 In both cases citation_url is the original source URL — wahl.chat does not
 re-serve or store the files (no local storage, no Firestore source-doc).
@@ -127,35 +130,42 @@ def _fetch_period_date(
         return None
 
 
-def determine_source(program: dict) -> tuple[SourceKind, str]:
-    """Resolve (source_kind, source_url) for an election-program record.
+def determine_source_candidates(program: dict) -> list[tuple[SourceKind, str]]:
+    """Resolve the ORDERED source candidates for an election-program record.
 
-    Applies the locked source rule: a non-null first ``link`` URI wins (HTML
-    scrape); otherwise a non-null ``file`` (PDF download).
+    The preferred first ``link`` URI comes first (HTML scrape); the ``file``
+    PDF follows as fallback. Callers try each in order — a stale/404 HTML
+    viewer must not lose a program whose PDF still resolves (both-sourced
+    programs exist in the live catalogue with exactly that failure shape).
 
     Args:
         program: AW election-program dict.
 
     Returns:
-        (SourceKind.LINK, uri) or (SourceKind.PDF, file_url).
+        Non-empty ordered list of (source_kind, source_url) candidates.
 
     Raises:
         ValueError: If the program has neither a usable link nor a file.
     """
+    candidates: list[tuple[SourceKind, str]] = []
     links = program.get("link") or []
-    link_uri: Optional[str] = None
     if links and isinstance(links, list):
         first = links[0]
-        if isinstance(first, dict):
-            link_uri = first.get("uri") or None
+        if isinstance(first, dict) and first.get("uri"):
+            candidates.append((SourceKind.LINK, first["uri"]))
 
     file_url: Optional[str] = program.get("file") or None
-
-    if link_uri:
-        return SourceKind.LINK, link_uri
     if file_url:
-        return SourceKind.PDF, file_url
-    raise ValueError("no link or file")
+        candidates.append((SourceKind.PDF, file_url))
+
+    if not candidates:
+        raise ValueError("no link or file")
+    return candidates
+
+
+def determine_source(program: dict) -> tuple[SourceKind, str]:
+    """Return the PREFERRED source candidate (see determine_source_candidates)."""
+    return determine_source_candidates(program)[0]
 
 
 def load_program_pages(source_kind: SourceKind, source_url: str) -> dict:
@@ -265,11 +275,15 @@ class ManifestoConnector(BaseConnector):
     # ------------------------------------------------------------------
 
     def _get_qdrant(self) -> QdrantClient:
-        """Return the per-instance Qdrant client, initializing on first call.
+        """Return the store client for discovery reads.
 
-        Mirrors the AW connector's lazy singleton. Kept as an instance method so
-        tests can monkeypatch it (or _get_ingested_program_ids) per-connector.
+        The runner binds its own client via ``bind_store()`` before discover(),
+        so one run has ONE Qdrant contract. The self-constructed client exists
+        only for standalone use outside the runner. Kept as an instance method
+        so tests can monkeypatch it (or _get_ingested_program_ids).
         """
+        if self._store_client is not None:
+            return self._store_client
         if self._qdrant is None:
             from qdrant_client import QdrantClient  # noqa: PLC0415
 
@@ -280,25 +294,30 @@ class ManifestoConnector(BaseConnector):
         return self._qdrant
 
     def _get_ingested_program_ids(self) -> set[int]:
-        """Return the set of AW program ids already ingested as party_manifesto.
+        """Return the AW program ids whose manifesto footprint is COMPLETE.
 
-        Scrolls all party_manifesto chunks and collects their external_id (= AW
-        program id). Used for set-difference discovery.
+        Scrolls all party_manifesto chunks, counting stored chunks per
+        external_id (= AW program id) and reading the completed-parent marker
+        ``meta.total_chunks``. A program counts as ingested ONLY when its
+        stored count reaches that marker — one stored chunk is not proof the
+        whole program committed (a 317-chunk program spans multiple upsert
+        requests; a mid-write failure previously excluded it from discovery
+        forever, permanently truncated). Chunks written before the marker
+        existed count as complete (legacy tolerance; a MANIFESTO_REFRESH run
+        re-verifies them via content_hash).
 
         This replaces the max(external_id) high-water mark, which permanently lost
-        any program that was skipped/failed below the max on a prior run (the max
-        advanced past it and the strict ``pid <= since`` filter never re-surfaced
-        it). Set-difference is gap-free and self-healing: a program missing from
-        Qdrant is always re-attempted, and a permanently-unprocessable program
-        simply stays absent without blocking newer programs. It also removes the
-        manifesto batch-window stall (already-present programs no longer occupy
-        the discover window).
+        any program that was skipped/failed below the max on a prior run.
+        Set-difference is gap-free and self-healing: a missing or incomplete
+        program is always re-attempted without blocking newer programs.
         """
         from qdrant_client import models as qdrant_models  # noqa: PLC0415
         from src.ingestion.setup_collection import COLLECTION_NAME  # noqa: PLC0415
 
         qdrant = self._get_qdrant()
-        ingested: set[int] = set()
+        collection_name = self._store_collection or COLLECTION_NAME
+        stored_counts: dict[int, int] = {}
+        expected_totals: dict[int, Optional[int]] = {}
         next_offset: Optional[qdrant_models.ExtendedPointId] = None
         scroll_filter = qdrant_models.Filter(
             must=[
@@ -310,19 +329,32 @@ class ManifestoConnector(BaseConnector):
         )
         while True:
             points, next_offset = qdrant.scroll(
-                collection_name=COLLECTION_NAME,
+                collection_name=collection_name,
                 scroll_filter=scroll_filter,
                 limit=1000,
                 offset=next_offset,
-                with_payload=["external_id"],
+                with_payload=["external_id", "meta.total_chunks"],
                 with_vectors=False,
             )
             for p in points:
-                ext = p.payload.get("external_id") if p.payload else None
-                if isinstance(ext, int):
-                    ingested.add(ext)
+                payload = p.payload or {}
+                ext = payload.get("external_id")
+                if not isinstance(ext, int):
+                    continue
+                stored_counts[ext] = stored_counts.get(ext, 0) + 1
+                total = (payload.get("meta") or {}).get("total_chunks")
+                if isinstance(total, int):
+                    expected_totals[ext] = total
+                else:
+                    expected_totals.setdefault(ext, None)
             if next_offset is None:
                 break
+
+        ingested: set[int] = set()
+        for ext, count in stored_counts.items():
+            expected = expected_totals.get(ext)
+            if expected is None or count >= expected:
+                ingested.add(ext)
         return ingested
 
     # ------------------------------------------------------------------
@@ -437,8 +469,7 @@ class ManifestoConnector(BaseConnector):
             }
 
         try:
-            source_kind, source_url = determine_source(program)
-            content = load_program_pages(source_kind, source_url)
+            candidates = determine_source_candidates(program)
         except ValueError as exc:
             return {
                 "program": program,
@@ -446,12 +477,28 @@ class ManifestoConnector(BaseConnector):
                 "skip_reason": str(exc),
             }
 
+        # Ordered fallback: the preferred HTML link first, the PDF file second.
+        # A stale link (404 viewer, too-short extraction) must not lose a
+        # program whose PDF still resolves.
+        failures: list[str] = []
+        for source_kind, source_url in candidates:
+            try:
+                content = load_program_pages(source_kind, source_url)
+            except ValueError as exc:
+                failures.append(f"{source_kind}: {exc}")
+                continue
+            return {
+                "program": program,
+                "period_date_iso": period_date_iso,
+                "source_kind": source_kind,
+                "source_url": source_url,
+                **content,
+            }
+
         return {
             "program": program,
             "period_date_iso": period_date_iso,
-            "source_kind": source_kind,
-            "source_url": source_url,
-            **content,
+            "skip_reason": "all source candidates failed — " + "; ".join(failures),
         }
 
     # ------------------------------------------------------------------

--- a/ai-backend/src/ingestion/connectors/manifestos/connector.py
+++ b/ai-backend/src/ingestion/connectors/manifestos/connector.py
@@ -1,0 +1,510 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+ManifestoConnector — synchronous single-pass connector for party manifestos.
+
+Implements the 3-method synchronous ABC (discover/fetch/normalize) and produces
+list[ChunkRecord] directly from normalize() — the runner (run.py) owns embed +
+upsert.  The cursor (since) is derived by the runner from Qdrant max(external_id)
+for "party_manifesto" and passed to discover().
+
+Source: the Abgeordnetenwatch ``election-program`` API (reuses ``AWClient``).
+
+Source rule (locked design):
+  1. If ``link[0].uri`` is non-null  -> scrape HTML main content (trafilatura).
+  2. Elif ``file`` (PDF url) non-null -> download + parse the PDF in-memory.
+  3. Else skip the program.
+
+In both cases citation_url is the original source URL — wahl.chat does not
+re-serve or store the files (no local storage, no Firestore source-doc).
+
+Scope: by default ALL programs are in scope. Set ``MANIFESTO_SINCE=YYYY-MM-DD``
+to floor ingestion at a parliament_period ``election_date`` (the operator chooses
+the window; the connector carries no built-in cut-off).
+
+This module also exposes the shared I/O helpers (``_fetch_period_date``,
+``determine_source``, ``load_program_pages``) used by both this connector and the
+bespoke bulk CLI (bulk.py) so there is a single fetch/parse implementation.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import date as date_type
+from io import BytesIO
+from typing import TYPE_CHECKING, Optional
+
+import requests as _requests
+
+from src.ingestion.connector import BaseConnector
+
+if TYPE_CHECKING:
+    from qdrant_client import QdrantClient
+from src.ingestion.connectors.abgeordnetenwatch.client import AWClient
+from src.ingestion.connectors.manifestos.mappers.corpus import (
+    SourceKind,
+    build_manifesto_records,
+    chunk_pages,
+    extract_main_text,
+)
+from src.ingestion.schemas import ChunkRecord, SourceType
+
+logger = logging.getLogger(__name__)
+
+# Env var used to floor ingestion by parliament_period election_date.
+_SINCE_ENV = "MANIFESTO_SINCE"
+
+
+def resolve_since_floor(value: Optional[str] = None) -> Optional[date_type]:
+    """Resolve the optional election-date floor for manifesto ingestion.
+
+    The connector carries no built-in cut-off: with nothing configured every
+    program is in scope. An operator opts into a window via ``MANIFESTO_SINCE``
+    (or, for the bulk CLI, ``--since``) as an ISO ``YYYY-MM-DD`` date; programs
+    whose parliament_period election_date is strictly before it are skipped.
+
+    Args:
+        value: Explicit floor string (e.g. the bulk CLI ``--since`` arg). When
+               None the ``MANIFESTO_SINCE`` env var is read; an unset/empty env
+               means no floor.
+
+    Returns:
+        The parsed floor date, or None when no floor is configured.
+
+    Raises:
+        ValueError: If a value is supplied but is not a valid ISO date — a
+                    misconfiguration is surfaced loudly rather than silently
+                    ingesting the entire back-catalogue.
+    """
+    raw = value if value is not None else os.getenv(_SINCE_ENV)
+    if raw is None or not raw.strip():
+        return None
+    try:
+        return date_type.fromisoformat(raw.strip())
+    except ValueError as exc:
+        raise ValueError(
+            f"{_SINCE_ENV} must be an ISO date (YYYY-MM-DD), got {raw!r}"
+        ) from exc
+
+
+# =============================================================================
+# SHARED I/O HELPERS (used by this connector and bulk.py)
+# =============================================================================
+
+
+def _fetch_period_date(
+    client: AWClient,
+    period_id: int,
+    cache: dict[int, Optional[str]],
+) -> Optional[str]:
+    """Resolve election_date for a parliament-period, caching by id.
+
+    Args:
+        client:    Initialised AWClient.
+        period_id: AW parliament-period integer id.
+        cache:     Mutable dict used to cache resolved dates (value may be None
+                   when the period could not be resolved).
+
+    Returns:
+        ISO date string (``election_date`` or ``start_date_period``), or None.
+    """
+    if period_id in cache:
+        return cache[period_id]
+    try:
+        resp = client.get(f"parliament-periods/{period_id}")
+        data = resp.get("data") or {}
+        date_str: Optional[str] = (
+            data.get("election_date") or data.get("start_date_period") or None
+        )
+        cache[period_id] = date_str
+        return date_str
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Could not resolve parliament-period %s: %s", period_id, exc)
+        cache[period_id] = None
+        return None
+
+
+def determine_source(program: dict) -> tuple[SourceKind, str]:
+    """Resolve (source_kind, source_url) for an election-program record.
+
+    Applies the locked source rule: a non-null first ``link`` URI wins (HTML
+    scrape); otherwise a non-null ``file`` (PDF download).
+
+    Args:
+        program: AW election-program dict.
+
+    Returns:
+        (SourceKind.LINK, uri) or (SourceKind.PDF, file_url).
+
+    Raises:
+        ValueError: If the program has neither a usable link nor a file.
+    """
+    links = program.get("link") or []
+    link_uri: Optional[str] = None
+    if links and isinstance(links, list):
+        first = links[0]
+        if isinstance(first, dict):
+            link_uri = first.get("uri") or None
+
+    file_url: Optional[str] = program.get("file") or None
+
+    if link_uri:
+        return SourceKind.LINK, link_uri
+    if file_url:
+        return SourceKind.PDF, file_url
+    raise ValueError("no link or file")
+
+
+def load_program_pages(source_kind: SourceKind, source_url: str) -> dict:
+    """Download/scrape one program and return its page-annotated text (I/O).
+
+    For ``link`` sources: GET the URI and extract the main article text via
+    trafilatura (boilerplate-stripping, format-agnostic — see extract_main_text).
+    For ``pdf`` sources: download the bytes and extract per-page text via pypdf.
+
+    Nothing is persisted to disk: the PDF is parsed in-memory and discarded.
+    Citations resolve to the original source URL, so wahl.chat never re-serves
+    the file.
+
+    Args:
+        source_kind: ``"link"`` or ``"pdf"``.
+        source_url:  The link URI or PDF download URL.
+
+    Returns:
+        Dict with keys ``pages`` (list[(page_no, text)]) and ``total_pages``
+        (int for pdf, None for link).
+
+    Raises:
+        ValueError: On any skip/failure (HTML too short, HTML fetch failed,
+                    PDF download failed, PDF parse failed) — the message is
+                    suitable for a "SKIP program ...: {msg}" log line.
+    """
+    if source_kind == SourceKind.LINK:
+        try:
+            resp = _requests.get(
+                source_url,
+                timeout=60,
+                headers={"User-Agent": "wahl.chat-ingest"},
+            )
+            resp.raise_for_status()
+            text_content = extract_main_text(resp.text)
+        except Exception as exc:  # noqa: BLE001
+            raise ValueError(f"HTML fetch failed: {exc}") from exc
+        if len(text_content) < 500:
+            raise ValueError(f"HTML too short ({len(text_content)} chars)")
+        return {"pages": [(1, text_content)], "total_pages": None}
+
+    # source_kind == "pdf"
+    # pypdf stays function-local: it's a heavy PDF-parsing dep that only the pdf
+    # path needs, so a link-only ingestion run never imports it.
+    import pypdf  # noqa: PLC0415
+
+    try:
+        pdf_resp = _requests.get(
+            source_url,
+            timeout=60,
+            headers={"User-Agent": "wahl.chat-ingest"},
+        )
+        pdf_resp.raise_for_status()
+        pdf_bytes = pdf_resp.content
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(f"PDF download failed: {exc}") from exc
+
+    try:
+        reader = pypdf.PdfReader(BytesIO(pdf_bytes))
+        total_pages = len(reader.pages)
+        pages_list: list[tuple[int, str]] = []
+        for page_no, page in enumerate(reader.pages, start=1):
+            page_text = page.extract_text() or ""
+            pages_list.append((page_no, page_text))
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(f"PDF parse failed: {exc}") from exc
+
+    return {"pages": pages_list, "total_pages": total_pages}
+
+
+# =============================================================================
+# ManifestoConnector
+# =============================================================================
+
+
+class ManifestoConnector(BaseConnector):
+    """Connector for AW election-program records → party_manifesto ChunkRecords.
+
+    Synchronous single-pass connector:
+        discover(since) → fetch → normalize → [runner embeds + upserts]
+
+    The cursor (since) is the max external_id (raw integer AW program_id) already
+    committed to Qdrant for "party_manifesto", derived by the runner via
+    get_cursor().  No Firestore and no bespoke flags on this path — those live in
+    bulk.py.  discover() caches the program records and resolved election dates as
+    per-run instance state so fetch() needs no second discovery pass.
+
+    """
+
+    # Class attribute: used by runner.get_cursor() to scope the Qdrant scroll.
+    source_type: str = SourceType.PARTY_MANIFESTO.value
+
+    def __init__(self) -> None:
+        self._client = AWClient()
+
+        # Per-run caches populated by discover() and read by fetch().
+        self._period_date_cache: dict[int, Optional[str]] = {}
+        self._programs: dict[int, dict] = {}
+        self._period_dates: dict[int, str] = {}
+
+        # Lazy Qdrant client for set-difference discovery.
+        # Initialised on first call to _get_qdrant().
+        self._qdrant: Optional[QdrantClient] = None
+
+    # ------------------------------------------------------------------
+    # 1a. Qdrant lazy singleton (set-difference discovery)
+    # ------------------------------------------------------------------
+
+    def _get_qdrant(self) -> QdrantClient:
+        """Return the per-instance Qdrant client, initializing on first call.
+
+        Mirrors the AW connector's lazy singleton. Kept as an instance method so
+        tests can monkeypatch it (or _get_ingested_program_ids) per-connector.
+        """
+        if self._qdrant is None:
+            from qdrant_client import QdrantClient  # noqa: PLC0415
+
+            self._qdrant = QdrantClient(
+                url=os.getenv("QDRANT_URL", "http://localhost:6333"),
+                api_key=os.getenv("QDRANT_API_KEY"),
+            )
+        return self._qdrant
+
+    def _get_ingested_program_ids(self) -> set[int]:
+        """Return the set of AW program ids already ingested as party_manifesto.
+
+        Scrolls all party_manifesto chunks and collects their external_id (= AW
+        program id). Used for set-difference discovery.
+
+        This replaces the max(external_id) high-water mark, which permanently lost
+        any program that was skipped/failed below the max on a prior run (the max
+        advanced past it and the strict ``pid <= since`` filter never re-surfaced
+        it). Set-difference is gap-free and self-healing: a program missing from
+        Qdrant is always re-attempted, and a permanently-unprocessable program
+        simply stays absent without blocking newer programs. It also removes the
+        manifesto batch-window stall (already-present programs no longer occupy
+        the discover window).
+        """
+        from qdrant_client import models as qdrant_models  # noqa: PLC0415
+        from src.ingestion.setup_collection import COLLECTION_NAME  # noqa: PLC0415
+
+        qdrant = self._get_qdrant()
+        ingested: set[int] = set()
+        next_offset: Optional[qdrant_models.ExtendedPointId] = None
+        scroll_filter = qdrant_models.Filter(
+            must=[
+                qdrant_models.FieldCondition(
+                    key="source_type",
+                    match=qdrant_models.MatchValue(value=self.source_type),
+                )
+            ]
+        )
+        while True:
+            points, next_offset = qdrant.scroll(
+                collection_name=COLLECTION_NAME,
+                scroll_filter=scroll_filter,
+                limit=1000,
+                offset=next_offset,
+                with_payload=["external_id"],
+                with_vectors=False,
+            )
+            for p in points:
+                ext = p.payload.get("external_id") if p.payload else None
+                if isinstance(ext, int):
+                    ingested.add(ext)
+            if next_offset is None:
+                break
+        return ingested
+
+    # ------------------------------------------------------------------
+    # 1b. discover — optional election-date floor + set-difference vs Qdrant,
+    #     ascending by program_id
+    # ------------------------------------------------------------------
+
+    def discover(self, since: Optional[int]) -> list[str]:
+        """Return election-program ids to process, oldest first.
+
+        Fetches all election-program records, resolves each program's
+        parliament-period election_date (cached), keeps those on or after the
+        configured MANIFESTO_SINCE floor (no floor by default → all kept), and
+        includes a program only when its id is NOT yet present in Qdrant
+        (set-difference — mirrors the AW votes connector). Caches the program
+        records + resolved dates so fetch() needs no re-discovery.
+
+        The global ``since`` argument from run_connector() is accepted (preserves
+        the ABC contract) but IGNORED — a max-external_id watermark permanently
+        dropped any program that transiently failed below the max; set-difference
+        is gap-free and always retries missing programs.
+
+        MANIFESTO_REFRESH=1 (same 1/true/yes parsing as the votes connector's
+        AW_REFRESH) forces a full reconcile: the already-ingested exclusion is
+        skipped so run.py's content-hash rewrite + orphan cleanup can propagate
+        replaced/corrected PDFs and shrunk programs. Unchanged chunks are
+        cheaply skipped there without re-embedding.
+
+        Args:
+            since: Max external_id (AW program integer ID) already committed to
+                   Qdrant for "party_manifesto". Accepted for ABC-contract
+                   compatibility but not used (set-difference supersedes it).
+
+        Returns:
+            List of program id strings sorted ascending by program_id.
+        """
+        self._programs = {}
+        self._period_dates = {}
+
+        since_floor = resolve_since_floor()
+
+        all_programs = self._client.get_all("election-program", {})
+
+        # MANIFESTO_REFRESH skips the ingested-ids exclusion so already
+        # present programs flow through run.py's content-hash guard again.
+        refresh = os.getenv("MANIFESTO_REFRESH", "").strip().lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        ingested_ids: set[int] = set() if refresh else self._get_ingested_program_ids()
+
+        eligible: list[int] = []
+        for program in all_programs:
+            pid = program.get("id")
+            if not isinstance(pid, int):
+                continue
+            period_obj = program.get("parliament_period") or {}
+            period_id = period_obj.get("id")
+            if not period_id:
+                continue
+            date_iso = _fetch_period_date(
+                self._client, int(period_id), self._period_date_cache
+            )
+            if not date_iso:
+                continue
+            try:
+                election_date = date_type.fromisoformat(date_iso)
+            except (ValueError, TypeError):
+                continue
+            if since_floor is not None and election_date < since_floor:
+                continue
+            if pid in ingested_ids:
+                continue
+            self._programs[pid] = program
+            self._period_dates[pid] = date_iso
+            eligible.append(pid)
+
+        eligible.sort()
+        return [str(pid) for pid in eligible]
+
+    # ------------------------------------------------------------------
+    # 2. fetch — download/scrape one program; never raises (defers to normalize)
+    # ------------------------------------------------------------------
+
+    def fetch(self, external_id: str) -> dict:
+        """Fetch raw page text + provenance for a single program id.
+
+        Reads the program record + election_date from the discover() cache, then
+        downloads/scrapes its content.  Any skip/failure is captured as a
+        ``skip_reason`` in the returned dict (never raised) so the runner — which
+        does not wrap fetch() — proceeds to normalize(), where the skip surfaces
+        as a ValueError and run_connector skip-and-continues.
+
+        Args:
+            external_id: String program id (e.g. "598").
+
+        Returns:
+            Dict with ``program``, ``period_date_iso``, ``source_kind``,
+            ``source_url``, ``pages``, ``total_pages`` — or a minimal dict
+            carrying ``skip_reason`` on any problem. Nothing is persisted to
+            disk (no stored_path — PDFs are parsed in-memory and discarded).
+        """
+        pid = int(external_id)
+        program = self._programs.get(pid)
+        period_date_iso = self._period_dates.get(pid)
+
+        if program is None:
+            return {
+                "program": None,
+                "skip_reason": f"program {pid} not in discover cache",
+            }
+
+        try:
+            source_kind, source_url = determine_source(program)
+            content = load_program_pages(source_kind, source_url)
+        except ValueError as exc:
+            return {
+                "program": program,
+                "period_date_iso": period_date_iso,
+                "skip_reason": str(exc),
+            }
+
+        return {
+            "program": program,
+            "period_date_iso": period_date_iso,
+            "source_kind": source_kind,
+            "source_url": source_url,
+            **content,
+        }
+
+    # ------------------------------------------------------------------
+    # 3. normalize — chunk + build ChunkRecords
+    # ------------------------------------------------------------------
+
+    def normalize(self, raw: dict) -> list[ChunkRecord]:
+        """Build ChunkRecords from a fetched program payload.
+
+        Args:
+            raw: Dict returned by fetch().
+
+        Returns:
+            list[ChunkRecord], one per chunk.
+
+        Raises:
+            ValueError: If fetch() flagged a skip, the election_date is missing,
+                        or the program produces no text/records.
+        """
+        skip_reason = raw.get("skip_reason")
+        if skip_reason:
+            raise ValueError(skip_reason)
+
+        program: dict = raw["program"]
+        period_date_iso: Optional[str] = raw.get("period_date_iso")
+        if not period_date_iso:
+            raise ValueError(
+                f"program {program.get('id')} has no resolvable election_date"
+            )
+
+        source_kind: SourceKind = raw["source_kind"]
+        chunk_tuples = chunk_pages(raw["pages"])
+        if not chunk_tuples:
+            raise ValueError(
+                f"program {program.get('id')} produced no text after chunking"
+            )
+
+        # HTML sources carry no page numbers per spec.
+        if source_kind == SourceKind.LINK:
+            build_chunks: list[tuple[str, Optional[int], Optional[int]]] = [
+                (text, None, None) for text, _ps, _pe in chunk_tuples
+            ]
+        else:
+            build_chunks = list(chunk_tuples)
+
+        records = build_manifesto_records(
+            program=program,
+            period_date_iso=period_date_iso,
+            chunks=build_chunks,
+            source_kind=source_kind,
+            source_url=raw["source_url"],
+            total_pages=raw.get("total_pages"),
+        )
+        if not records:
+            raise ValueError(f"program {program.get('id')} produced no records")
+        return records

--- a/ai-backend/src/ingestion/connectors/manifestos/mappers/__init__.py
+++ b/ai-backend/src/ingestion/connectors/manifestos/mappers/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""Pure (no-I/O) transforms for the manifesto connector.
+
+corpus.py — election-program record → party_manifesto ChunkRecord list, plus the
+            slug/region/wahlperiode derivation and token-bounded page chunking.
+"""

--- a/ai-backend/src/ingestion/connectors/manifestos/mappers/__init__.py
+++ b/ai-backend/src/ingestion/connectors/manifestos/mappers/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/src/ingestion/connectors/manifestos/mappers/corpus.py
+++ b/ai-backend/src/ingestion/connectors/manifestos/mappers/corpus.py
@@ -1,0 +1,446 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Pure transforms: AW election-program record → party_manifesto ChunkRecord list.
+
+No I/O — every function here is deterministic and unit-testable (no network,
+no OpenAI, no Qdrant, no Firestore). The connector (connector.py) and the bulk
+CLI (bulk.py) both call into these helpers.
+
+Public helpers:
+  - party_to_slug         — party.label → canonical party slug
+  - region_for_period     — parliament-period label → scalar region code
+  - wahlperiode_for_period — Bundestag period label → Wahlperiode number
+  - chunk_pages           — page-annotated text → token-bounded chunks
+  - build_manifesto_records — program + chunks → list[ChunkRecord]
+  - _slugify              — clean ASCII slug (umlaut transliteration)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+from datetime import date as date_type
+from enum import StrEnum
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+from src.ingestion.chunking import chunk_pages  # noqa: F401 (re-exported for connector)
+from src.ingestion.party_slugs import (
+    CANONICAL_PARTY_SLUGS,
+    PARTY_SLUG_QUARANTINE,
+    STATE_PARTY_SLUGS,
+    normalize_party_label,
+)
+from src.ingestion.ids import compute_source_item_id, make_chunk_key
+from src.ingestion.schemas import AuthorityTier, ChunkRecord, SourceType
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# ManifestoMeta — source-owned meta for party_manifesto chunks.
+# ---------------------------------------------------------------------------
+
+
+class SourceKind(StrEnum):
+    """How an election-program's text was obtained (locked source rule).
+
+    ``LINK`` — HTML page scraped via trafilatura; ``PDF`` — file downloaded and
+    parsed. StrEnum so it stays a clean ``"link"``/``"pdf"`` string in logs and
+    in the stored chunk ``meta``.
+    """
+
+    LINK = "link"
+    PDF = "pdf"
+
+
+class ManifestoMeta(BaseModel):
+    """Typed builder for the manifesto chunk ``meta`` dict.
+
+    Mirrors the schemas.py convention (VoteMeta / SpeechMeta): extra="forbid"
+    rejects typo'd keys at build time; None-valued fields are dropped via
+    ``model_dump(exclude_none=True)``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    aw_program_id: int
+    parliament_period_id: Optional[int] = None
+    parliament_period_label: Optional[str] = None
+    source_kind: Optional[SourceKind] = None
+    source_url: Optional[str] = None
+    total_pages: Optional[int] = None
+    page_start: Optional[int] = None
+    page_end: Optional[int] = None
+    # Only stamped when the party slug quarantines to "unbekannt".
+    raw_party_label: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Party slug map — for election-program party.label
+# ---------------------------------------------------------------------------
+
+# Keys are lowercased and invisible-char-stripped (as produced by
+# normalize_party_label). The major-party core and the state/regional layer are
+# the shared source of truth in src/ingestion/party_slugs.py (so a party's
+# manifesto slug tenant-aligns with its vote slug); the entries below are the
+# manifesto-only long-tail parties (no votes/speeches counterpart). Any label
+# not here still gets a clean derived slug via _slugify — manifestos never
+# quarantine an unknown party the way votes/speeches do.
+_MANIFESTO_PARTY_SLUG_MAP: dict[str, str] = {
+    **CANONICAL_PARTY_SLUGS,
+    **STATE_PARTY_SLUGS,
+    "die partei": "die-partei",
+    "partei der humanisten": "pdh",
+    "partei für verjüngungsforschung": "verjuengung",
+    "tierschutzpartei": "tierschutzpartei",
+    "bündnis c": "buendnis-c",
+    "pdf": "pdf",
+    "werteunion": "werteunion",
+    "die gerechtigkeitspartei - team todenhöfer": "gerechtigkeit",
+    "bayernpartei": "bayernpartei",
+    "pdr": "pdr",
+}
+
+# ---------------------------------------------------------------------------
+# German state -> ISO 3166-2 code map
+# ---------------------------------------------------------------------------
+
+_STATE_CODE_MAP: dict[str, str] = {
+    "baden-württemberg": "DE-BW",
+    "bayern": "DE-BY",
+    "berlin": "DE-BE",
+    "brandenburg": "DE-BB",
+    "bremen": "DE-HB",
+    "hamburg": "DE-HH",
+    "hessen": "DE-HE",
+    "mecklenburg-vorpommern": "DE-MV",
+    "niedersachsen": "DE-NI",
+    "nordrhein-westfalen": "DE-NW",
+    "rheinland-pfalz": "DE-RP",
+    "saarland": "DE-SL",
+    "sachsen": "DE-SN",
+    "sachsen-anhalt": "DE-ST",
+    "schleswig-holstein": "DE-SH",
+    "thüringen": "DE-TH",
+}
+
+# ---------------------------------------------------------------------------
+# Bundestag election year -> Wahlperiode number
+# ---------------------------------------------------------------------------
+
+_BUNDESTAG_WAHLPERIODE: dict[str, int] = {
+    "2013": 18,
+    "2017": 19,
+    "2021": 20,
+    "2025": 21,
+}
+
+
+# =============================================================================
+# SLUGIFY helper for directory names and derived party slugs
+# =============================================================================
+
+# Umlaut / ß transliteration table — applied before ASCII-safe slug generation.
+_UMLAUT_TABLE = str.maketrans(
+    {
+        "ä": "ae",
+        "ö": "oe",
+        "ü": "ue",
+        "ß": "ss",
+        "Ä": "ae",
+        "Ö": "oe",
+        "Ü": "ue",
+    }
+)
+
+
+def _slugify(text: str) -> str:
+    """Convert text to a clean, filesystem-safe ASCII slug.
+
+    Steps:
+      1. Transliterate German umlauts / ß to ASCII digraphs.
+      2. Lowercase and strip leading/trailing whitespace.
+      3. Replace every run of non-[a-z0-9] characters with a single "-".
+      4. Strip leading/trailing "-".
+      5. Return "unbekannt" if the result is empty.
+
+    Examples::
+
+        _slugify("Volt")            -> "volt"
+        _slugify("Klimaliste")      -> "klimaliste"
+        _slugify("Freie Sachsen")   -> "freie-sachsen"
+        _slugify("Tierschutz hier!") -> "tierschutz-hier"
+        _slugify("Sozialistische Gleichheitspartei") -> "sozialistische-gleichheitspartei"
+
+    Args:
+        text: Input string (party label or similar).
+
+    Returns:
+        Lowercase ASCII slug string, never empty (falls back to ``"unbekannt"``).
+    """
+    text = text.translate(_UMLAUT_TABLE)
+    text = text.lower().strip()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    text = text.strip("-")
+    return text if text else "unbekannt"
+
+
+# =============================================================================
+# PURE HELPERS (no I/O — unit-testable)
+# =============================================================================
+
+
+def party_to_slug(label: Optional[str]) -> str:
+    """Map a party label from the AW election-program API to a canonical slug.
+
+    Resolution order:
+      1. Normalise the label with ``normalize_party_label`` (strips the U+00AD
+         soft hyphen / zero-width chars, collapses whitespace, lowercases).
+         Empty/whitespace-only -> ``"unbekannt"`` immediately.
+      2. Look up in the explicit ``_MANIFESTO_PARTY_SLUG_MAP``.  Major parties
+         map to their chat-context slugs (e.g. ``"gruene"``).
+      3. Fall back to ``_slugify(label)`` for long-tail parties — transliterates
+         umlauts and produces a clean derived slug (e.g. "Klimaliste" ->
+         ``"klimaliste"``).  ``_slugify`` never returns empty (falls back to
+         ``"unbekannt"``).
+
+    Args:
+        label: Raw ``party.label`` string from an AW election-program record,
+               or None.
+
+    Returns:
+        Canonical party slug, e.g. ``"spd"``, ``"gruene"``, ``"klimaliste"``.
+        Returns ``"unbekannt"`` only for empty/None input or an unresolvable
+        label that produces no ASCII characters.
+    """
+    if not label:
+        return PARTY_SLUG_QUARANTINE
+    normalised = normalize_party_label(label)
+    if not normalised:
+        return PARTY_SLUG_QUARANTINE
+    explicit = _MANIFESTO_PARTY_SLUG_MAP.get(normalised)
+    if explicit is not None:
+        return explicit
+    # Derive a slug from the original label (preserves umlaut transliteration
+    # that normalize_party_label strips away).
+    return _slugify(label)
+
+
+def region_for_period(period_label: str) -> str:
+    """Derive a scalar region code from a parliament-period label.
+
+    Mapping rules:
+      - "Bundestag …"  -> "DE"
+      - "EU-Parlament …" / "Europaparlament …" -> "EU"
+      - "<State> Wahl YYYY" -> "DE-<code>" using the German state map
+      - Fallback -> "unbekannt" (quarantine) + WARNING
+
+    The fallback is a QUARANTINE, not "DE" — an unrecognized label (new
+    format, Kommunalwahl) stamped "DE" would MatchAny-match EVERY election
+    context and could never be scoped. "unbekannt" matches no real region_path,
+    so quarantined chunks are unreachable by retrieval until re-labeled — safe
+    by design, and the WARNING makes the gap visible.
+
+    Args:
+        period_label: The ``label`` field of a parliament-period record,
+                      e.g. ``"Bundestag Wahl 2021"``.
+
+    Returns:
+        Scalar region string for Qdrant payload, e.g. ``"DE"`` or ``"DE-BW"``;
+        ``"unbekannt"`` for unrecognized labels.
+    """
+    lower = period_label.strip().lower()
+    if lower.startswith("bundestag"):
+        return "DE"
+    if lower.startswith("eu-parlament") or lower.startswith("europaparlament"):
+        return "EU"
+    # Try German state prefix: "<State> Wahl YYYY"
+    # Sort longest-name-first so the most-specific name wins any prefix collision
+    # (e.g. "sachsen-anhalt" before "sachsen" avoids mis-tagging DE-SN for DE-ST).
+    for state_name, code in sorted(_STATE_CODE_MAP.items(), key=lambda kv: -len(kv[0])):
+        if lower.startswith(state_name):
+            return code
+    logger.warning(
+        "region_for_period: unrecognized parliament-period label %r — quarantining "
+        "with region 'unbekannt' (unreachable by retrieval until re-labeled; "
+        "add a mapping rule if this is a real election level).",
+        period_label,
+    )
+    return "unbekannt"
+
+
+def wahlperiode_for_period(period_label: str) -> Optional[int]:
+    """Derive the Bundestag Wahlperiode number from a parliament-period label.
+
+    Only Bundestag periods yield a non-None value.
+
+    Args:
+        period_label: The ``label`` field of a parliament-period record,
+                      e.g. ``"Bundestag Wahl 2021"``.
+
+    Returns:
+        Integer Wahlperiode (e.g. 20), or None for non-Bundestag periods.
+    """
+    lower = period_label.strip().lower()
+    if not lower.startswith("bundestag"):
+        return None
+    # Extract 4-digit year
+    match = re.search(r"\b(20\d{2}|19\d{2})\b", period_label)
+    if match:
+        return _BUNDESTAG_WAHLPERIODE.get(match.group(1))
+    return None
+
+
+def extract_main_text(html: str) -> str:
+    """Extract the main article text from a manifesto web page (pure, no network).
+
+    Uses trafilatura's main-content extraction (text-vs-link density + semantic
+    heuristics) to isolate the document body and strip boilerplate — navigation,
+    headers, footers, cookie banners, share buttons, sidebars — so only the
+    manifesto prose is embedded, not site chrome.  Format-agnostic: no per-party
+    selectors.
+
+    Pages with no extractable article body (e.g. a "download our program"
+    landing page) yield an empty / very short string; the caller's length floor
+    then skips them rather than embedding navigation noise.
+
+    Args:
+        html: Raw HTML of the fetched page.
+
+    Returns:
+        Clean plain-text main content, or "" when nothing substantive is found.
+    """
+    import trafilatura  # noqa: PLC0415
+
+    extracted = trafilatura.extract(
+        html,
+        include_comments=False,
+        include_tables=True,
+        favor_recall=True,
+    )
+    return (extracted or "").strip()
+
+
+# chunk_pages is centralised in src.ingestion.chunking (imported above and
+# re-exported here for the manifesto connector). Manifestos split per page so
+# each chunk's citation #page= anchor lands on the page the passage is on.
+
+
+def build_manifesto_records(
+    program: dict,
+    period_date_iso: str,
+    chunks: list[tuple[str, Optional[int], Optional[int]]],
+    source_kind: SourceKind,
+    source_url: Optional[str],
+    total_pages: Optional[int] = None,
+) -> list[ChunkRecord]:
+    """Build ChunkRecord list for one manifesto program (pure, no I/O).
+
+    Constructs the locked payload envelope + source-owned meta for each chunk.
+    None-valued meta keys are omitted (build dict, drop None).
+
+    citation_url points directly at the original source (the AW ``file`` PDF URL
+    for pdf sources, or the link URI for link sources) — wahl.chat does not
+    re-serve or duplicate the file, so the citation resolves to where the
+    document actually lives.
+
+    Args:
+        program:         AW election-program dict with keys: id, label, party,
+                         parliament_period (label field used here).
+        period_date_iso: ISO date string from parliament_period election_date
+                         (used as publish_date).
+        chunks:          List of (text, page_start, page_end) tuples. page_start
+                         and page_end may be None for HTML sources.
+        source_kind:     ``"pdf"`` or ``"link"``.
+        source_url:      Provenance URL (PDF download URL or link URI). Used
+                         verbatim as the citation_url.
+        total_pages:     Total page count (pdf only; None for link sources).
+
+    Returns:
+        List of ChunkRecord instances, one per chunk.
+    """
+    program_id: int = program["id"]
+    program_label: str = program.get("label") or ""
+    party_label: str = (program.get("party") or {}).get("label") or ""
+    period_label: str = (program.get("parliament_period") or {}).get("label") or ""
+
+    party_slug = party_to_slug(party_label)
+    region = region_for_period(period_label)
+    wahlperiode = wahlperiode_for_period(period_label)
+
+    publish_date = date_type.fromisoformat(period_date_iso)
+
+    sid = compute_source_item_id("party_manifesto", str(program_id))
+
+    # citation_url is the original source URL (external PDF or weblink).
+    citation_url = source_url
+
+    citation_title = f"{program_label} – {period_label}"
+
+    parliament_period_id = (program.get("parliament_period") or {}).get("id")
+
+    records: list[ChunkRecord] = []
+    for chunk_index, (text, page_start, page_end) in enumerate(chunks):
+        # Typed meta builder (schemas convention that votes/speeches follow —
+        # extra="forbid" rejects typos at build time); exclude_none drops
+        # None-valued keys.
+        meta: dict = ManifestoMeta(
+            aw_program_id=program_id,
+            parliament_period_id=parliament_period_id,
+            parliament_period_label=period_label,
+            source_kind=source_kind,
+            source_url=source_url,
+            total_pages=total_pages,
+            page_start=page_start,
+            page_end=page_end,
+            raw_party_label=party_label if party_slug == "unbekannt" else None,
+        ).model_dump(mode="json", exclude_none=True)
+
+        # Change-aware content_hash (mirrors the op mapper): per-chunk text so an
+        # updated program text re-writes via run.py's guard; includes the resolved
+        # party slug (indexed tenant field). NOTE: on the connector path the
+        # guard only sees already-present programs on MANIFESTO_REFRESH=1 runs
+        # (normal discover excludes them via set-difference); bulk.py rewrites
+        # each program's footprint unconditionally.
+        content_hash = hashlib.sha256(
+            json.dumps(
+                {
+                    "text": text,
+                    "party_slug": party_slug,
+                    "region": region,
+                    "wahlperiode": wahlperiode,
+                    "program_id": program_id,
+                },
+                sort_keys=True,
+                ensure_ascii=False,
+            ).encode("utf-8")
+        ).hexdigest()
+
+        chunk_key = make_chunk_key(sid, chunk_index)
+        records.append(
+            ChunkRecord(
+                chunk_key=chunk_key,
+                source_item_id=sid,
+                chunk_index=chunk_index,
+                text=text,
+                party_id=party_slug,
+                region=region,
+                authority_tier=AuthorityTier.SELF_REPORTED,
+                source_type=SourceType.PARTY_MANIFESTO,
+                publish_date=publish_date,
+                citation_url=citation_url,
+                citation_title=citation_title,
+                external_id=program_id,
+                wahlperiode=wahlperiode,
+                content_hash=content_hash,
+                meta=meta if meta else None,
+            )
+        )
+    return records

--- a/ai-backend/src/ingestion/connectors/manifestos/mappers/corpus.py
+++ b/ai-backend/src/ingestion/connectors/manifestos/mappers/corpus.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -78,6 +78,11 @@ class ManifestoMeta(BaseModel):
     total_pages: Optional[int] = None
     page_start: Optional[int] = None
     page_end: Optional[int] = None
+    # Completed-parent marker: how many chunks THIS normalize produced for the
+    # whole program. Discovery compares it against the stored count so a
+    # partially-committed multi-slice upsert is re-discovered and repaired
+    # instead of being treated as complete forever.
+    total_chunks: Optional[int] = None
     # Only stamped when the party slug quarantines to "unbekannt".
     raw_party_label: Optional[str] = None
 
@@ -359,8 +364,9 @@ def build_manifesto_records(
         chunks:          List of (text, page_start, page_end) tuples. page_start
                          and page_end may be None for HTML sources.
         source_kind:     ``"pdf"`` or ``"link"``.
-        source_url:      Provenance URL (PDF download URL or link URI). Used
-                         verbatim as the citation_url.
+        source_url:      Provenance URL (PDF download URL or link URI). PDF
+                         chunks cite it with a per-chunk ``#page=`` anchor;
+                         link chunks cite it verbatim.
         total_pages:     Total page count (pdf only; None for link sources).
 
     Returns:
@@ -379,15 +385,26 @@ def build_manifesto_records(
 
     sid = compute_source_item_id("party_manifesto", str(program_id))
 
-    # citation_url is the original source URL (external PDF or weblink).
-    citation_url = source_url
-
     citation_title = f"{program_label} – {period_label}"
 
     parliament_period_id = (program.get("parliament_period") or {}).get("id")
 
     records: list[ChunkRecord] = []
+    total_chunks = len(chunks)
     for chunk_index, (text, page_start, page_end) in enumerate(chunks):
+        # Chunk-specific citation: PDF chunks deep-link to the page the passage
+        # starts on (pypdf page numbers are 1-based physical PDF pages, so the
+        # anchor is exact). Never clobber an existing fragment; link sources
+        # keep the plain URI.
+        citation_url = source_url
+        if (
+            source_kind == SourceKind.PDF
+            and citation_url
+            and page_start
+            and "#" not in citation_url
+        ):
+            citation_url = f"{citation_url}#page={page_start}"
+
         # Typed meta builder (schemas convention that votes/speeches follow —
         # extra="forbid" rejects typos at build time); exclude_none drops
         # None-valued keys.
@@ -400,15 +417,19 @@ def build_manifesto_records(
             total_pages=total_pages,
             page_start=page_start,
             page_end=page_end,
+            total_chunks=total_chunks,
             raw_party_label=party_label if party_slug == "unbekannt" else None,
         ).model_dump(mode="json", exclude_none=True)
 
         # Change-aware content_hash (mirrors the op mapper): per-chunk text so an
         # updated program text re-writes via run.py's guard; includes the resolved
-        # party slug (indexed tenant field). NOTE: on the connector path the
-        # guard only sees already-present programs on MANIFESTO_REFRESH=1 runs
-        # (normal discover excludes them via set-difference); bulk.py rewrites
-        # each program's footprint unconditionally.
+        # party slug (indexed tenant field) AND the displayed citation/provenance
+        # (URL with page anchor, title, source, page window, publish date) — a
+        # provenance-only correction must be refreshable, not permanently stale.
+        # NOTE: on the connector path the guard only sees already-present
+        # programs on MANIFESTO_REFRESH=1 runs (normal discover excludes them
+        # via set-difference); bulk.py rewrites each program's footprint
+        # unconditionally.
         content_hash = hashlib.sha256(
             json.dumps(
                 {
@@ -417,6 +438,13 @@ def build_manifesto_records(
                     "region": region,
                     "wahlperiode": wahlperiode,
                     "program_id": program_id,
+                    "citation_url": citation_url,
+                    "citation_title": citation_title,
+                    "source_url": source_url,
+                    "page_start": page_start,
+                    "page_end": page_end,
+                    "total_pages": total_pages,
+                    "publish_date": period_date_iso,
                 },
                 sort_keys=True,
                 ensure_ascii=False,

--- a/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_corpus_chunk_poll.py
+++ b/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_corpus_chunk_poll.py
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Active tests for the vote-record array model: corpus.chunk_poll produces ONE
+ChunkRecord per poll, embeds the subject only, and carries the tally in the
+party_ids / vote_results payload (not in the embedded text).
+
+These tests import only live symbols (no deleted matcher/SourceItemRecord),
+so unlike test_mappers.py they are NOT skipped. Fixtures are loaded from disk like
+test_connector.py.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+from src.ingestion.connectors.abgeordnetenwatch.mappers.corpus import (
+    _canonical_party_slug,
+    _normalize_fraction_label,
+    chunk_poll,
+)
+from src.ingestion.ids import compute_source_item_id
+from src.ingestion.schemas import AuthorityTier, ChunkRecord, SourceType
+
+_FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+class _SourceItemStub:
+    """Minimal SourceItemLike stub (mirrors connector.normalize())."""
+
+    def __init__(self) -> None:
+        self.source_item_id = compute_source_item_id("vote_record", "3602")
+        self.region = "DE"
+        self.authority_tier = AuthorityTier.FACTUAL_RECORD
+        self.source_type = SourceType.VOTE_RECORD
+        self.publish_date = date(2020, 5, 14)
+
+
+def _load_raw_3602() -> dict:
+    poll = json.loads((_FIXTURES_DIR / "aw_poll_3602_poll.json").read_text())["data"]
+    votes = json.loads((_FIXTURES_DIR / "aw_poll_3602_votes.json").read_text())["data"]
+    return {"poll": poll, "votes": votes}
+
+
+def _chunks() -> list[ChunkRecord]:
+    return chunk_poll(_SourceItemStub(), _load_raw_3602())
+
+
+def test_one_chunk_per_poll() -> None:
+    """The array model collapses the 7-fraction poll to a single chunk."""
+    chunks = _chunks()
+    assert len(chunks) == 1
+    assert isinstance(chunks[0], ChunkRecord)
+
+
+def test_party_ids_lists_all_participants() -> None:
+    chunk = _chunks()[0]
+    assert set(chunk.party_ids or []) == {
+        "fdp",
+        "spd",
+        "linke",
+        "afd",
+        "cdu",
+        "gruene",
+        "fraktionslos",
+    }
+    # party_id (tenant key) is the _all sentinel — votes opt out of tenant grouping.
+    assert chunk.party_id == "_all"
+
+
+def test_vote_results_one_entry_per_party_with_tally() -> None:
+    chunk = _chunks()[0]
+    # vote_results now lives in meta (envelope+meta split).
+    meta = chunk.meta or {}
+    results = meta.get("vote_results") or []
+    assert len(results) == 7
+    assert all(isinstance(r, dict) for r in results)
+    # Every participating party in party_ids has a matching results entry.
+    assert {r["party_id"] for r in results} == set(chunk.party_ids or [])
+    # Stance is one of the locked derive_stance outputs.
+    assert all(
+        r["stance"] in {"agree", "disagree", "neutral", "absent"} for r in results
+    )
+
+
+def test_embed_text_is_subject_not_tally() -> None:
+    """Subject (label + topics + intro) is embedded; the tally is NOT."""
+    chunk = _chunks()[0]
+    assert "Corona-Maßnahmen zum Schutz der Bevölkerung" in chunk.text
+    # Topic labels are folded into the embed text to strengthen topic search.
+    assert "Gesundheit" in chunk.text
+    # The old tally template ("X Ja / Y Nein / ...") must not appear in the vector.
+    assert "Ja /" not in chunk.text
+    assert "Nein /" not in chunk.text
+
+
+def test_motion_outcome_from_field_accepted() -> None:
+    # Fixture poll 3602 has "field_accepted": true.
+    # motion_outcome now lives in meta (envelope+meta split).
+    chunk = _chunks()[0]
+    meta = chunk.meta or {}
+    assert meta.get("motion_outcome") == "angenommen"
+
+
+def test_citation_fields_preserved() -> None:
+    chunk = _chunks()[0]
+    assert chunk.citation_title == "Corona-Maßnahmen zum Schutz der Bevölkerung"
+    assert chunk.citation_url and chunk.citation_url.startswith("https://")
+
+
+def test_vote_chunk_dump_has_no_speech_meta_keys() -> None:
+    """A vote chunk's exclude_none dump must not contain SpeechMeta keys."""
+    chunk = _chunks()[0]
+    dumped = chunk.model_dump(mode="json", exclude_none=True)
+    # SpeechMeta keys must not appear at the top level of a vote chunk.
+    for speech_key in (
+        "person_id",
+        "speaker_name",
+        "xml_rede_id",
+        "protocol_id",
+        "protocol_api_id",
+    ):
+        assert speech_key not in dumped, (
+            f"Vote chunk dump must not contain SpeechMeta key '{speech_key}'"
+        )
+    # vote_results and motion_outcome must NOT appear at top-level (they live in meta).
+    assert "vote_results" not in dumped, "vote_results must live in meta, not top-level"
+    assert "motion_outcome" not in dumped, (
+        "motion_outcome must live in meta, not top-level"
+    )
+    # They must appear inside meta.
+    assert "meta" in dumped, "Vote chunk must have a meta dict"
+    assert "vote_results" in dumped["meta"], "meta must contain vote_results"
+
+
+def test_vote_chunk_party_ids_top_level() -> None:
+    """party_ids must remain top-level (indexed envelope field) on a vote chunk."""
+    chunk = _chunks()[0]
+    dumped = chunk.model_dump(mode="json", exclude_none=True)
+    assert "party_ids" in dumped, "party_ids must be top-level in vote chunk dump"
+    assert isinstance(dumped["party_ids"], list)
+    assert len(dumped["party_ids"]) > 0
+
+
+def test_soft_hyphen_greens_label_maps_to_gruene() -> None:
+    """Regression: AW returns the Greens fraction with a U+00AD soft hyphen
+    ("BÜNDNIS 90/­DIE GRÜNEN"). A naive lowercase+strip lookup misses the
+    map key and quarantines the whole Green fraction as "unbekannt" on every
+    20th/21st-Bundestag vote. The normaliser must strip the soft hyphen so the
+    label resolves to "gruene"."""
+    soft_hyphen_label = "BÜNDNIS 90/­DIE GRÜNEN"
+    assert "­" in soft_hyphen_label  # guard: the bug only exists with it
+    assert _canonical_party_slug(soft_hyphen_label) == "gruene"
+    # also with the parliament-period parenthetical AW puts on vote labels
+    assert (
+        _canonical_party_slug("BÜNDNIS 90/­DIE GRÜNEN (Bundestag 2021 - 2025)")
+        == "gruene"
+    )
+
+
+def test_normalize_fraction_label_strips_invisible_chars() -> None:
+    """_normalize_fraction_label removes zero-width/soft-hyphen chars, collapses
+    whitespace, strips and lowercases."""
+    assert _normalize_fraction_label("BÜNDNIS 90/­DIE GRÜNEN") == "bündnis 90/die grünen"
+    assert _normalize_fraction_label("  FDP​ ") == "fdp"
+
+
+# ---------------------------------------------------------------------------
+# State-party slug map extension
+# These tests cover _AW_FRACTION_SLUG_MAP additions for Landtag fractions.
+# ---------------------------------------------------------------------------
+
+
+class TestStatePartySlugMap:
+    """Additions to _AW_FRACTION_SLUG_MAP for state-level parties.
+
+    AW fraction labels include a parliament-period parenthetical suffix
+    (e.g. "Freie Wähler (Bayern 2023 - 2028)") that `_canonical_party_slug`
+    strips before looking up in the map.  These tests verify that the
+    stripped base names resolve to canonical slugs matching the manifesto map
+    (so retrieval returns both vote and manifesto chunks for the same party).
+    """
+
+    def test_freie_waehler_resolves_to_fw(self) -> None:
+        """'Freie Wähler (Bayern 2023 - 2028)' must resolve to 'fw'."""
+        assert _canonical_party_slug("Freie Wähler (Bayern 2023 - 2028)") == "fw"
+
+    def test_ssw_resolves_to_ssw(self) -> None:
+        """'SSW (Schleswig-Holstein 2022 - 2027)' must resolve to 'ssw'."""
+        assert _canonical_party_slug("SSW (Schleswig-Holstein 2022 - 2027)") == "ssw"
+
+    def test_bvb_fw_resolves_to_bvb_fw(self) -> None:
+        """'BVB/Freie Wähler (Brandenburg 2024 - 2029)' must resolve to 'bvb-fw'."""
+        assert (
+            _canonical_party_slug("BVB/Freie Wähler (Brandenburg 2024 - 2029)")
+            == "bvb-fw"
+        )
+
+    def test_unknown_fraction_quarantined_as_unbekannt(self) -> None:
+        """Unknown fraction labels must return the quarantine slug 'unbekannt'."""
+        assert _canonical_party_slug("Irgendeine Unbekannte Fraktion") == "unbekannt"
+
+    def test_csu_regression_unchanged(self) -> None:
+        """CSU must still resolve to 'csu' after the map extension (regression)."""
+        assert _canonical_party_slug("CSU") == "csu"
+
+
+def test_region_for_period_aw_labels() -> None:
+    """region_for_period() resolves AW parliament_period labels to ISO 3166-2 codes.
+
+    AW Landtag period labels use the form 'State YYYY - YYYY' (space before year,
+    no 'Wahl' prefix), e.g. 'Bayern 2023 - 2028'.  region_for_period() must handle
+    this form without modification.
+    """
+    from src.ingestion.connectors.manifestos.mappers.corpus import region_for_period
+
+    assert region_for_period("Bayern 2023 - 2028") == "DE-BY"
+
+
+# ---------------------------------------------------------------------------
+# content_hash covers the stamped envelope fields
+# ---------------------------------------------------------------------------
+
+
+def test_chunk_poll_stamps_envelope_fields() -> None:
+    """chunk_poll owns the full envelope stamping: external_id,
+    wahlperiode, legislature_period_id and relevance_levels."""
+    chunk = chunk_poll(
+        _SourceItemStub(),
+        _load_raw_3602(),
+        wahlperiode=19,
+        legislature_period_id=111,
+    )[0]
+    assert chunk.external_id == 3602
+    assert chunk.wahlperiode == 19
+    assert chunk.legislature_period_id == 111
+    # Fixture topics: Gesundheit / Innere Sicherheit / Öffentliche Finanzen —
+    # all resolve to {federal, state} (no ALL_LEVELS fallback).
+    assert chunk.relevance_levels == ["federal", "state"]
+
+
+def test_content_hash_changes_with_envelope_fields() -> None:
+    """the content_hash must cover the normalize()-stamped envelope fields
+    so an AW_REFRESH reconcile run propagates envelope corrections."""
+    raw = _load_raw_3602()
+
+    base = chunk_poll(
+        _SourceItemStub(), raw, wahlperiode=19, legislature_period_id=111
+    )[0]
+
+    different_period = chunk_poll(
+        _SourceItemStub(), raw, wahlperiode=20, legislature_period_id=132
+    )[0]
+    assert different_period.content_hash != base.content_hash, (
+        "changing wahlperiode/legislature_period_id must change content_hash"
+    )
+
+    other_region_stub = _SourceItemStub()
+    other_region_stub.region = "DE-BY"
+    different_region = chunk_poll(
+        other_region_stub, raw, wahlperiode=19, legislature_period_id=111
+    )[0]
+    assert different_region.content_hash != base.content_hash, (
+        "changing region must change content_hash"
+    )
+
+    repeat = chunk_poll(
+        _SourceItemStub(), raw, wahlperiode=19, legislature_period_id=111
+    )[0]
+    assert repeat.content_hash == base.content_hash, (
+        "content_hash must stay deterministic for identical inputs"
+    )

--- a/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_corpus_chunk_poll.py
+++ b/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_corpus_chunk_poll.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_legislature_config.py
+++ b/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_legislature_config.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_legislature_config.py
+++ b/ai-backend/tests/ingestion/connectors/abgeordnetenwatch/test_legislature_config.py
@@ -1,0 +1,334 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Tests for legislature_config.py.
+
+Covers:
+  - LANDTAG_LEGISLATURE_IDS count = 16 states + outgoing rows
+  - Every Landtag entry has a DE-XX region code
+  - Bundestag keys 111/132/161 are present with region 'DE'
+  - Every Landtag region matches region_for_period(label) from the manifesto mapper
+  - Outgoing BW/RP 2021–2026 rows present with correct region/dates
+  - term_window_for_context() window derivation
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from src.ingestion.connectors.abgeordnetenwatch.legislature_config import (
+    LANDTAG_LEGISLATURE_IDS,
+    LEGISLATURE_CONFIG,
+    TERM_END_SENTINEL,
+    LegislatureConfig,
+    term_window_for_context,
+)
+from src.ingestion.connectors.manifestos.mappers.corpus import region_for_period
+
+
+class TestLegislatureConfigShape:
+    """LEGISLATURE_CONFIG structural assertions."""
+
+    # Outgoing-term rows added (retained alongside the post-2026-election
+    # rows so the two-pass split can separate them by publish_date).
+    _OUTGOING_LANDTAG_IDS = (126, 127)  # BW 2021–2026, RP 2021–2026
+    # Prior-term rows (pre-outgoing): votes land in the HISTORIC bucket of a 2026 chat.
+    # Prior legislature terms per state ("current + 1 prior" ingestion depth);
+    # BW carries two extra rows (outgoing 126 + prior 105) around its 2026 election.
+    _PRIOR_LANDTAG_IDS = (
+        105,  # BW 2016–2021
+        107,  # BE 2016–2021
+        108,  # MV 2016–2021
+        109,  # NW 2017–2022
+        110,  # SH 2017–2022
+        112,  # NI 2017–2022
+        113,  # SL 2017–2022
+        114,  # ST 2016–2021
+        115,  # BY 2018–2023
+        116,  # HE 2019–2024
+        118,  # HB 2019–2023
+        119,  # SN 2019–2024
+        120,  # BB 2019–2024
+        121,  # TH 2019–2024
+        122,  # HH 2020–2025
+    )
+
+    def test_all_16_states_represented(self) -> None:
+        """Every one of the 16 German states must have at least one Landtag row."""
+        regions = {LEGISLATURE_CONFIG[lid].region for lid in LANDTAG_LEGISLATURE_IDS}
+        expected = {
+            "DE-BW",
+            "DE-BY",
+            "DE-BE",
+            "DE-BB",
+            "DE-HB",
+            "DE-HH",
+            "DE-HE",
+            "DE-MV",
+            "DE-NI",
+            "DE-NW",
+            "DE-RP",
+            "DE-SL",
+            "DE-SN",
+            "DE-ST",
+            "DE-SH",
+            "DE-TH",
+        }
+        assert regions == expected, (
+            f"Landtag regions {regions!r} do not cover exactly the 16 states {expected!r}"
+        )
+
+    def test_landtag_legislature_ids_count(self) -> None:
+        """LANDTAG_LEGISLATURE_IDS == 16 states + outgoing (126/127) + prior (105) rows."""
+        expected_count = (
+            16 + len(self._OUTGOING_LANDTAG_IDS) + len(self._PRIOR_LANDTAG_IDS)
+        )
+        assert len(LANDTAG_LEGISLATURE_IDS) == expected_count, (
+            f"Expected {expected_count} Landtag IDs (16 states + "
+            f"{len(self._OUTGOING_LANDTAG_IDS)} outgoing + "
+            f"{len(self._PRIOR_LANDTAG_IDS)} prior rows), got "
+            f"{len(LANDTAG_LEGISLATURE_IDS)}: {LANDTAG_LEGISLATURE_IDS}"
+        )
+
+    def test_prior_bw_row_present_and_does_not_hijack_current_window(self) -> None:
+        """The prior BW 2016–2021 row (105) exists with correct region/dates, is a
+        Landtag id, and does NOT hijack the CURRENT window for a 2026 BW chat — the
+        election-date 'containing' tiebreak must still resolve to the outgoing 126 term."""
+        assert 105 in LANDTAG_LEGISLATURE_IDS
+        cfg = LEGISLATURE_CONFIG[105]
+        assert cfg.region == "DE-BW"
+        assert cfg.date_from == "2016-05-11"
+        assert cfg.date_to == "2021-05-10"
+        # DE-BW now has three periods (105, 126, 165); the 2026 election date sits inside
+        # the outgoing 126 term, so the current window must still be 2021-05-11..2026-05-11.
+        window = term_window_for_context(["DE", "DE-BW"], None, date(2026, 3, 8))
+        assert window is not None
+        assert window[0] == datetime(2021, 5, 11, tzinfo=timezone.utc)
+        assert window[1] == datetime(2026, 5, 11, tzinfo=timezone.utc)
+
+    def test_outgoing_bw_rp_rows_present(self) -> None:
+        """The outgoing BW/RP 2021–2026 rows must be present with correct region/dates.
+
+        Both terms coexist with the post-election 165/166 rows: outgoing 126/127
+        carry the 2021–2026 voting record; 165/166 begin the 2026–2031 term.
+        """
+        outgoing = {
+            126: ("DE-BW", "2021-05-11", "2026-05-11"),
+            127: ("DE-RP", "2021-03-12", "2026-05-18"),
+        }
+        for lid, (region, date_from, date_to) in outgoing.items():
+            assert lid in LANDTAG_LEGISLATURE_IDS, (
+                f"Outgoing Landtag ID {lid} missing from LANDTAG_LEGISLATURE_IDS"
+            )
+            cfg = LEGISLATURE_CONFIG[lid]
+            assert cfg.region == region, (
+                f"ID {lid}: region {cfg.region!r} != {region!r}"
+            )
+            assert cfg.date_from == date_from, (
+                f"ID {lid}: date_from {cfg.date_from!r} != {date_from!r}"
+            )
+            assert cfg.date_to == date_to, (
+                f"ID {lid}: date_to {cfg.date_to!r} != {date_to!r}"
+            )
+            # Range sits within 2021–2026 (outgoing term voters want around the election).
+            assert cfg.date_from.startswith("2021"), (
+                f"ID {lid} outgoing term must start in 2021"
+            )
+            assert cfg.date_to.startswith("2026"), (
+                f"ID {lid} outgoing term must end in 2026"
+            )
+
+        # Post-election rows must still be present alongside the outgoing ones.
+        assert LEGISLATURE_CONFIG[165].date_from.startswith("2026")
+        assert LEGISLATURE_CONFIG[166].date_from.startswith("2026")
+
+    def test_all_landtag_regions_are_de_xx(self) -> None:
+        """Every Landtag entry must have a DE-XX ISO 3166-2 state region code."""
+        bad = [
+            lid
+            for lid in LANDTAG_LEGISLATURE_IDS
+            if not LEGISLATURE_CONFIG[lid].region.startswith("DE-")
+        ]
+        assert not bad, (
+            f"Landtag IDs with non-DE-XX region: {bad!r} — "
+            "each Landtag must have a region code like 'DE-BY', not 'DE'"
+        )
+
+    def test_bundestag_keys_present(self) -> None:
+        """LEGISLATURE_CONFIG must contain Bundestag period IDs 111, 132, and 161."""
+        for expected_key in (111, 132, 161):
+            assert expected_key in LEGISLATURE_CONFIG, (
+                f"Bundestag key {expected_key} missing from LEGISLATURE_CONFIG"
+            )
+
+    def test_bundestag_regions_are_de(self) -> None:
+        """Bundestag entries 111/132/161 must have region 'DE' (not 'DE-*')."""
+        for kid in (111, 132, 161):
+            assert LEGISLATURE_CONFIG[kid].region == "DE", (
+                f"Bundestag key {kid} has region {LEGISLATURE_CONFIG[kid].region!r}, "
+                "expected 'DE'"
+            )
+
+    def test_all_landtag_regions_match_region_for_period(self) -> None:
+        """Every Landtag row's stored region must equal region_for_period(row.label).
+
+        This ensures the manifesto-connector region derivation function is the source
+        of truth and the config values are not independently diverged.
+        """
+        mismatches: list[str] = []
+        for lid in LANDTAG_LEGISLATURE_IDS:
+            cfg = LEGISLATURE_CONFIG[lid]
+            derived = region_for_period(cfg.label)
+            if derived != cfg.region:
+                mismatches.append(
+                    f"ID={lid} label={cfg.label!r}: "
+                    f"stored={cfg.region!r}, region_for_period()={derived!r}"
+                )
+        assert not mismatches, (
+            "region_for_period(label) mismatch in LEGISLATURE_CONFIG:\n"
+            + "\n".join(mismatches)
+        )
+
+    def test_legislature_config_config_dataclass_is_frozen(self) -> None:
+        """LegislatureConfig must be a frozen dataclass (immutable config)."""
+        cfg = LEGISLATURE_CONFIG[149]  # Bayern — guaranteed to exist
+        try:
+            cfg.region = "XX"  # type: ignore[misc]
+            raise AssertionError(
+                "LegislatureConfig.region must be read-only (frozen=True)"
+            )
+        except (AttributeError, TypeError):
+            pass  # expected: frozen dataclass raises on assignment
+
+    def test_all_landtag_ids_in_legislature_config(self) -> None:
+        """Every ID in LANDTAG_LEGISLATURE_IDS must be a key in LEGISLATURE_CONFIG."""
+        missing = [
+            lid for lid in LANDTAG_LEGISLATURE_IDS if lid not in LEGISLATURE_CONFIG
+        ]
+        assert not missing, (
+            f"LANDTAG_LEGISLATURE_IDS contains IDs not in LEGISLATURE_CONFIG: {missing!r}"
+        )
+
+
+class TestTermWindowForContext:
+    """term_window_for_context() term-window derivation."""
+
+    def test_window_by_period_id(self) -> None:
+        """An explicit legislature_period_id resolves that row's (date_from, date_to)."""
+        window = term_window_for_context(region_path=["DE"], legislature_period_id=161)
+        assert window is not None
+        start, end = window
+        assert start == datetime(2025, 3, 25, tzinfo=timezone.utc)
+        assert end == datetime(2029, 2, 22, tzinfo=timezone.utc)
+
+    def test_window_by_region_single(self) -> None:
+        """A region with exactly one period resolves that window (no period id)."""
+        # Bayern (DE-BY) has a single row: 149 Bayern 2023 - 2028.
+        window = term_window_for_context(
+            region_path=["DE", "DE-BY"], legislature_period_id=None
+        )
+        assert window is not None
+        start, end = window
+        assert start == datetime(2023, 10, 26, tzinfo=timezone.utc)
+        assert end == datetime(2028, 10, 31, tzinfo=timezone.utc)
+
+    def test_window_by_region_multi_picks_outgoing(self) -> None:
+        """A multi-period region picks the OUTGOING term for an election on/before 2026.
+
+        DE-BW now has two rows (126 outgoing 2021–2026, 165 post-election 2026–2031).
+        For an election_date inside the outgoing term, the helper must return the
+        outgoing window, not the post-election one.
+        """
+        window = term_window_for_context(
+            region_path=["DE", "DE-BW"],
+            legislature_period_id=None,
+            election_date=date(2026, 3, 8),
+        )
+        assert window is not None
+        start, end = window
+        assert start == datetime(2021, 5, 11, tzinfo=timezone.utc)
+        assert end == datetime(2026, 5, 11, tzinfo=timezone.utc)
+
+    def test_window_multi_no_election_date_picks_latest(self) -> None:
+        """With no election_date, a multi-period region deterministically picks
+        the latest term by end date (final documented fallback branch)."""
+        window = term_window_for_context(
+            region_path=["DE", "DE-BW"],
+            legislature_period_id=None,
+            election_date=None,
+        )
+        assert window is not None
+        start, end = window
+        # Latest DE-BW term by end date is the post-election 165 (2026–2031).
+        assert start == datetime(2026, 5, 12, tzinfo=timezone.utc)
+        assert end == datetime(2031, 5, 20, tzinfo=timezone.utc)
+
+    def test_window_none_when_unresolved(self) -> None:
+        """Unknown region / general context with no matching row returns None."""
+        assert (
+            term_window_for_context(
+                region_path=["DE", "DE-XX"], legislature_period_id=None
+            )
+            is None
+        )
+        assert (
+            term_window_for_context(region_path=None, legislature_period_id=None)
+            is None
+        )
+        # Unknown period id with no region falls through to None.
+        assert (
+            term_window_for_context(region_path=None, legislature_period_id=999999)
+            is None
+        )
+
+    def test_window_datetimes_are_tz_aware(self) -> None:
+        """Returned datetimes carry tzinfo=UTC; date_to=None maps to the sentinel."""
+        window = term_window_for_context(region_path=["DE"], legislature_period_id=161)
+        assert window is not None
+        start, end = window
+        assert start.tzinfo == timezone.utc
+        assert end.tzinfo == timezone.utc
+
+    def test_window_open_ended_maps_to_sentinel(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A row with date_to=None maps its term_end to the far-future UTC sentinel."""
+        monkeypatch.setitem(
+            LEGISLATURE_CONFIG,
+            900001,
+            LegislatureConfig(
+                900001, "DE-ZZ", "Testland 2020 - open", "2020-01-01", None
+            ),
+        )
+        window = term_window_for_context(
+            region_path=["DE", "DE-ZZ"], legislature_period_id=900001
+        )
+        assert window is not None
+        start, end = window
+        assert start == datetime(2020, 1, 1, tzinfo=timezone.utc)
+        assert end == TERM_END_SENTINEL
+        assert end.tzinfo == timezone.utc
+
+
+class TestWahlperiodeField:
+    """LegislatureConfig.wahlperiode — Bundestag rows carry the number,
+    Landtag rows stay None (state Wahlperiode ints collide across states)."""
+
+    def test_bundestag_rows_carry_wahlperiode(self) -> None:
+        assert LEGISLATURE_CONFIG[111].wahlperiode == 19
+        assert LEGISLATURE_CONFIG[132].wahlperiode == 20
+        assert LEGISLATURE_CONFIG[161].wahlperiode == 21
+
+    def test_landtag_rows_have_no_wahlperiode(self) -> None:
+        bad = [
+            lid
+            for lid in LANDTAG_LEGISLATURE_IDS
+            if LEGISLATURE_CONFIG[lid].wahlperiode is not None
+        ]
+        assert not bad, (
+            f"Landtag rows must not carry a wahlperiode int, offenders: {bad!r}"
+        )

--- a/ai-backend/tests/ingestion/connectors/manifestos/__init__.py
+++ b/ai-backend/tests/ingestion/connectors/manifestos/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0

--- a/ai-backend/tests/ingestion/connectors/manifestos/__init__.py
+++ b/ai-backend/tests/ingestion/connectors/manifestos/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0

--- a/ai-backend/tests/ingestion/connectors/manifestos/test_connector.py
+++ b/ai-backend/tests/ingestion/connectors/manifestos/test_connector.py
@@ -1,0 +1,403 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Unit tests for ManifestoConnector (src/ingestion/connectors/manifestos/connector.py).
+
+Pure: no network, no OpenAI, no Qdrant, no Firestore. The AWClient is never
+exercised — discover()'s caches are seeded directly and load_program_pages is
+monkeypatched, so fetch()/normalize() are tested without I/O.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.ingestion.connector import BaseConnector
+from src.ingestion.connectors.manifestos import connector as conn_mod
+from src.ingestion.connectors.manifestos.connector import ManifestoConnector
+from src.ingestion.schemas import SourceType
+
+_PDF_PROGRAM = {
+    "id": 598,
+    "label": "Wahlprogramm SPD 2025",
+    "party": {"id": 1, "label": "SPD"},
+    "parliament_period": {"id": 111, "label": "Bundestag Wahl 2025"},
+    "link": [],
+    "file": "https://example.com/spd-programm-2025.pdf",
+}
+
+_LINK_PROGRAM = {
+    "id": 701,
+    "label": "Wahlprogramm Grüne Berlin 2023",
+    "party": {"id": 5, "label": "BÜNDNIS 90/DIE GRÜNEN"},
+    "parliament_period": {"id": 200, "label": "Berlin Wahl 2023"},
+    "link": [{"uri": "https://gruene-berlin.de/programm", "title": "Programm"}],
+    "file": None,
+}
+
+
+def _seed(connector: ManifestoConnector, program: dict, date_iso: str) -> None:
+    """Seed the per-run discover() caches so fetch() can run without discovery."""
+    pid = program["id"]
+    connector._programs = {pid: program}
+    connector._period_dates = {pid: date_iso}
+
+
+class TestInterface:
+    def test_is_base_connector(self) -> None:
+        assert issubclass(ManifestoConnector, BaseConnector)
+
+    def test_source_type_is_party_manifesto(self) -> None:
+        assert ManifestoConnector.source_type == SourceType.PARTY_MANIFESTO.value
+
+
+class TestFetchNormalize:
+    def test_pdf_fetch_then_normalize(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        connector = ManifestoConnector()
+        _seed(connector, _PDF_PROGRAM, "2025-02-23")
+
+        monkeypatch.setattr(
+            conn_mod,
+            "load_program_pages",
+            lambda *a, **k: {
+                "pages": [(1, "Ein Programmtext. " * 50)],
+                "total_pages": 1,
+            },
+        )
+
+        raw = connector.fetch("598")
+        assert raw["source_kind"] == "pdf"
+        assert "skip_reason" not in raw
+
+        records = connector.normalize(raw)
+        assert records
+        rec = records[0]
+        assert rec.party_id == "spd"
+        assert rec.source_type == SourceType.PARTY_MANIFESTO
+        assert rec.external_id == 598
+        # citation_url is the original source (AW file) URL, not a re-serve route.
+        assert rec.citation_url == "https://example.com/spd-programm-2025.pdf"
+
+    def test_link_pages_have_no_page_numbers(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        connector = ManifestoConnector()
+        _seed(connector, _LINK_PROGRAM, "2023-09-10")
+
+        monkeypatch.setattr(
+            conn_mod,
+            "load_program_pages",
+            lambda *a, **k: {
+                "pages": [(1, "HTML Programmtext. " * 50)],
+                "total_pages": None,
+            },
+        )
+
+        records = connector.normalize(connector.fetch("701"))
+        meta = records[0].meta
+        assert meta is not None
+        assert "page_start" not in meta
+        assert "page_end" not in meta
+        assert records[0].region == "DE-BE"
+
+    def test_fetch_skip_reason_propagates_as_valueerror(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        connector = ManifestoConnector()
+        _seed(connector, _PDF_PROGRAM, "2025-02-23")
+
+        def _boom(*a: object, **k: object) -> dict:
+            raise ValueError("PDF download failed: boom")
+
+        monkeypatch.setattr(conn_mod, "load_program_pages", _boom)
+
+        raw = connector.fetch("598")
+        assert raw["skip_reason"] == "PDF download failed: boom"
+        with pytest.raises(ValueError, match="PDF download failed"):
+            connector.normalize(raw)
+
+    def test_program_not_in_cache_skips(self) -> None:
+        connector = ManifestoConnector()
+        raw = connector.fetch("999")  # nothing seeded
+        assert "not in discover cache" in raw["skip_reason"]
+        with pytest.raises(ValueError):
+            connector.normalize(raw)
+
+
+class TestDiscoverSetDifference:
+    """(a) discover() uses gap-free set-difference against Qdrant, not a
+    max-external_id watermark that permanently drops failed-below-max programs."""
+
+    class _FakeAwClient:
+        def __init__(self, programs: list[dict]) -> None:
+            self._programs = programs
+
+        def get_all(self, endpoint: str, params: dict) -> list[dict]:
+            return self._programs
+
+    def test_failed_program_below_max_is_rediscovered(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A program with an id BELOW the stored max (e.g. it transiently failed
+        on run 1 while a higher id succeeded) must be re-discovered on run 2;
+        already-ingested programs are excluded."""
+        failed_program = dict(_PDF_PROGRAM, id=555)
+        ingested_program = dict(_PDF_PROGRAM, id=598)
+
+        connector = ManifestoConnector()
+        connector._client = self._FakeAwClient([failed_program, ingested_program])  # type: ignore[assignment]
+        monkeypatch.setattr(
+            conn_mod, "_fetch_period_date", lambda *a, **k: "2025-02-23"
+        )
+        monkeypatch.setattr(connector, "_get_ingested_program_ids", lambda: {598})
+
+        # Under the OLD watermark filter, since=598 would exclude 555 forever.
+        ids = connector.discover(since=598)
+
+        assert "555" in ids, "a failed-below-max program must be re-discovered"
+        assert "598" not in ids, "already-ingested programs must be excluded"
+
+    def test_no_floor_by_default_includes_old_program(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With MANIFESTO_SINCE unset there is NO built-in cut-off — an old
+        program (would-be-excluded under the former hardcoded 2020 floor) is
+        ingested."""
+        monkeypatch.delenv("MANIFESTO_SINCE", raising=False)
+        old_program = dict(_PDF_PROGRAM, id=100)
+
+        connector = ManifestoConnector()
+        connector._client = self._FakeAwClient([old_program])  # type: ignore[assignment]
+        monkeypatch.setattr(
+            conn_mod, "_fetch_period_date", lambda *a, **k: "2017-09-24"
+        )
+        monkeypatch.setattr(connector, "_get_ingested_program_ids", lambda: set())
+
+        assert connector.discover(since=None) == ["100"]
+
+    def test_manifesto_since_floors_out_older_programs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """MANIFESTO_SINCE excludes programs whose election_date is before it,
+        and keeps those on or after it."""
+        # Distinct parliament_period ids so each maps to its own election_date.
+        old_program = dict(
+            _PDF_PROGRAM, id=100, parliament_period={"id": 900, "label": "old"}
+        )
+        new_program = dict(
+            _PDF_PROGRAM, id=101, parliament_period={"id": 901, "label": "new"}
+        )
+        dates = {900: "2017-09-24", 901: "2025-02-23"}
+
+        connector = ManifestoConnector()
+        connector._client = self._FakeAwClient([old_program, new_program])  # type: ignore[assignment]
+        monkeypatch.setattr(
+            conn_mod,
+            "_fetch_period_date",
+            lambda _client, period_id, _cache: dates[period_id],
+        )
+        monkeypatch.setattr(connector, "_get_ingested_program_ids", lambda: set())
+        monkeypatch.setenv("MANIFESTO_SINCE", "2020-01-01")
+
+        ids = connector.discover(since=None)
+        assert ids == ["101"], f"only the >= floor program is kept, got {ids!r}"
+
+    def test_invalid_manifesto_since_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A malformed MANIFESTO_SINCE surfaces loudly rather than silently
+        ingesting everything."""
+        monkeypatch.setenv("MANIFESTO_SINCE", "not-a-date")
+        with pytest.raises(ValueError, match="MANIFESTO_SINCE must be an ISO date"):
+            conn_mod.resolve_since_floor()
+
+
+class TestManifestoRefresh:
+    """MANIFESTO_REFRESH=1 skips the ingested-ids exclusion so run.py's
+    content-hash rewrite + orphan cleanup can reconcile replaced PDFs."""
+
+    def test_refresh_includes_already_ingested_programs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ingested_program = dict(_PDF_PROGRAM, id=598)
+        new_program = dict(_PDF_PROGRAM, id=700)
+
+        connector = ManifestoConnector()
+        connector._client = TestDiscoverSetDifference._FakeAwClient(  # type: ignore[assignment]
+            [ingested_program, new_program]
+        )
+        monkeypatch.setattr(
+            conn_mod, "_fetch_period_date", lambda *a, **k: "2025-02-23"
+        )
+
+        def _boom() -> set[int]:
+            raise AssertionError(
+                "MANIFESTO_REFRESH must not touch Qdrant for the ingested-ids set"
+            )
+
+        monkeypatch.setattr(connector, "_get_ingested_program_ids", _boom)
+        monkeypatch.setenv("MANIFESTO_REFRESH", "1")
+
+        ids = connector.discover(since=None)
+
+        assert ids == ["598", "700"], (
+            "refresh discover must return ALL eligible programs (incl. ingested), "
+            f"got {ids!r}"
+        )
+
+    def test_refresh_flag_parsing_matches_aw_refresh(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """'true'/'yes'/'1' enable refresh; other values do not."""
+        ingested_program = dict(_PDF_PROGRAM, id=598)
+
+        for value, expect_included in [
+            ("true", True),
+            ("YES", True),
+            ("1", True),
+            ("0", False),
+            ("off", False),
+            ("", False),
+        ]:
+            connector = ManifestoConnector()
+            connector._client = TestDiscoverSetDifference._FakeAwClient(  # type: ignore[assignment]
+                [ingested_program]
+            )
+            monkeypatch.setattr(
+                conn_mod, "_fetch_period_date", lambda *a, **k: "2025-02-23"
+            )
+            monkeypatch.setattr(connector, "_get_ingested_program_ids", lambda: {598})
+            monkeypatch.setenv("MANIFESTO_REFRESH", value)
+
+            ids = connector.discover(since=None)
+            assert ("598" in ids) is expect_included, (
+                f"MANIFESTO_REFRESH={value!r}: expected included={expect_included}, got {ids!r}"
+            )
+
+
+class TestDetermineSource:
+    """determine_source precedence — link[0].uri wins over file; both
+    null raises; a non-dict link entry falls back to file."""
+
+    def test_link_uri_wins_over_file(self) -> None:
+        program = {
+            "link": [{"uri": "https://example.com/programm", "title": "Programm"}],
+            "file": "https://example.com/programm.pdf",
+        }
+        assert conn_mod.determine_source(program) == (
+            "link",
+            "https://example.com/programm",
+        )
+
+    def test_file_used_when_no_link(self) -> None:
+        program = {"link": [], "file": "https://example.com/programm.pdf"}
+        assert conn_mod.determine_source(program) == (
+            "pdf",
+            "https://example.com/programm.pdf",
+        )
+
+    def test_null_link_uri_falls_back_to_file(self) -> None:
+        program = {
+            "link": [{"uri": None, "title": "kaputt"}],
+            "file": "https://example.com/programm.pdf",
+        }
+        assert conn_mod.determine_source(program) == (
+            "pdf",
+            "https://example.com/programm.pdf",
+        )
+
+    def test_non_dict_link_entry_falls_back_to_file(self) -> None:
+        program = {
+            "link": ["https://not-a-dict.example.com"],
+            "file": "https://example.com/programm.pdf",
+        }
+        assert conn_mod.determine_source(program) == (
+            "pdf",
+            "https://example.com/programm.pdf",
+        )
+
+    def test_both_null_raises(self) -> None:
+        with pytest.raises(ValueError, match="no link or file"):
+            conn_mod.determine_source({"link": [], "file": None})
+
+
+class TestLoadProgramPagesHtmlFloor:
+    """HTML sources shorter than 500 extracted chars are skipped (a
+    'download our program' landing page must not be embedded)."""
+
+    class _FakeResponse:
+        def __init__(self, text: str) -> None:
+            self.text = text
+
+        def raise_for_status(self) -> None:
+            return None
+
+    def test_short_html_raises_floor_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        nav_only = "<html><body><nav><a href='/'>Home</a></nav></body></html>"
+        monkeypatch.setattr(
+            "requests.get", lambda *a, **k: self._FakeResponse(nav_only)
+        )
+        with pytest.raises(ValueError, match="HTML too short"):
+            conn_mod.load_program_pages("link", "https://example.com/landing")
+
+    def test_long_html_passes_floor(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        paragraph = (
+            "<p>"
+            + ("Wir fordern bezahlbaren Wohnraum für alle Menschen. " * 20)
+            + "</p>"
+        )
+        html = (
+            f"<html><body><article><h1>Programm</h1>{paragraph}</article></body></html>"
+        )
+        monkeypatch.setattr("requests.get", lambda *a, **k: self._FakeResponse(html))
+        result = conn_mod.load_program_pages("link", "https://example.com/programm")
+        assert result["total_pages"] is None
+        assert len(result["pages"]) == 1
+        page_no, text = result["pages"][0]
+        assert page_no == 1
+        assert len(text) >= 500
+
+
+class TestGetIngestedProgramIds:
+    """_get_ingested_program_ids paginates the Qdrant scroll and filters
+    non-int external_ids."""
+
+    class _Point:
+        def __init__(self, payload: dict | None) -> None:
+            self.payload = payload
+
+    class _PagingQdrant:
+        """Two scroll pages; second page carries the terminating None offset."""
+
+        def __init__(self) -> None:
+            self.calls: list[object] = []
+
+        def scroll(self, **kwargs: object) -> tuple:
+            offset = kwargs.get("offset")
+            self.calls.append(offset)
+            P = TestGetIngestedProgramIds._Point
+            if offset is None:
+                return (
+                    [P({"external_id": 598}), P({"external_id": "not-int"})],
+                    "page-2-offset",
+                )
+            return (
+                [P({"external_id": 700}), P(None), P({"external_id": 3.5})],
+                None,
+            )
+
+    def test_pagination_and_non_int_filtering(self) -> None:
+        connector = ManifestoConnector()
+        fake = self._PagingQdrant()
+        connector._qdrant = fake  # type: ignore[assignment]
+
+        ids = connector._get_ingested_program_ids()
+
+        assert ids == {598, 700}, f"expected int-only ids across pages, got {ids!r}"
+        assert fake.calls == [None, "page-2-offset"], (
+            "scroll must be called once per page, chaining next_offset"
+        )

--- a/ai-backend/tests/ingestion/connectors/manifestos/test_connector.py
+++ b/ai-backend/tests/ingestion/connectors/manifestos/test_connector.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -77,8 +77,9 @@ class TestFetchNormalize:
         assert rec.party_id == "spd"
         assert rec.source_type == SourceType.PARTY_MANIFESTO
         assert rec.external_id == 598
-        # citation_url is the original source (AW file) URL, not a re-serve route.
-        assert rec.citation_url == "https://example.com/spd-programm-2025.pdf"
+        # citation_url is the original source (AW file) URL — with a per-chunk
+        # #page anchor so the citation opens on the supporting page.
+        assert rec.citation_url == "https://example.com/spd-programm-2025.pdf#page=1"
 
     def test_link_pages_have_no_page_numbers(
         self, monkeypatch: pytest.MonkeyPatch
@@ -114,7 +115,9 @@ class TestFetchNormalize:
         monkeypatch.setattr(conn_mod, "load_program_pages", _boom)
 
         raw = connector.fetch("598")
-        assert raw["skip_reason"] == "PDF download failed: boom"
+        # Every candidate failed → the skip reason enumerates the attempts.
+        assert "PDF download failed: boom" in raw["skip_reason"]
+        assert raw["skip_reason"].startswith("all source candidates failed")
         with pytest.raises(ValueError, match="PDF download failed"):
             connector.normalize(raw)
 
@@ -400,4 +403,79 @@ class TestGetIngestedProgramIds:
         assert ids == {598, 700}, f"expected int-only ids across pages, got {ids!r}"
         assert fake.calls == [None, "page-2-offset"], (
             "scroll must be called once per page, chaining next_offset"
+        )
+
+
+class TestSourceFallback:
+    """A dead preferred HTML link falls back to the PDF instead of skipping."""
+
+    def test_html_failure_falls_back_to_pdf(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        program = {
+            "id": 129,
+            "label": "Programm",
+            "party": {"label": "SPD"},
+            "parliament_period": {"id": 50, "label": "Bundestag Wahl 2021"},
+            "link": [{"uri": "https://archive.example/dead-viewer"}],
+            "file": "https://example.com/program-129.pdf",
+        }
+        connector = ManifestoConnector()
+        _seed(connector, program, "2021-09-26")
+
+        def _fake_load(source_kind: object, source_url: str) -> dict:
+            if "dead-viewer" in source_url:
+                raise ValueError("HTML fetch failed: 404")
+            return {"pages": [(1, "PDF Inhalt " * 100)], "total_pages": 1}
+
+        monkeypatch.setattr(conn_mod, "load_program_pages", _fake_load)
+
+        raw = connector.fetch("129")
+        assert "skip_reason" not in raw, (
+            f"PDF fallback must rescue the program, got skip: {raw.get('skip_reason')}"
+        )
+        assert raw["source_url"] == "https://example.com/program-129.pdf"
+        records = connector.normalize(raw)
+        assert records, "the fallback-fetched program must normalize to chunks"
+
+
+class TestCompletenessAwareSetDifference:
+    """One stored chunk is NOT proof a program committed completely."""
+
+    class _Store:
+        """Fake store: program 600 has 2 of 3 chunks stored (partial commit),
+        program 700 has 2 of 2 (complete)."""
+
+        def scroll(self, **kwargs: object) -> tuple:
+            from types import SimpleNamespace
+
+            points = [
+                SimpleNamespace(
+                    id=f"p600-{i}",
+                    payload={
+                        "external_id": 600,
+                        "meta": {"total_chunks": 3},
+                    },
+                )
+                for i in range(2)
+            ] + [
+                SimpleNamespace(
+                    id=f"p700-{i}",
+                    payload={
+                        "external_id": 700,
+                        "meta": {"total_chunks": 2},
+                    },
+                )
+                for i in range(2)
+            ]
+            return (points, None)
+
+    def test_partial_program_is_rediscovered(self) -> None:
+        connector = ManifestoConnector()
+        connector.bind_store(self._Store(), "wahlchat_chunks_test")
+        ingested = connector._get_ingested_program_ids()
+        assert 700 in ingested, "a complete program counts as ingested"
+        assert 600 not in ingested, (
+            "a partially-committed program (2/3 chunks) must be re-discovered "
+            "so the runner's footprint comparison repairs the missing tail"
         )

--- a/ai-backend/tests/ingestion/connectors/manifestos/test_corpus.py
+++ b/ai-backend/tests/ingestion/connectors/manifestos/test_corpus.py
@@ -1,0 +1,728 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Unit tests for src/ingestion/connectors/manifestos/mappers/corpus.py.
+
+Tests are pure (no network, no OpenAI, no Qdrant, no Firestore): they cover
+only the deterministic helper functions:
+  (a) party_to_slug   — all known parties + soft-hyphen Greens + unknown
+  (b) region_for_period — Bundestag, EU, states, fallback
+  (c) wahlperiode_for_period — Bundestag years, non-Bundestag
+  (d) chunk_pages     — single page, multi-page over max_tokens, page spans
+  (e) build_manifesto_records — pdf program, link program, unknown party
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from src.ingestion.connectors.manifestos.mappers.corpus import (
+    _slugify,
+    build_manifesto_records,
+    chunk_pages,
+    extract_main_text,
+    party_to_slug,
+    region_for_period,
+    wahlperiode_for_period,
+)
+from src.ingestion.schemas import AuthorityTier, SourceType
+
+
+# ===========================================================================
+# (a) party_to_slug
+# ===========================================================================
+
+
+class TestPartyToSlug:
+    """party_to_slug maps all known AW party labels to canonical slugs."""
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("SPD", "spd"),
+            ("spd", "spd"),
+            ("CDU", "cdu"),
+            ("CSU", "csu"),
+            ("FDP", "fdp"),
+            ("AfD", "afd"),
+            ("afd", "afd"),
+            ("BSW", "bsw"),
+            ("bsw", "bsw"),
+            ("Fraktionslos", "fraktionslos"),
+            # Standard ASCII Greens label
+            ("BÜNDNIS 90/DIE GRÜNEN", "gruene"),
+            ("bündnis 90/die grünen", "gruene"),
+            ("Die Grünen", "gruene"),
+            ("grüne", "gruene"),
+            # Linke variants
+            ("DIE LINKE", "linke"),
+            ("Die Linke.", "linke"),
+            ("Linke", "linke"),
+            # Explicit map — smaller parties
+            ("FREIE WÄHLER", "fw"),
+            ("ÖDP", "oedp"),
+            ("Die PARTEI", "die-partei"),
+            ("dieBasis", "basis"),
+            ("Partei der Humanisten", "pdh"),
+            # Explicit map — Piraten / Volt now have entries
+            ("Piraten", "piraten"),
+            ("Volt", "volt"),
+            # Fallback via _slugify — not in explicit map
+            ("Klimaliste", "klimaliste"),
+            ("Tierschutz hier!", "tierschutz-hier"),
+            # Missing / empty
+            (None, "unbekannt"),
+            ("", "unbekannt"),
+        ],
+    )
+    def test_known_and_unknown(self, raw: str | None, expected: str) -> None:
+        assert party_to_slug(raw) == expected
+
+    def test_soft_hyphen_greens(self) -> None:
+        """U+00AD soft hyphen in 'BÜNDNIS 90/­DIE GRÜNEN' must resolve to gruene."""
+        # This is the exact label AW embeds in the 20th/21st Bundestag Greens fraction
+        label_with_soft_hyphen = "BÜNDNIS 90/­DIE GRÜNEN"
+        assert party_to_slug(label_with_soft_hyphen) == "gruene"
+
+    def test_unknown_party_derives_slug_via_slugify(self) -> None:
+        """A party not in the explicit map gets a clean derived slug (not 'unbekannt')."""
+        assert party_to_slug("Klimaliste Sachsen") == "klimaliste-sachsen"
+
+    def test_empty_string_returns_unbekannt(self) -> None:
+        assert party_to_slug("") == "unbekannt"
+
+    def test_none_returns_unbekannt(self) -> None:
+        assert party_to_slug(None) == "unbekannt"
+
+
+# ===========================================================================
+# (_slugify helper)
+# ===========================================================================
+
+
+class TestSlugify:
+    """_slugify produces clean ASCII slugs with umlaut transliteration."""
+
+    @pytest.mark.parametrize(
+        "text, expected",
+        [
+            ("Volt", "volt"),
+            ("Klimaliste", "klimaliste"),
+            ("Freie Sachsen", "freie-sachsen"),
+            ("Tierschutz hier!", "tierschutz-hier"),
+            ("Sozialistische Gleichheitspartei", "sozialistische-gleichheitspartei"),
+            # Umlaut transliteration
+            ("Ödnis", "oednis"),
+            ("Überparteilich", "ueberparteilich"),
+            ("Grüne", "gruene"),
+            ("Größe", "groesse"),
+            # Punctuation collapse / suffix stripping
+            ("MERA25", "mera25"),
+            # U+00B3 superscript-3 is not [a-z0-9], gets replaced then stripped
+            ("Volt³", "volt"),
+            # Already clean
+            ("fdp", "fdp"),
+        ],
+    )
+    def test_slugify_output(self, text: str, expected: str) -> None:
+        assert _slugify(text) == expected
+
+    def test_empty_string_returns_unbekannt(self) -> None:
+        assert _slugify("") == "unbekannt"
+
+    def test_punctuation_only_returns_unbekannt(self) -> None:
+        assert _slugify("!!!") == "unbekannt"
+
+
+# ===========================================================================
+# (b) region_for_period
+# ===========================================================================
+
+
+class TestRegionForPeriod:
+    """region_for_period maps parliament-period labels to scalar region codes."""
+
+    @pytest.mark.parametrize(
+        "label, expected",
+        [
+            ("Bundestag Wahl 2021", "DE"),
+            ("Bundestag Wahl 2025", "DE"),
+            ("Bundestag 2017 - 2021", "DE"),
+            ("EU-Parlament Wahl 2024", "EU"),
+            ("Europaparlament Wahl 2019", "EU"),
+            ("Bayern Wahl 2023", "DE-BY"),
+            ("Baden-Württemberg Wahl 2021", "DE-BW"),
+            ("Berlin Wahl 2023", "DE-BE"),
+            ("Hamburg Wahl 2020", "DE-HH"),
+            ("Nordrhein-Westfalen Wahl 2022", "DE-NW"),
+            ("Thüringen Wahl 2024", "DE-TH"),
+            ("Sachsen Wahl 2024", "DE-SN"),
+            # Regression: Sachsen-Anhalt must NOT match the shorter "sachsen" prefix (insertion-order bug)
+            ("Sachsen-Anhalt Wahl 2021", "DE-ST"),
+            # unrecognized labels are QUARANTINED, not stamped "DE" —
+            # region "DE" would MatchAny-match every context; "unbekannt"
+            # matches none, so the chunk is unreachable until re-labeled.
+            ("Kommunalwahl München 2026", "unbekannt"),
+            ("Unbekanntes Parlament", "unbekannt"),
+        ],
+    )
+    def test_region_mapping(self, label: str, expected: str) -> None:
+        assert region_for_period(label) == expected
+
+    def test_unknown_label_quarantine_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """the quarantine fallback must log a WARNING so the gap is visible."""
+        import logging
+
+        from src.ingestion.connectors.manifestos.mappers import corpus as corpus_mod
+
+        with caplog.at_level(logging.WARNING, logger=corpus_mod.logger.name):
+            assert region_for_period("Völlig Unbekanntes Gremium 2030") == "unbekannt"
+        assert any("unbekannt" in r.message for r in caplog.records)
+
+    def test_de_only_for_bundestag_labels(self) -> None:
+        """'DE' is reserved for labels starting with 'bundestag'."""
+        assert region_for_period("Bundestag Wahl 2029") == "DE"
+        assert region_for_period("Irgendein Bundes-Gremium") == "unbekannt"
+
+
+# ===========================================================================
+# (c) wahlperiode_for_period
+# ===========================================================================
+
+
+class TestWahlperiodeForPeriod:
+    """wahlperiode_for_period maps Bundestag election years to period numbers."""
+
+    @pytest.mark.parametrize(
+        "label, expected",
+        [
+            ("Bundestag Wahl 2017", 19),
+            ("Bundestag Wahl 2021", 20),
+            ("Bundestag Wahl 2025", 21),
+            ("Bundestag 2021 - 2025", 20),
+            # Non-Bundestag -> None
+            ("EU-Parlament Wahl 2024", None),
+            ("Bayern Wahl 2023", None),
+            ("Berlin Wahl 2021", None),
+            # Bundestag with unknown year -> None
+            ("Bundestag Wahl 1998", None),
+        ],
+    )
+    def test_wahlperiode(self, label: str, expected: int | None) -> None:
+        assert wahlperiode_for_period(label) == expected
+
+
+# ===========================================================================
+# extract_main_text — trafilatura main-content extraction
+# ===========================================================================
+
+
+_HTML_WITH_BOILERPLATE = """
+<!DOCTYPE html>
+<html lang="de">
+  <head><title>Wahlprogramm</title></head>
+  <body>
+    <nav><a href="/">Startseite</a> <a href="/spenden">JETZT SPENDEN</a></nav>
+    <header>Cookie-Hinweis: Diese Seite verwendet Cookies. Akzeptieren</header>
+    <article>
+      <h1>Unser Wahlprogramm 2025</h1>
+      <p>Wir setzen uns für bezahlbaren Wohnraum ein. Jeder Mensch hat ein Recht
+      auf eine sichere und finanzierbare Wohnung, und wir werden den sozialen
+      Wohnungsbau massiv ausbauen und Mietpreisbremsen konsequent durchsetzen.</p>
+      <p>Klimaschutz ist die zentrale Aufgabe unserer Zeit. Wir investieren in
+      erneuerbare Energien, den öffentlichen Nahverkehr und eine klimaneutrale
+      Industrie, damit Deutschland seine Klimaziele erreicht.</p>
+    </article>
+    <footer>Impressum | Datenschutz | Folgen Sie uns auf Twitter</footer>
+  </body>
+</html>
+"""
+
+
+class TestExtractMainText:
+    """extract_main_text isolates article body and drops site boilerplate."""
+
+    def test_keeps_main_content(self) -> None:
+        text = extract_main_text(_HTML_WITH_BOILERPLATE)
+        assert "bezahlbaren Wohnraum" in text
+        assert "erneuerbare Energien" in text
+
+    def test_strips_boilerplate(self) -> None:
+        text = extract_main_text(_HTML_WITH_BOILERPLATE)
+        assert "JETZT SPENDEN" not in text
+        assert "Cookie-Hinweis" not in text
+        assert "Impressum" not in text
+
+    def test_empty_html_returns_empty(self) -> None:
+        assert extract_main_text("") == ""
+
+    def test_no_article_body_returns_short_or_empty(self) -> None:
+        # A nav-only landing page has no extractable article — caller's length
+        # floor then skips it rather than embedding navigation noise.
+        nav_only = "<html><body><nav><a href='/'>Home</a></nav></body></html>"
+        assert len(extract_main_text(nav_only)) < 500
+
+
+# ===========================================================================
+# (d) chunk_pages
+# ===========================================================================
+
+
+class TestChunkPages:
+    """chunk_pages splits each page independently (per-page char chunking) so a
+    chunk never straddles a page boundary and its #page= anchor stays accurate."""
+
+    def test_empty_pages_returns_empty(self) -> None:
+        assert chunk_pages([]) == []
+
+    def test_single_page_short_text_one_chunk(self) -> None:
+        result = chunk_pages([(1, "Dies ist ein kurzer Text.")])
+        assert len(result) == 1
+        chunk, page_start, page_end = result[0]
+        assert "kurzer Text" in chunk
+        assert page_start == 1
+        assert page_end == 1
+
+    def test_html_single_block_page_1(self) -> None:
+        """HTML source passes pages=[(1, text)]; every chunk is attributed to page 1."""
+        text = "Ein langer HTML-Text. " * 200
+        result = chunk_pages([(1, text)], chunk_size=200, chunk_overlap=20)
+        assert len(result) >= 1
+        for _, ps, pe in result:
+            assert ps == 1
+            assert pe == 1
+
+    def test_each_page_chunked_independently(self) -> None:
+        """Two short pages -> one chunk each, each within its own page."""
+        pages = [(1, "Seite eins Text."), (2, "Seite zwei Text.")]
+        result = chunk_pages(pages)
+        assert len(result) == 2
+        assert {(ps, pe) for _, ps, pe in result} == {(1, 1), (2, 2)}
+
+    def test_long_page_splits_within_same_page(self) -> None:
+        """A page longer than the size limit splits into multiple chunks, all
+        attributed to that same page (page_start == page_end)."""
+        result = chunk_pages([(3, "Wort " * 500)], chunk_size=200, chunk_overlap=20)
+        assert len(result) > 1
+        for _, ps, pe in result:
+            assert ps == 3
+            assert pe == 3
+
+
+# ===========================================================================
+# (e) build_manifesto_records
+# ===========================================================================
+
+_PDF_PROGRAM = {
+    "id": 598,
+    "label": "Wahlprogramm SPD 2025",
+    "party": {"id": 1, "label": "SPD"},
+    "parliament_period": {
+        "id": 111,
+        "label": "Bundestag Wahl 2025",
+        "api_url": "https://example.com/api/v2/parliament-periods/111",
+    },
+    "link": [],
+    "file": "https://example.com/spd-programm-2025.pdf",
+}
+
+_LINK_PROGRAM = {
+    "id": 701,
+    "label": "Wahlprogramm Grüne Berlin 2023",
+    "party": {"id": 5, "label": "BÜNDNIS 90/DIE GRÜNEN"},
+    "parliament_period": {
+        "id": 200,
+        "label": "Berlin Wahl 2023",
+        "api_url": "https://example.com/api/v2/parliament-periods/200",
+    },
+    "link": [{"uri": "https://gruene-berlin.de/programm", "title": "Programm"}],
+    "file": None,
+}
+
+_UNKNOWN_PARTY_PROGRAM = {
+    "id": 999,
+    "label": "Programm Partei XYZ 2025",
+    # Use a label whose _slugify output is "unbekannt" (all non-ASCII, non-alnum)
+    # so the party_id field is "unbekannt" and raw_party_label appears in meta.
+    "party": {"id": 42, "label": "!!!"},
+    "parliament_period": {
+        "id": 111,
+        "label": "Bundestag Wahl 2025",
+        "api_url": "https://example.com/api/v2/parliament-periods/111",
+    },
+    "link": [],
+    "file": "https://example.com/xyz.pdf",
+}
+
+
+def _simple_chunks(n: int = 2) -> list[tuple[str, int, int]]:
+    return [(f"Text chunk {i} " * 20, i, i) for i in range(1, n + 1)]
+
+
+def _link_chunks(n: int = 1) -> list[tuple[str, None, None]]:
+    return [(f"HTML text chunk {i} " * 20, None, None) for i in range(1, n + 1)]
+
+
+class TestBuildManifestoRecords:
+    """build_manifesto_records produces correctly-shaped ChunkRecord instances."""
+
+    def test_pdf_program_citation_url_is_source_url(self) -> None:
+        """PDF program must have citation_url = the original source (AW file) URL.
+
+        wahl.chat no longer re-serves manifesto PDFs, so the citation points at
+        the document where it actually lives.
+        """
+        records = build_manifesto_records(
+            program=_PDF_PROGRAM,
+            period_date_iso="2025-02-23",
+            chunks=_simple_chunks(2),
+            source_kind="pdf",
+            source_url="https://example.com/spd-programm-2025.pdf",
+            total_pages=5,
+        )
+        assert len(records) == 2
+        for rec in records:
+            assert rec.citation_url == "https://example.com/spd-programm-2025.pdf"
+
+    def test_pdf_program_source_type_and_authority(self) -> None:
+        records = build_manifesto_records(
+            program=_PDF_PROGRAM,
+            period_date_iso="2025-02-23",
+            chunks=_simple_chunks(1),
+            source_kind="pdf",
+            source_url="https://example.com/spd.pdf",
+            total_pages=1,
+        )
+        rec = records[0]
+        assert rec.source_type == SourceType.PARTY_MANIFESTO
+        assert rec.authority_tier == AuthorityTier.SELF_REPORTED
+
+    def test_pdf_program_party_id_and_region(self) -> None:
+        records = build_manifesto_records(
+            program=_PDF_PROGRAM,
+            period_date_iso="2025-02-23",
+            chunks=_simple_chunks(1),
+            source_kind="pdf",
+            source_url="https://example.com/spd.pdf",
+        )
+        rec = records[0]
+        assert rec.party_id == "spd"
+        assert rec.region == "DE"
+
+    def test_pdf_program_wahlperiode(self) -> None:
+        records = build_manifesto_records(
+            program=_PDF_PROGRAM,
+            period_date_iso="2025-02-23",
+            chunks=_simple_chunks(1),
+            source_kind="pdf",
+            source_url="https://example.com/spd.pdf",
+        )
+        assert records[0].wahlperiode == 21
+
+    def test_pdf_program_meta_fields(self) -> None:
+        records = build_manifesto_records(
+            program=_PDF_PROGRAM,
+            period_date_iso="2025-02-23",
+            chunks=_simple_chunks(2),
+            source_kind="pdf",
+            source_url="https://example.com/spd.pdf",
+            total_pages=3,
+        )
+        rec = records[0]
+        assert rec.meta is not None
+        assert rec.meta["source_kind"] == "pdf"
+        assert rec.meta["source_url"] == "https://example.com/spd.pdf"
+        assert "stored_path" not in rec.meta
+        assert rec.meta["total_pages"] == 3
+        assert rec.meta["page_start"] == 1
+        assert rec.meta["page_end"] == 1
+        assert "raw_party_label" not in rec.meta
+
+    def test_pdf_program_meta_has_no_none_values(self) -> None:
+        records = build_manifesto_records(
+            program=_PDF_PROGRAM,
+            period_date_iso="2025-02-23",
+            chunks=_simple_chunks(1),
+            source_kind="pdf",
+            source_url="https://example.com/spd.pdf",
+        )
+        meta = records[0].meta
+        assert meta is not None
+        for v in meta.values():
+            assert v is not None, f"None value found in meta: {meta}"
+
+    def test_pdf_program_external_id(self) -> None:
+        records = build_manifesto_records(
+            program=_PDF_PROGRAM,
+            period_date_iso="2025-02-23",
+            chunks=_simple_chunks(1),
+            source_kind="pdf",
+            source_url="https://example.com/spd.pdf",
+        )
+        assert records[0].external_id == 598
+
+    def test_pdf_program_publish_date(self) -> None:
+        records = build_manifesto_records(
+            program=_PDF_PROGRAM,
+            period_date_iso="2025-02-23",
+            chunks=_simple_chunks(1),
+            source_kind="pdf",
+            source_url="https://example.com/spd.pdf",
+        )
+        assert records[0].publish_date == date(2025, 2, 23)
+
+    def test_link_program_citation_url_is_link_uri(self) -> None:
+        """Link program must have citation_url = the link URI."""
+        records = build_manifesto_records(
+            program=_LINK_PROGRAM,
+            period_date_iso="2023-09-10",
+            chunks=_link_chunks(1),
+            source_kind="link",
+            source_url="https://gruene-berlin.de/programm",
+        )
+        assert len(records) == 1
+        assert records[0].citation_url == "https://gruene-berlin.de/programm"
+
+    def test_link_program_source_kind_in_meta(self) -> None:
+        records = build_manifesto_records(
+            program=_LINK_PROGRAM,
+            period_date_iso="2023-09-10",
+            chunks=_link_chunks(1),
+            source_kind="link",
+            source_url="https://gruene-berlin.de/programm",
+        )
+        meta = records[0].meta
+        assert meta is not None
+        assert meta["source_kind"] == "link"
+
+    def test_link_program_no_stored_path_in_meta(self) -> None:
+        records = build_manifesto_records(
+            program=_LINK_PROGRAM,
+            period_date_iso="2023-09-10",
+            chunks=_link_chunks(1),
+            source_kind="link",
+            source_url="https://gruene-berlin.de/programm",
+        )
+        meta = records[0].meta
+        assert meta is not None
+        assert "stored_path" not in meta
+
+    def test_link_program_page_numbers_none(self) -> None:
+        """Link source chunks have page_start=None and page_end=None."""
+        records = build_manifesto_records(
+            program=_LINK_PROGRAM,
+            period_date_iso="2023-09-10",
+            chunks=_link_chunks(1),
+            source_kind="link",
+            source_url="https://gruene-berlin.de/programm",
+        )
+        meta = records[0].meta
+        assert meta is not None
+        # page_start and page_end should be absent (None values dropped)
+        assert "page_start" not in meta
+        assert "page_end" not in meta
+
+    def test_link_program_region_is_state(self) -> None:
+        """Berlin period -> region DE-BE."""
+        records = build_manifesto_records(
+            program=_LINK_PROGRAM,
+            period_date_iso="2023-09-10",
+            chunks=_link_chunks(1),
+            source_kind="link",
+            source_url="https://gruene-berlin.de/programm",
+        )
+        assert records[0].region == "DE-BE"
+
+    def test_unknown_party_raw_party_label_in_meta(self) -> None:
+        """When slug == 'unbekannt', meta must contain raw_party_label."""
+        records = build_manifesto_records(
+            program=_UNKNOWN_PARTY_PROGRAM,
+            period_date_iso="2025-02-23",
+            chunks=_simple_chunks(1),
+            source_kind="pdf",
+            source_url="https://example.com/xyz.pdf",
+        )
+        rec = records[0]
+        assert rec.party_id == "unbekannt"
+        assert rec.meta is not None
+        assert rec.meta.get("raw_party_label") == "!!!"
+
+    def test_chunk_indices_are_sequential(self) -> None:
+        records = build_manifesto_records(
+            program=_PDF_PROGRAM,
+            period_date_iso="2025-02-23",
+            chunks=_simple_chunks(5),
+            source_kind="pdf",
+            source_url="https://example.com/spd.pdf",
+        )
+        assert [r.chunk_index for r in records] == list(range(5))
+
+    def test_source_item_id_is_stable(self) -> None:
+        """Same program_id always yields the same source_item_id."""
+        records_a = build_manifesto_records(
+            program=_PDF_PROGRAM,
+            period_date_iso="2025-02-23",
+            chunks=_simple_chunks(1),
+            source_kind="pdf",
+            source_url="https://example.com/spd.pdf",
+        )
+        records_b = build_manifesto_records(
+            program=_PDF_PROGRAM,
+            period_date_iso="2025-02-23",
+            chunks=_simple_chunks(1),
+            source_kind="pdf",
+            source_url="https://example.com/spd.pdf",
+        )
+        assert records_a[0].source_item_id == records_b[0].source_item_id
+
+    def test_citation_title_format(self) -> None:
+        records = build_manifesto_records(
+            program=_PDF_PROGRAM,
+            period_date_iso="2025-02-23",
+            chunks=_simple_chunks(1),
+            source_kind="pdf",
+            source_url="https://example.com/spd.pdf",
+        )
+        assert (
+            records[0].citation_title == "Wahlprogramm SPD 2025 – Bundestag Wahl 2025"
+        )
+
+    def test_content_hash_present_and_change_sensitive(self) -> None:
+        """(d) Manifesto chunks stamp a per-chunk content_hash so an updated
+        program text re-writes via run.py's change-aware guard."""
+        records = build_manifesto_records(
+            program=_PDF_PROGRAM,
+            period_date_iso="2025-02-23",
+            chunks=_simple_chunks(2),
+            source_kind="pdf",
+            source_url="https://example.com/spd.pdf",
+        )
+        assert all(r.content_hash is not None for r in records), (
+            "every manifesto chunk must stamp content_hash"
+        )
+        assert records[0].content_hash != records[1].content_hash, (
+            "content_hash is per-chunk (different texts → different hashes)"
+        )
+
+        changed = build_manifesto_records(
+            program=_PDF_PROGRAM,
+            period_date_iso="2025-02-23",
+            chunks=[("Ganz neuer Programmtext. " * 20, 1, 1)],
+            source_kind="pdf",
+            source_url="https://example.com/spd.pdf",
+        )
+        assert changed[0].content_hash != records[0].content_hash, (
+            "changing the chunk text must change content_hash"
+        )
+
+
+# ===========================================================================
+# manifesto/votes slug-map parity
+# ===========================================================================
+
+
+class TestSlugMapParity:
+    """The same real party must resolve to the same slug across connectors —
+    otherwise manifesto party_id != vote slug != context party_id and
+    tenant-filtered retrieval returns nothing. The shared slug knowledge now
+    lives in one module (src/ingestion/party_slugs.py); these tests guard that
+    every connector map is built from it rather than a private copy."""
+
+    def test_new_e3_entries_resolve(self) -> None:
+        assert party_to_slug("Bürger in Wut") == "biw"
+        assert party_to_slug("BVB/Freie Wähler") == "bvb-fw"
+        assert party_to_slug("Die Basis") == "basis"
+        assert party_to_slug("SSW") == "ssw"
+
+    def test_canonical_core_is_shared_verbatim(self) -> None:
+        """The major-party core must appear identically in every connector map."""
+        from src.ingestion.connectors.abgeordnetenwatch.mappers.corpus import (
+            _AW_FRACTION_SLUG_MAP,
+        )
+        from src.ingestion.connectors.bundestag_speeches.mappers.corpus import (
+            _PARTY_SLUG_MAP as _SPEECH_SLUG_MAP,
+        )
+        from src.ingestion.connectors.manifestos.mappers.corpus import (
+            _MANIFESTO_PARTY_SLUG_MAP,
+        )
+        from src.ingestion.party_slugs import CANONICAL_PARTY_SLUGS
+
+        for name, m in {
+            "votes": _AW_FRACTION_SLUG_MAP,
+            "speeches": _SPEECH_SLUG_MAP,
+            "manifestos": _MANIFESTO_PARTY_SLUG_MAP,
+        }.items():
+            missing = {
+                label: slug
+                for label, slug in CANONICAL_PARTY_SLUGS.items()
+                if m.get(label) != slug
+            }
+            assert not missing, (
+                f"{name} map diverges from the canonical core: {missing!r}"
+            )
+
+    def test_votes_and_manifestos_share_the_state_party_layer(self) -> None:
+        """Votes and manifestos must agree on state/regional slugs (speeches
+        deliberately exclude these — Bundestag fractions only)."""
+        from src.ingestion.connectors.abgeordnetenwatch.mappers.corpus import (
+            _AW_FRACTION_SLUG_MAP,
+        )
+        from src.ingestion.connectors.manifestos.mappers.corpus import (
+            _MANIFESTO_PARTY_SLUG_MAP,
+        )
+        from src.ingestion.party_slugs import STATE_PARTY_SLUGS
+
+        for label, slug in STATE_PARTY_SLUGS.items():
+            assert _AW_FRACTION_SLUG_MAP.get(label) == slug
+            assert _MANIFESTO_PARTY_SLUG_MAP.get(label) == slug
+
+
+# ===========================================================================
+# chunk_pages default budget
+# ===========================================================================
+
+
+# ===========================================================================
+# ManifestoMeta typed builder
+# ===========================================================================
+
+
+class TestManifestoMeta:
+    def test_extra_fields_forbidden(self) -> None:
+        import pydantic
+        import pytest as _pytest
+
+        from src.ingestion.connectors.manifestos.mappers.corpus import ManifestoMeta
+
+        with _pytest.raises(pydantic.ValidationError):
+            ManifestoMeta(aw_program_id=1, not_a_field="boom")  # type: ignore[call-arg]
+
+    def test_model_dump_drops_none(self) -> None:
+        from src.ingestion.connectors.manifestos.mappers.corpus import ManifestoMeta
+
+        dumped = ManifestoMeta(
+            aw_program_id=598,
+            source_kind="link",
+            source_url="https://example.com",
+        ).model_dump(exclude_none=True)
+        assert dumped == {
+            "aw_program_id": 598,
+            "source_kind": "link",
+            "source_url": "https://example.com",
+        }
+
+
+# ===========================================================================
+# chunk_pages overlap > 0 behavior
+# ===========================================================================
+
+
+# Chunker internals (char splitting, overlap, edge cases) are covered by the
+# shared tests/ingestion/test_chunking.py — the manifesto connector only relies
+# on the per-page (page_start, page_end) contract, exercised above.

--- a/ai-backend/tests/ingestion/connectors/manifestos/test_corpus.py
+++ b/ai-backend/tests/ingestion/connectors/manifestos/test_corpus.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -372,11 +372,11 @@ def _link_chunks(n: int = 1) -> list[tuple[str, None, None]]:
 class TestBuildManifestoRecords:
     """build_manifesto_records produces correctly-shaped ChunkRecord instances."""
 
-    def test_pdf_program_citation_url_is_source_url(self) -> None:
-        """PDF program must have citation_url = the original source (AW file) URL.
-
-        wahl.chat no longer re-serves manifesto PDFs, so the citation points at
-        the document where it actually lives.
+    def test_pdf_program_citation_url_deep_links_to_page(self) -> None:
+        """PDF chunks cite the original source URL WITH a per-chunk #page=
+        anchor (page_start), so the citation opens on the supporting page
+        instead of the document start. wahl.chat still never re-serves the
+        file — the anchor is appended to where the document actually lives.
         """
         records = build_manifesto_records(
             program=_PDF_PROGRAM,
@@ -387,8 +387,25 @@ class TestBuildManifestoRecords:
             total_pages=5,
         )
         assert len(records) == 2
-        for rec in records:
-            assert rec.citation_url == "https://example.com/spd-programm-2025.pdf"
+        assert records[0].citation_url == (
+            "https://example.com/spd-programm-2025.pdf#page=1"
+        )
+        assert records[1].citation_url == (
+            "https://example.com/spd-programm-2025.pdf#page=2"
+        )
+        # A provenance-only page move must change content_hash (refreshable).
+        assert records[0].content_hash != records[1].content_hash
+
+    def test_pdf_source_url_with_existing_fragment_is_not_clobbered(self) -> None:
+        records = build_manifesto_records(
+            program=_PDF_PROGRAM,
+            period_date_iso="2025-02-23",
+            chunks=_simple_chunks(1),
+            source_kind="pdf",
+            source_url="https://example.com/spd.pdf#zoom=100",
+            total_pages=1,
+        )
+        assert records[0].citation_url == "https://example.com/spd.pdf#zoom=100"
 
     def test_pdf_program_source_type_and_authority(self) -> None:
         records = build_manifesto_records(


### PR DESCRIPTION
V2 stack 5/9 — party manifestos (`party_manifesto`) from the abgeordnetenwatch election-program API.

- **HTML scrape / PDF parse** with page metadata, so citations can deep-link to the cited page; citations always point at the original publisher — we never re-host files.
- **Chunking via the shared boundary-aware chunker**; `region` tagged per election (federal programs `DE`, Landtagswahl programs `DE-<state>`), which is what makes level-scoped retrieval work downstream.
- **Cross-connector slug-parity guard**: the same real party must resolve to the same `party_id` across votes, speeches, and manifestos — otherwise tenant-filtered retrieval silently returns nothing. This test is why manifestos come after speeches in the stack.
- Includes the two AW test files deferred from the votes PR (they assert region mapping via this connector's `region_for_period`).

The connector has a local dev CLI (`bulk.py`, `--dry-run`/`--ids`/`--limit`) alongside the standard registry path.

Verified: ruff, mypy, 490 tests, GDPR wall guard.
