### PR TITLE
V2 stack 6/9: openparliament.tv speech enrichment

### DIFF
--- a/ai-backend/src/deeplink.py
+++ b/ai-backend/src/deeplink.py
@@ -26,6 +26,20 @@ from typing import Optional
 _DEEPLINK_FUZZY_THRESHOLD = 0.6
 
 
+def _sanitize_sentence_map(value: object) -> list[dict]:
+    """Coerce a persisted ``sentence_map`` to a list of dict entries.
+
+    Persisted payloads are UNTRUSTED at this boundary: a legacy or corrupt
+    point can carry a string, a non-list, or non-dict list entries — any of
+    which would raise inside the "never raises" locators and turn a whole
+    party answer into an error. Anything malformed degrades to ``[]`` (callers
+    then fall back to the stored citation_url / bare video URI).
+    """
+    if not isinstance(value, list):
+        return []
+    return [entry for entry in value if isinstance(entry, dict)]
+
+
 def locate_deeplink(quoted: str, sentence_map: list[dict], video_uri: str) -> str:
     """Map cited text to a phrase-level video deep-link (zero embeddings).
 
@@ -56,6 +70,7 @@ def locate_deeplink(quoted: str, sentence_map: list[dict], video_uri: str) -> st
         ``video_uri#t={ts_start}`` for the best sentence, or the coarse
         speech-start link, or ``video_uri`` unchanged when inputs are empty.
     """
+    sentence_map = _sanitize_sentence_map(sentence_map)
     if not sentence_map:
         return video_uri
     # A sentence may lack ts_start on legacy/corrupt payloads; `.get` keeps the
@@ -165,7 +180,7 @@ def _best_sentence_ts_by_relevance(
         return None
     best_ts: Optional[float] = None
     best_score = 0
-    for sentence in sentence_map:
+    for sentence in _sanitize_sentence_map(sentence_map):
         score = len(q_tokens & _content_tokens(sentence.get("text") or ""))
         if score > best_score:
             best_score = score
@@ -192,19 +207,24 @@ def _speech_deeplink_url(payload: dict, quoted: str) -> Optional[str]:
          the topically-relevant sentence rather than at 0:00.
     Never raises.
     """
-    meta = payload.get("meta") or {}
+    meta = payload.get("meta")
+    if not isinstance(meta, dict):
+        # A corrupt persisted meta (string, list, …) must degrade to the stored
+        # citation_url, never crash response assembly.
+        meta = {}
+    sentence_map = _sanitize_sentence_map(meta.get("sentence_map"))
+    video_uri = meta.get("video_uri")
     if (
         payload.get("source") == "op"
-        and meta.get("sentence_map")
-        and meta.get("video_uri")
+        and sentence_map
+        and isinstance(video_uri, str)
+        and video_uri
     ):
-        sentence_map = meta["sentence_map"]
-        video_uri = meta["video_uri"]
         url = locate_deeplink(quoted, sentence_map, video_uri)
         # locate_deeplink returned the coarse speech-start link → try relevance.
         # `.get` mirrors locate_deeplink's ts_start guard so a map whose first
         # sentence lacks ts_start compares equal (both fall back to bare uri).
-        first_ts = (sentence_map[0] or {}).get("ts_start")
+        first_ts = sentence_map[0].get("ts_start")
         coarse = f"{video_uri}#t={first_ts}" if first_ts is not None else video_uri
         if url == coarse:
             ts = _best_sentence_ts_by_relevance(quoted, sentence_map)

--- a/ai-backend/src/deeplink.py
+++ b/ai-backend/src/deeplink.py
@@ -1,0 +1,297 @@
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Citation deep-link refinement (zero embeddings, never raises).
+
+After the LLM answers, a cited op video speech can be sharpened so the user lands
+on the exact passage rather than the whole speech: rewrite ``citation_url`` to
+``video_uri#t={ts_start}`` so the video opens at the cited phrase
+(``locate_deeplink`` / ``_speech_deeplink_url`` / ``_refine_speech_deeplinks``).
+
+Everything here is lexical (difflib ratios + content-word overlap), takes only
+already-fetched payloads, and is contractually non-raising: a malformed payload
+degrades to the unrefined url, never crashing citation assembly. Source-supplied
+URIs are only appended to — never fetched or executed.
+"""
+
+import difflib
+import re
+from typing import Optional
+
+# Second-pass deep-link locator. A cited op speech chunk carries a
+# `meta.sentence_map` (verbatim sentences + per-sentence timestamps). The locator
+# matches the model's quoted text to the best sentence and rewrites the citation
+# url to `video_uri#t={ts_start}` (phrase-level deep-link). Fuzzy fallback uses a
+# difflib ratio; below this bar the locator opens the video at the speech start.
+_DEEPLINK_FUZZY_THRESHOLD = 0.6
+
+
+def locate_deeplink(quoted: str, sentence_map: list[dict], video_uri: str) -> str:
+    """Map cited text to a phrase-level video deep-link (zero embeddings).
+
+    Given the model's quoted/answer text and a matched op whole-speech chunk's
+    ``meta.sentence_map`` (a list of ``{"text", "ts_start", "ts_end"}``), find the
+    sentence whose text best matches and return ``f"{video_uri}#t={ts_start}"`` so
+    the citation opens the video at that phrase.
+
+    Matching (verbatim-first):
+      1. Exact substring either direction (``quoted in sentence`` or
+         ``sentence in quoted``) → that sentence wins immediately.
+      2. Else the best ``difflib.SequenceMatcher`` ratio sentence, if it clears
+         ``_DEEPLINK_FUZZY_THRESHOLD``.
+      3. Else fall back to ``sentence_map[0]["ts_start"]`` — a coarse link that
+         opens the video at the speech start.
+
+    NEVER raises: an empty / None ``quoted`` or an empty / missing
+    ``sentence_map`` returns ``video_uri`` unchanged (no ``#t=`` fragment), so a
+    malformed payload can never crash citation assembly. The
+    source-supplied ``video_uri`` is only appended to — never fetched or executed.
+
+    Args:
+        quoted: The model's quoted/answer text to locate within the speech.
+        sentence_map: Verbatim sentences with ``ts_start`` timestamps.
+        video_uri: The op speech's video URI (already validated at ingest).
+
+    Returns:
+        ``video_uri#t={ts_start}`` for the best sentence, or the coarse
+        speech-start link, or ``video_uri`` unchanged when inputs are empty.
+    """
+    if not sentence_map:
+        return video_uri
+    # A sentence may lack ts_start on legacy/corrupt payloads; `.get` keeps the
+    # "never raises" contract (a KeyError here would fail the whole party answer).
+    first_ts = sentence_map[0].get("ts_start")
+    q = (quoted or "").strip().lower()
+    if not q:
+        # No text to locate → coarse speech-start link (or bare uri if no ts).
+        return f"{video_uri}#t={first_ts}" if first_ts is not None else video_uri
+
+    best: Optional[dict] = None
+    best_ratio = 0.0
+    exact = False
+    for sentence in sentence_map:
+        text = (sentence.get("text") or "").lower()
+        if not text:
+            continue
+        if q in text or text in q:
+            best, exact = sentence, True
+            break
+        ratio = difflib.SequenceMatcher(None, q, text).ratio()
+        if ratio > best_ratio:
+            best, best_ratio = sentence, ratio
+
+    if best is not None and (exact or best_ratio >= _DEEPLINK_FUZZY_THRESHOLD):
+        ts = best.get("ts_start")
+    else:
+        # No sentence cleared the fuzzy bar → coarse speech-start fallback.
+        ts = first_ts
+    # A missing/None ts must never render as the literal "#t=None".
+    return f"{video_uri}#t={ts}" if ts is not None else video_uri
+
+
+# German function words / fillers to ignore when scoring query↔sentence overlap.
+# Kept small and lowercase; the > 3-char length gate already drops most of them,
+# but the plenary-opener words ("damen", "herren", "kollegen"…) recur in every
+# speech and would otherwise dominate the overlap score.
+_DEEPLINK_STOPWORDS = frozenset(
+    {
+        "damen",
+        "herren",
+        "kollegen",
+        "kolleginnen",
+        "präsident",
+        "präsidentin",
+        "sehr",
+        "geehrte",
+        "geehrter",
+        "liebe",
+        "meine",
+        "unsere",
+        "diese",
+        "dieser",
+        "dieses",
+        "haben",
+        "werden",
+        "wird",
+        "wurde",
+        "worden",
+        "einen",
+        "eine",
+        "einem",
+        "einer",
+        "auch",
+        "aber",
+        "nicht",
+        "schon",
+        "noch",
+        "mehr",
+        "sein",
+        "sind",
+        "dass",
+        "denn",
+        "dann",
+        "hier",
+        "damit",
+        "durch",
+        "über",
+        "unter",
+    }
+)
+
+
+def _content_tokens(text: str) -> set[str]:
+    """Lowercase content words (> 3 chars, not a stopword) for overlap scoring."""
+    return {
+        w
+        for w in re.findall(r"\w+", (text or "").lower())
+        if len(w) > 3 and w not in _DEEPLINK_STOPWORDS
+    }
+
+
+def _best_sentence_ts_by_relevance(
+    query: str, sentence_map: list[dict]
+) -> Optional[float]:
+    """Pick the ts_start of the sentence sharing the most content words with query.
+
+    At citation-assembly time the model's answer text does not exist yet — the
+    only reference text available is the (improved) RAG query, which is a
+    paraphrase, not a verbatim quote, so ``locate_deeplink``'s exact/fuzzy match
+    always falls back to the speech start. This lightweight lexical ranker instead
+    lands the deep-link on the sentence most topically related to the question
+    (zero embeddings, never raises). Returns ``None`` when nothing overlaps.
+    """
+    q_tokens = _content_tokens(query)
+    if not q_tokens:
+        return None
+    best_ts: Optional[float] = None
+    best_score = 0
+    for sentence in sentence_map:
+        score = len(q_tokens & _content_tokens(sentence.get("text") or ""))
+        if score > best_score:
+            best_score = score
+            best_ts = sentence.get("ts_start")
+    return best_ts if best_score > 0 else None
+
+
+def _speech_deeplink_url(payload: dict, quoted: str) -> Optional[str]:
+    """Return the citation url for a speech payload, deep-linked for op speeches.
+
+    For an op-sourced speech (``source == "op"``) that carries a
+    ``meta.sentence_map`` and ``meta.video_uri``, refine the citation to a
+    phrase-level ``video_uri#t={ts_start}`` deep-link. DIP speeches (no
+    ``sentence_map``) — and any op chunk missing the media payload — keep their
+    stored ``citation_url`` unchanged.
+
+    Two-stage resolution:
+      1. ``locate_deeplink`` — verbatim/fuzzy match of ``quoted`` against the
+         sentences (resolves the exact phrase when ``quoted`` is a real quote,
+         e.g. a future post-generation refinement pass).
+      2. When (1) only yields the coarse speech-start link — which is the norm
+         because ``quoted`` is the paraphrased RAG query, not a verbatim quote —
+         fall back to lexical query↔sentence relevance so the video still opens on
+         the topically-relevant sentence rather than at 0:00.
+    Never raises.
+    """
+    meta = payload.get("meta") or {}
+    if (
+        payload.get("source") == "op"
+        and meta.get("sentence_map")
+        and meta.get("video_uri")
+    ):
+        sentence_map = meta["sentence_map"]
+        video_uri = meta["video_uri"]
+        url = locate_deeplink(quoted, sentence_map, video_uri)
+        # locate_deeplink returned the coarse speech-start link → try relevance.
+        # `.get` mirrors locate_deeplink's ts_start guard so a map whose first
+        # sentence lacks ts_start compares equal (both fall back to bare uri).
+        first_ts = (sentence_map[0] or {}).get("ts_start")
+        coarse = f"{video_uri}#t={first_ts}" if first_ts is not None else video_uri
+        if url == coarse:
+            ts = _best_sentence_ts_by_relevance(quoted, sentence_map)
+            if ts is not None:
+                return f"{video_uri}#t={ts}"
+        return url
+    return payload.get("citation_url")
+
+
+# Inline citation markers the model emits: [N] or [N, M, ...] (0-based into sources).
+_CITATION_MARKER_RE = re.compile(r"\[(\d+(?:\s*,\s*\d+)*)\]")
+
+
+def _cited_claim_for_index(answer: str, idx: int) -> Optional[str]:
+    """Return the sentence(s) in *answer* that actually cite source ``idx``.
+
+    Post-generation deep-link refinement: the citation URL is first built
+    BEFORE the answer exists, so the op video timestamp can only be guessed from
+    the RAG query. Once the answer is in hand we can do better — feed the model's
+    REAL asserted claim (the clause ending at its ``[idx]`` marker) to the video
+    locator, so the deep-link lands on the sentence the answer is genuinely about
+    rather than a merely query-topical one. Returns None when the source is not
+    cited (keep the coarse query-based link). Never raises.
+    """
+    if not answer:
+        return None
+    claims: list[str] = []
+    for match in _CITATION_MARKER_RE.finditer(answer):
+        indices = {
+            int(tok) for tok in match.group(1).replace(" ", "").split(",") if tok
+        }
+        if idx not in indices:
+            continue
+        # The claim is the clause ending at this marker — walk back to the prior
+        # sentence terminator, then strip any other inline [..] markers.
+        start = match.start()
+        boundary = max(answer.rfind(sep, 0, start) for sep in (".", "!", "?", "\n"))
+        clause = _CITATION_MARKER_RE.sub("", answer[boundary + 1 : start]).strip()
+        if clause:
+            claims.append(clause)
+    return " ".join(claims) if claims else None
+
+
+def _refine_speech_deeplinks(
+    sources: list[dict],
+    speech_refs: list[tuple[int, dict]],
+    answer: str,
+) -> bool:
+    """Re-resolve op speech deep-links from the model's actual cited claim.
+
+    Mutates *sources* in place: for each refinable op speech source (kept in
+    *speech_refs* as ``(index_in_sources, op_payload)``) whose ``[index]`` the
+    answer cites, recompute ``video_uri#t={ts}`` from the cited claim instead of
+    the pre-answer RAG query, and update ``url`` / ``video_url``. Returns True when
+    any URL changed (so the caller re-emits sources_ready). Never raises.
+    """
+    changed = False
+    for idx, payload in speech_refs:
+        if idx >= len(sources):
+            continue
+        claim = _cited_claim_for_index(answer, idx)
+        if not claim:
+            continue
+        refined = _speech_deeplink_url(payload, claim)
+        if refined and refined != sources[idx].get("url"):
+            sources[idx]["url"] = refined
+            if _is_video_link(refined):
+                sources[idx]["video_url"] = refined
+            changed = True
+    return changed
+
+
+def _is_video_link(url: Optional[str]) -> bool:
+    """True when a URL is a playable video deep-link (``#t=`` fragment or ``.mp4``).
+
+    Mirrors the frontend's video detection (``videoTimestampSeconds``): op speeches
+    resolve to ``video_uri#t={seconds}`` direct-MP4 deep-links, while an op speech
+    missing its media payload falls back to a non-video page (dbtg.tv) that must
+    NOT be offered as an in-page video. Keeps ``video_url`` honest.
+    """
+    if not url:
+        return False
+    lowered = url.lower()
+    # Keep in parity with the frontend isVideoUrl (web/lib/utils.ts).
+    return (
+        "#t=" in url
+        or lowered.endswith(".mp4")
+        or ".mp4#" in lowered
+        or ".mp4?" in lowered
+    )

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/connector.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/connector.py
@@ -238,8 +238,13 @@ def is_op_superseded(
         op_norm = _norm_speech_text(
             " ".join(t for _idx, t in sorted(texts, key=lambda pair: pair[0]))
         )
-        if op_norm and difflib.SequenceMatcher(None, dip_norm, op_norm).ratio() >= (
-            _RESURRECTION_TEXT_MATCH_RATIO
+        # autojunk=False keeps this comparator symmetric with the op supersede
+        # pass: the default auto-junk heuristic marks frequent characters as
+        # junk on long normalized speech strings and misses real twins.
+        if (
+            op_norm
+            and difflib.SequenceMatcher(None, dip_norm, op_norm, autojunk=False).ratio()
+            >= _RESURRECTION_TEXT_MATCH_RATIO
         ):
             return True
     return False

--- a/ai-backend/src/ingestion/connectors/openparliament_tv/__init__.py
+++ b/ai-backend/src/ingestion/connectors/openparliament_tv/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/src/ingestion/connectors/openparliament_tv/__init__.py
+++ b/ai-backend/src/ingestion/connectors/openparliament_tv/__init__.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""openparliament.tv speech connector package — video-timestamped plenary speeches.
+
+Source: the OpenParliamentTV-Data-DE GitHub repository's `processed/*-session.json`
+bulk files (keyless). These carry sentence-level, video-aligned German Bundestag
+speech transcripts. This connector layer *coexists* with the DIP bundestag_speeches
+connector, deduping downstream on `speech_key` and adding a timed `sentence_map`
+plus a video deep-link payload.
+
+Package structure (mirrors connectors/bundestag_speeches/):
+  connector.py        — OpenParliamentTvConnector(BaseConnector): discover/fetch/normalize
+  client.py           — OpTvClient: keyless GitHub-bulk enumerate + pinned-host raw fetch, curl fallback
+  parser.py           — parse_session_json: session JSON → speech dicts w/ alignment gate + sentence_map
+  schemas.py          — OpSpeechMeta (Pydantic, extra="forbid"): video/audio/timestamp payload
+  constants.py        — RAW_BASE, TREES_URL, SESSION_FILE_RE, LOOKBACK_DAYS, _OP_FACTION_SLUG_MAP
+  mappers/
+    corpus.py         — build_chunk_records, op_party_slug
+"""

--- a/ai-backend/src/ingestion/connectors/openparliament_tv/bulk.py
+++ b/ai-backend/src/ingestion/connectors/openparliament_tv/bulk.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -30,8 +30,9 @@ Usage (local dev):
     QDRANT_URL=http://localhost:6333 ENV=dev \\
         uv run python -m src.ingestion.connectors.openparliament_tv.bulk --from-github
 
-Requires: make stores-up first (Qdrant running at QDRANT_URL).
-          OPENAI_API_KEY in ai-backend/.env (auto-loaded if present).
+Requires: make stores-up first (Qdrant running at QDRANT_URL) and the
+          configured embedding provider's API key in ai-backend/.env
+          (auto-loaded; exported shell env wins).
 """
 
 from __future__ import annotations
@@ -43,12 +44,24 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-from langchain_openai import OpenAIEmbeddings
+# CLI startup ONLY: load ai-backend/.env BEFORE the imports below — embeddings
+# and setup_collection freeze EMBEDDING_MODEL / EMBEDDING_DIM / COLLECTION_NAME
+# from the environment at import time, so a later load_dotenv() configures
+# nothing. override=False keeps explicitly-exported shell env authoritative.
+if __name__ == "__main__":
+    from dotenv import load_dotenv
+
+    _bulk_env_path = Path(__file__).resolve().parents[4] / ".env"
+    if _bulk_env_path.exists():
+        load_dotenv(_bulk_env_path, override=False)
+
+from langchain_core.embeddings import Embeddings
 from qdrant_client import QdrantClient
 
+from src.embeddings import get_embeddings
 from src.ingestion.connector import BaseConnector
 from src.ingestion.connectors.bundestag_speeches.constants import MDB_STAMMDATEN_FILE
-from src.ingestion.connectors.bundestag_speeches.mdb import load_mdb_lookup
+from src.ingestion.connectors.bundestag_speeches.mdb import ensure_mdb_lookup
 from src.ingestion.connectors.openparliament_tv.client import OpTvClient
 from src.ingestion.connectors.openparliament_tv.mappers.corpus import (
     build_chunk_records,
@@ -56,9 +69,10 @@ from src.ingestion.connectors.openparliament_tv.mappers.corpus import (
 from src.ingestion.connectors.openparliament_tv.supersede import (
     supersede_dip_duplicates,
 )
+from src.ingestion.ids import compute_chunk_id
 from src.ingestion.run import _embed_texts, _upsert_chunks
 from src.ingestion.schemas import ChunkRecord
-from src.ingestion.setup_collection import COLLECTION_NAME, EMBEDDING_MODEL
+from src.ingestion.setup_collection import COLLECTION_NAME, check_fingerprint
 
 # Shared speech-dedup helper — one definition for both speech connectors.
 from src.ingestion.speech_dedup import datum_to_external_id as _datum_to_external_id
@@ -110,7 +124,7 @@ _MDB_PATH: Path = Path(__file__).resolve().parents[4] / MDB_STAMMDATEN_FILE
 def ingest(
     client: OpTvClient,
     qdrant: QdrantClient,
-    embed: OpenAIEmbeddings,
+    embed: Embeddings,
     mdb_lookup: dict,
     limit: Optional[int] = None,
 ) -> tuple[int, int]:
@@ -123,7 +137,7 @@ def ingest(
     Args:
         client:     Initialised OpTvClient.
         qdrant:     Initialised QdrantClient.
-        embed:      Initialised OpenAIEmbeddings instance.
+        embed:      Embeddings client from ``get_embeddings()``.
         mdb_lookup: MdB-Stammdaten lookup for the empty-faction / CSU fallback.
         limit:      Maximum number of usable speeches to process (None = all).
 
@@ -137,8 +151,52 @@ def ingest(
     def _flush(b: list[ChunkRecord]) -> int:
         if not b:
             return 0
+        from qdrant_client import models as qdrant_models  # noqa: PLC0415
+
         vectors = _embed_texts(embed, [c.text for c in b])
         _upsert_chunks(qdrant, COLLECTION_NAME, b, vectors)
+        # Replacement safety: only AFTER the fresh chunks are durably written,
+        # delete stored points the new output no longer produces (a corrected
+        # speech that shrinks from two chunks to one must not keep the stale
+        # higher-index chunk retrievable). Speeches removed from the upstream
+        # dump entirely are out of scope for a backfill (no discover step) —
+        # the live connector's reconciliation owns those.
+        new_ids_by_siid: dict[str, set[str]] = {}
+        for c in b:
+            new_ids_by_siid.setdefault(str(c.source_item_id), set()).add(
+                str(compute_chunk_id(c.source_item_id, c.chunk_index))
+            )
+        orphans: list[str] = []
+        next_offset = None
+        scroll_filter = qdrant_models.Filter(
+            must=[
+                qdrant_models.FieldCondition(
+                    key="source_item_id",
+                    match=qdrant_models.MatchAny(any=sorted(new_ids_by_siid)),
+                )
+            ]
+        )
+        while True:
+            points, next_offset = qdrant.scroll(
+                collection_name=COLLECTION_NAME,
+                scroll_filter=scroll_filter,
+                limit=1000,
+                offset=next_offset,
+                with_payload=["source_item_id"],
+                with_vectors=False,
+            )
+            for p in points:
+                siid = str((p.payload or {}).get("source_item_id"))
+                if str(p.id) not in new_ids_by_siid.get(siid, set()):
+                    orphans.append(str(p.id))
+            if next_offset is None:
+                break
+        if orphans:
+            qdrant.delete(
+                collection_name=COLLECTION_NAME,
+                points_selector=qdrant_models.PointIdsList(points=sorted(orphans)),
+                wait=True,
+            )
         # Supersede each flushed batch's DIP twins immediately. Without this
         # the entire historical overlap stays duplicated forever: later live runs
         # see the backfilled sessions as present-skips, so the post_upsert hook
@@ -206,13 +264,6 @@ def ingest(
 # =============================================================================
 
 if __name__ == "__main__":
-    # Load ai-backend/.env if present. bulk.py is 4 levels deep → parents[4] = ai-backend/.
-    from dotenv import load_dotenv  # noqa: PLC0415
-
-    _env_path = Path(__file__).resolve().parents[4] / ".env"
-    if _env_path.exists():
-        load_dotenv(_env_path, override=False)
-
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
     parser = argparse.ArgumentParser(
@@ -245,10 +296,18 @@ if __name__ == "__main__":
         sys.exit(2)
 
     qdrant_url = os.getenv("QDRANT_URL", "http://localhost:6333")
-    _qdrant = QdrantClient(url=qdrant_url)
-    _embed = OpenAIEmbeddings(model=EMBEDDING_MODEL)
+    _qdrant = QdrantClient(url=qdrant_url, api_key=os.getenv("QDRANT_API_KEY"))
+    # Same provider factory + task type as run.py — the backfill must write
+    # vectors in the corpus's configured embedding space, not hardcoded OpenAI.
+    _embed = get_embeddings(task_type="RETRIEVAL_DOCUMENT")
+    # Refuse to write into a collection whose fingerprint contradicts the
+    # current provider/model configuration.
+    check_fingerprint(_qdrant, COLLECTION_NAME)
     _client = OpTvClient()
-    _mdb_lookup = load_mdb_lookup(_MDB_PATH)
+    # ensure_* downloads the MdB master on a clean checkout and FAILS LOUD when
+    # it cannot: silently continuing with an empty lookup mis-tenants every
+    # chair/minister speech as "unbekannt" and drops it from party retrieval.
+    _mdb_lookup = ensure_mdb_lookup(_MDB_PATH)
 
     print(
         f"Backfilling openparliament.tv speeches from GitHub (limit={args.limit}) ..."

--- a/ai-backend/src/ingestion/connectors/openparliament_tv/bulk.py
+++ b/ai-backend/src/ingestion/connectors/openparliament_tv/bulk.py
@@ -1,0 +1,267 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Standalone --from-github bulk backfill for openparliament.tv speeches.
+
+Enumerates the WP20+21 ``processed/*-session.json`` bulk files via ``OpTvClient``,
+runs each session's speech items through ``build_chunk_records``, and embeds +
+upserts into ``wahlchat_chunks_{ENV}`` in batches. The live connector
+(``connector.py``) handles incremental runs via ``run.py`` and the YYYYMMDD cursor;
+this script handles the one-shot historical backfill from GitHub.
+
+Design notes:
+  - This is the ONLY file within the ``openparliament_tv`` package permitted to call
+    the runner ``_embed_texts`` / ``_upsert_chunks`` helpers directly. The connector
+    never touches those — ``run.py`` owns that path.
+  - Each record is stamped ``external_id=YYYYMMDD(dateStart)`` (same as
+    ``normalize()``) so ``run.py``'s ``get_cursor("parliamentary_speech",
+    source="op")`` picks up the backfill and the first live incremental run does not
+    re-embed everything.
+  - Idempotent: deterministic chunk UUIDs (``compute_chunk_id``) mean re-running
+    upserts the same Qdrant point IDs (a no-op), and the ``content_hash`` guard
+    re-writes only genuinely changed chunks.
+
+Usage (local dev):
+    cd ai-backend
+    uv run python -m src.ingestion.connectors.openparliament_tv.bulk --help
+    uv run python -m src.ingestion.connectors.openparliament_tv.bulk --from-github --limit 20
+    QDRANT_URL=http://localhost:6333 ENV=dev \\
+        uv run python -m src.ingestion.connectors.openparliament_tv.bulk --from-github
+
+Requires: make stores-up first (Qdrant running at QDRANT_URL).
+          OPENAI_API_KEY in ai-backend/.env (auto-loaded if present).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from langchain_openai import OpenAIEmbeddings
+from qdrant_client import QdrantClient
+
+from src.ingestion.connector import BaseConnector
+from src.ingestion.connectors.bundestag_speeches.constants import MDB_STAMMDATEN_FILE
+from src.ingestion.connectors.bundestag_speeches.mdb import load_mdb_lookup
+from src.ingestion.connectors.openparliament_tv.client import OpTvClient
+from src.ingestion.connectors.openparliament_tv.mappers.corpus import (
+    build_chunk_records,
+)
+from src.ingestion.connectors.openparliament_tv.supersede import (
+    supersede_dip_duplicates,
+)
+from src.ingestion.run import _embed_texts, _upsert_chunks
+from src.ingestion.schemas import ChunkRecord
+from src.ingestion.setup_collection import COLLECTION_NAME, EMBEDDING_MODEL
+
+# Shared speech-dedup helper — one definition for both speech connectors.
+from src.ingestion.speech_dedup import datum_to_external_id as _datum_to_external_id
+
+logger = logging.getLogger(__name__)
+
+
+class _OpSourceStub(BaseConnector):
+    """Minimal connector stand-in for the supersede op source-gate.
+
+    ``supersede_dip_duplicates`` fires only for ``connector.source == "op"``;
+    the backfill has no live connector instance, so this stub carries the gate.
+    Only the class attributes are ever read — the pipeline methods are never
+    called during a bulk backfill.
+    """
+
+    source_type = "parliamentary_speech"
+    source = "op"
+
+    def discover(self, since):  # noqa: ANN001, ANN201 — never called
+        raise NotImplementedError(
+            "_OpSourceStub only carries the supersede source gate"
+        )
+
+    def fetch(self, external_id):  # noqa: ANN001, ANN201 — never called
+        raise NotImplementedError(
+            "_OpSourceStub only carries the supersede source gate"
+        )
+
+    def normalize(self, raw):  # noqa: ANN001, ANN201 — never called
+        raise NotImplementedError(
+            "_OpSourceStub only carries the supersede source gate"
+        )
+
+
+_OP_GATE = _OpSourceStub()
+
+_BATCH_SIZE = 100  # chunks per embed+upsert batch
+
+# MdB-Stammdaten XML, resolved relative to ai-backend/ (bulk.py is 4 levels deep).
+_MDB_PATH: Path = Path(__file__).resolve().parents[4] / MDB_STAMMDATEN_FILE
+
+
+# =============================================================================
+# MAIN INGEST LOOP
+# =============================================================================
+
+
+def ingest(
+    client: OpTvClient,
+    qdrant: QdrantClient,
+    embed: OpenAIEmbeddings,
+    mdb_lookup: dict,
+    limit: Optional[int] = None,
+) -> tuple[int, int]:
+    """Enumerate WP20+21 session files and upsert their aligned speeches in batches.
+
+    Each raw session ``data[]`` item is passed through ``build_chunk_records`` (which
+    applies the alignment gate); usable speeches are stamped with
+    ``external_id=YYYYMMDD(dateStart)`` so ``get_cursor`` picks up the backfill.
+
+    Args:
+        client:     Initialised OpTvClient.
+        qdrant:     Initialised QdrantClient.
+        embed:      Initialised OpenAIEmbeddings instance.
+        mdb_lookup: MdB-Stammdaten lookup for the empty-faction / CSU fallback.
+        limit:      Maximum number of usable speeches to process (None = all).
+
+    Returns:
+        Tuple of (speeches_processed, chunks_upserted).
+    """
+    speeches_processed = 0
+    chunks_total = 0
+    batch: list[ChunkRecord] = []
+
+    def _flush(b: list[ChunkRecord]) -> int:
+        if not b:
+            return 0
+        vectors = _embed_texts(embed, [c.text for c in b])
+        _upsert_chunks(qdrant, COLLECTION_NAME, b, vectors)
+        # Supersede each flushed batch's DIP twins immediately. Without this
+        # the entire historical overlap stays duplicated forever: later live runs
+        # see the backfilled sessions as present-skips, so the post_upsert hook
+        # never fires for them and the PDF graft never happens.
+        supersede_dip_duplicates(qdrant, COLLECTION_NAME, b, connector=_OP_GATE)
+        return len(b)
+
+    session_files = client.list_session_files()
+    logger.info("op backfill: %d WP20+21 session files to scan.", len(session_files))
+
+    for name in session_files:
+        if limit is not None and speeches_processed >= limit:
+            break
+
+        try:
+            session = client.fetch_session_json(name)
+        except Exception as exc:  # noqa: BLE001 — a bad session file must not abort the backfill
+            logger.warning(
+                "op backfill: fetch failed for %s (%s) — skipping.", name, exc
+            )
+            continue
+
+        for item in session.get("data") or []:
+            if not isinstance(item, dict):
+                continue
+            if limit is not None and speeches_processed >= limit:
+                break
+
+            records = build_chunk_records(item, mdb_lookup)
+            if not records:
+                # Unaligned / ASR-only / empty-text item — skip (not counted).
+                # debug (not warning): these are legitimately common in the bulk
+                # feed, so per-item visibility belongs in a debug run, not the
+                # normal log stream.
+                logger.debug(
+                    "op backfill: skipping item with no usable records (id=%s)",
+                    item.get("id"),
+                )
+                continue
+
+            ext = _datum_to_external_id(item.get("dateStart"))
+            if ext is not None:
+                records = [c.model_copy(update={"external_id": ext}) for c in records]
+
+            speeches_processed += 1
+            batch.extend(records)
+            chunks_total += len(records)
+
+            if len(batch) >= _BATCH_SIZE:
+                flushed = _flush(batch)
+                logger.info(
+                    "Flushed batch of %d chunks (total so far: %d)",
+                    flushed,
+                    chunks_total,
+                )
+                batch = []
+
+    _flush(batch)
+
+    return speeches_processed, chunks_total
+
+
+# =============================================================================
+# __main__ entrypoint
+# =============================================================================
+
+if __name__ == "__main__":
+    # Load ai-backend/.env if present. bulk.py is 4 levels deep → parents[4] = ai-backend/.
+    from dotenv import load_dotenv  # noqa: PLC0415
+
+    _env_path = Path(__file__).resolve().parents[4] / ".env"
+    if _env_path.exists():
+        load_dotenv(_env_path, override=False)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill openparliament.tv WP20+21 speeches from the keyless GitHub bulk "
+            "repository into the Qdrant wahlchat_chunks_{ENV} collection. No API key "
+            "required — reads processed/*-session.json, not the live op API."
+        ),
+    )
+    parser.add_argument(
+        "--from-github",
+        dest="from_github",
+        action="store_true",
+        help="Enumerate + backfill from the OpenParliamentTV-Data-DE GitHub bulk repo.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Process at most N usable speeches (for smoke testing).",
+    )
+    args = parser.parse_args()
+
+    if not args.from_github:
+        print(
+            "ERROR: nothing to do — pass --from-github to run the GitHub bulk backfill.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    qdrant_url = os.getenv("QDRANT_URL", "http://localhost:6333")
+    _qdrant = QdrantClient(url=qdrant_url)
+    _embed = OpenAIEmbeddings(model=EMBEDDING_MODEL)
+    _client = OpTvClient()
+    _mdb_lookup = load_mdb_lookup(_MDB_PATH)
+
+    print(
+        f"Backfilling openparliament.tv speeches from GitHub (limit={args.limit}) ..."
+    )
+    try:
+        processed, chunks = ingest(
+            _client, _qdrant, _embed, _mdb_lookup, limit=args.limit
+        )
+    except Exception:  # noqa: BLE001
+        import traceback  # noqa: PLC0415
+
+        print("ERROR: backfill failed:", file=sys.stderr)
+        traceback.print_exc()
+        sys.exit(1)
+
+    print(f"Done. speeches_processed={processed}  chunks_upserted={chunks}")

--- a/ai-backend/src/ingestion/connectors/openparliament_tv/client.py
+++ b/ai-backend/src/ingestion/connectors/openparliament_tv/client.py
@@ -1,0 +1,211 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""OpTvClient — the single I/O home for keyless openparliament.tv GitHub-bulk calls.
+
+Design goals (mirrors bundestag_speeches/client.DipClient posture):
+  - RAW_BASE / TREES_URL are pinned module constants — the fetch host is never
+    derived from a caller arg or a session-supplied URI.
+  - `curl_get` uses a fixed arg list, never routed through a shell
+    (command-injection mitigation).
+  - Requests are paced with a small sleep to be a good GitHub citizen (keyless).
+  - `fetch_session_json` builds its URL ONLY from `RAW_BASE + a validated basename`;
+    it NEVER fetches videoFileURI/audioFileURI/sourcePage (SSRF mitigation).
+
+Public API:
+  OpTvClient(sleep=0.2)
+    .list_session_files() -> list[str]      — enumerate `processed/*-session.json` basenames
+    .fetch_session_json(name) -> dict       — fetch + json.loads one session file
+  curl_get(url, accept) -> str              — fixed-arg subprocess curl, never shell-routed
+"""
+
+from __future__ import annotations
+
+import json
+import logging as _logging
+import re
+import subprocess
+import time
+
+import requests
+
+from .constants import (
+    _MAX_TREE_ENTRIES,
+    RAW_BASE,
+    SESSION_FILE_RE,
+    TREES_URL,
+)
+
+_client_logger = _logging.getLogger(__name__)
+
+# Compiled once; matches `processed/YYYYY-session.json` full paths from the trees API.
+_SESSION_FILE_PATTERN = re.compile(SESSION_FILE_RE)
+
+# A validated basename is exactly `YYYYY-session.json` (the trees `path` minus the
+# `processed/` prefix). Enforced before building the pinned RAW_BASE fetch URL so a
+# hostile trees response can never inject `../` or an absolute URL into the path.
+_BASENAME_PATTERN = re.compile(r"^2[01]\d{3}-session\.json$")
+
+
+class OpTvChallengeError(RuntimeError):
+    """Raised when a pinned-host session file cannot be fetched (HTTP + curl both failed)."""
+
+
+class OpTvClient:
+    """Paced, keyless HTTP client for the openparliament.tv GitHub bulk repository.
+
+    Enforces:
+      - Sequential `sleep`-second delay between requests (keyless GitHub courtesy).
+      - Up to 3 attempts per fetch; fixed-arg `curl` fallback on redirect / non-2xx.
+      - Fetch host pinned to RAW_BASE / TREES_URL; basenames validated before use.
+
+    Args:
+        sleep: Inter-request delay in seconds (default 0.2).
+    """
+
+    def __init__(self, sleep: float = 0.2) -> None:
+        self.sleep = sleep
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "Accept": "application/json",
+                "User-Agent": "Mozilla/5.0 wahl-chat-op-connector-student-project/1.0",
+            }
+        )
+
+    def list_session_files(self) -> list[str]:
+        """Enumerate `processed/*-session.json` bulk files via the GitHub trees API.
+
+        GET the keyless recursive trees listing, filter `tree[].path` entries by
+        SESSION_FILE_RE, and return the sorted set of matching basenames
+        (`YYYYY-session.json`, i.e. the path with the `processed/` prefix stripped).
+
+        Returns:
+            Sorted list of session-file basenames.
+
+        Raises:
+            requests.HTTPError: on a non-2xx trees response (after all attempts).
+        """
+        data = self._get_json(TREES_URL)
+
+        tree = data.get("tree", [])
+        if not isinstance(tree, list):
+            _client_logger.warning(
+                "OpTvClient.list_session_files(): trees response 'tree' is not a list — got %s.",
+                type(tree).__name__,
+            )
+            return []
+
+        names: set[str] = set()
+        for index, entry in enumerate(tree):
+            if index >= _MAX_TREE_ENTRIES:
+                _client_logger.warning(
+                    "OpTvClient.list_session_files(): hit hard trees cap of %d entries — stopping.",
+                    _MAX_TREE_ENTRIES,
+                )
+                break
+            if not isinstance(entry, dict):
+                continue
+            path = entry.get("path")
+            if not isinstance(path, str):
+                continue
+            match = _SESSION_FILE_PATTERN.match(path)
+            if match:
+                names.add(f"{match.group(1)}-session.json")
+
+        return sorted(names)
+
+    def fetch_session_json(self, name: str) -> dict:
+        """Fetch one `processed/{name}` session file and parse its JSON body.
+
+        The URL is built ONLY from the pinned RAW_BASE plus a validated basename —
+        NEVER from a session-supplied videoFileURI/audioFileURI/sourcePage (SSRF).
+
+        Args:
+            name: Session-file basename (e.g. "20101-session.json").
+
+        Returns:
+            Parsed JSON dict (JSON:API `{"meta": ..., "data": [...]}` shape).
+
+        Raises:
+            ValueError: if `name` is not a validated `YYYYY-session.json` basename.
+            OpTvChallengeError: if both the HTTP request and the curl fallback fail.
+        """
+        if not _BASENAME_PATTERN.match(name):
+            raise ValueError(
+                f"refusing to fetch un-validated op session basename: {name!r} "
+                "(must match 'YYYYY-session.json')"
+            )
+
+        # Pinned host + validated basename only — no source-supplied URI ever reaches here.
+        url = f"{RAW_BASE}/{name}"
+        return self._get_json(url)
+
+    def _get_json(self, url: str) -> dict:
+        """GET `url` (a pinned-host URL) and return parsed JSON, with a curl fallback.
+
+        Up to 3 attempts; on a redirect away from the requested host or a non-2xx
+        status on the final attempt, fall back to a fixed-arg curl fetch.
+        """
+        for attempt in range(3):
+            try:
+                response = self.session.get(url, timeout=60)
+            except requests.RequestException:
+                if attempt == 2:
+                    body = curl_get(url, accept="application/json")
+                    time.sleep(self.sleep)
+                    return json.loads(body)
+                time.sleep(2 * (attempt + 1))
+                continue
+
+            if response.status_code == 200:
+                time.sleep(self.sleep)
+                return response.json()
+
+            if attempt == 2:
+                try:
+                    body = curl_get(url, accept="application/json")
+                except OpTvChallengeError as exc:
+                    # Preserve the original HTTP status (e.g. 404 vs 500)
+                    # that the plain curl fallback error would otherwise drop —
+                    # makes bulk backfill failures triageable. The curl posture
+                    # (pinned host, fixed arg list) is untouched.
+                    raise OpTvChallengeError(
+                        f"HTTP {response.status_code} for {url}; "
+                        f"curl fallback also failed: {exc}"
+                    ) from exc
+                time.sleep(self.sleep)
+                return json.loads(body)
+            time.sleep(2 * (attempt + 1))
+
+        # Unreachable — the loop either returns or raises on the final attempt.
+        raise OpTvChallengeError(f"could not fetch pinned op URL: {url}")
+
+
+def curl_get(url: str, accept: str = "*/*") -> str:
+    """Fetch a URL via subprocess curl with a fixed argument list (never shell-routed).
+
+    Security: the URL is pinned-host-derived (RAW_BASE / TREES_URL + validated
+    basename), not user-supplied; the arg list is fixed at call time and never
+    passed through a shell (command-injection mitigation).
+
+    Args:
+        url: URL to fetch (pinned-host-derived; not source input).
+        accept: Accept header value (default "*/*").
+
+    Returns:
+        Response body as a string.
+
+    Raises:
+        OpTvChallengeError: if curl exits non-zero.
+    """
+    # Fixed arg list — passed directly to subprocess, never routed through a shell.
+    command = ["curl", "-sS", "-L", "--fail", "-H", f"Accept: {accept}", url]
+    result = subprocess.run(command, text=True, capture_output=True, timeout=90)
+    if result.returncode != 0:
+        raise OpTvChallengeError(
+            result.stderr.strip()
+            or "curl could not fetch the pinned openparliament.tv URL"
+        )
+    return result.stdout

--- a/ai-backend/src/ingestion/connectors/openparliament_tv/client.py
+++ b/ai-backend/src/ingestion/connectors/openparliament_tv/client.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/src/ingestion/connectors/openparliament_tv/connector.py
+++ b/ai-backend/src/ingestion/connectors/openparliament_tv/connector.py
@@ -1,0 +1,288 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+OpenParliamentTvConnector — live incremental connector for openparliament.tv.
+
+Coexist layer alongside ``bundestag_speeches`` (DIP): produces the SAME
+``source_type = "parliamentary_speech"`` chunks but with ``source = "op"`` (the
+discriminator) plus a timed ``sentence_map`` and a video deep-link payload.
+The runner (run.py) owns embed + upsert; this connector is a pure data-transform.
+
+Design (mirrors bundestag_speeches/connector.py, session-granular):
+    discover(since) → fetch → normalize → [runner embeds + upserts]
+
+The cursor (``since``) is a YYYYMMDD integer derived by the runner from Qdrant
+max(external_id) for ``parliamentary_speech`` + ``source="op"`` (a source-scoped
+cursor). ``discover`` floors the enumerated session files at
+``since − LOOKBACK_DAYS`` so a session that only *just* aligned BELOW
+the prior cursor is re-picked instead of being stranded forever — the runner's
+already-present + ``content_hash`` guard makes the re-scan cheap.
+
+Security / robustness:
+    - Keyless GitHub-bulk path: NO API-key guard (unlike DIP's _require_dip_key).
+    - ``fetch`` never raises: a missing session returns a ``skip_reason`` dict.
+    - ``normalize`` raises ``ValueError`` on a skip_reason or a session that yields
+      zero usable (aligned + proceedings) speeches → runner skip-and-warn; the
+      cursor does NOT advance past a skipped session (idempotent upsert re-processes
+      once the session later aligns).
+    - Source-supplied media URIs (video/audio/sourcePage) are stored as strings and
+      NEVER fetched during ingest; only OpTvClient (pinned host) performs I/O.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+from src.ingestion.connector import BaseConnector
+from src.ingestion.connectors.bundestag_speeches.constants import MDB_STAMMDATEN_FILE
+from src.ingestion.connectors.bundestag_speeches.mdb import ensure_mdb_lookup
+from src.ingestion.connectors.openparliament_tv.client import OpTvClient
+from src.ingestion.connectors.openparliament_tv.mappers.corpus import (
+    build_chunk_records,
+)
+from src.ingestion.connectors.openparliament_tv.supersede import (
+    supersede_dip_duplicates,
+)
+from src.ingestion.schemas import ChunkRecord, SourceType
+
+# Shared speech-dedup helpers — one definition for both speech connectors.
+from src.ingestion.speech_dedup import datum_to_external_id as _datum_to_external_id
+from src.ingestion.speech_dedup import lookback_floor as _lookback_floor
+
+logger = logging.getLogger(__name__)
+
+# MdB-Stammdaten XML, resolved relative to ai-backend/. connector.py is 4 levels
+# deep: src/ingestion/connectors/openparliament_tv/connector.py → parents[4] = ai-backend/.
+_MDB_PATH: Path = Path(__file__).resolve().parents[4] / MDB_STAMMDATEN_FILE
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _session_external_id(items: list[dict]) -> Optional[int]:
+    """Derive a session's YYYYMMDD external_id from the earliest item ``dateStart``."""
+    ext_ids = [
+        e
+        for e in (
+            _datum_to_external_id(it.get("dateStart"))
+            for it in items
+            if isinstance(it, dict)
+        )
+        if e is not None
+    ]
+    return min(ext_ids) if ext_ids else None
+
+
+# ---------------------------------------------------------------------------
+# OpenParliamentTvConnector
+# ---------------------------------------------------------------------------
+
+
+class OpenParliamentTvConnector(BaseConnector):
+    """Connector for openparliament.tv plenary speeches → parliamentary_speech chunks.
+
+    Session-granular live incremental connector:
+        discover(since) → fetch(session_id) → normalize → [runner embeds + upserts]
+
+    Class attributes drive the runner's source-scoped cursor (get_cursor): the
+    ``source_type`` matches DIP (``parliamentary_speech``) but ``source = "op"`` keeps
+    the op and DIP cursors independent.
+    """
+
+    # Used by runner.get_cursor() to scope the Qdrant scroll — SAME as DIP.
+    source_type: str = SourceType.PARLIAMENTARY_SPEECH.value
+
+    # Connector discriminator: op and DIP do NOT share one
+    # parliamentary_speech cursor, and the op supersede-delete hook stays op-gated.
+    source: str = "op"
+
+    def __init__(self, sleep: float = 0.2) -> None:
+        self._client = OpTvClient(sleep=sleep)
+        # Per-run caches: populated in discover(), read in fetch().
+        # basename(str) → {"items": list[raw item], "basename": str, "ext": int}
+        self._sessions: dict[str, dict] = {}
+        # MdB-Stammdaten lookup loaded once per run in discover().
+        self._mdb_lookup: Optional[dict] = None
+
+    # ------------------------------------------------------------------
+    # 1. discover — enumerate WP20+21 session files; floor at since − LOOKBACK
+    # ------------------------------------------------------------------
+
+    def discover(self, since: Optional[int]) -> list[str]:
+        """Return unique session basenames to process, floored at the lookback.
+
+        Enumerates the bulk ``processed/*-session.json`` basenames via the client
+        and iterates them in DESCENDING date order, stopping the per-file fetches
+        as soon as a fetched session's derived YYYYMMDD external_id drops below
+        the ``since − LOOKBACK_DAYS`` floor. Without this early stop EVERY WP20+21
+        session JSON (~260+ multi-MB files, paced) would be fetched on each
+        incremental run — defeating the cursor and the 15-min job posture.
+
+        Descending-order invariant: the validated basename shape is
+        ``{EP:2}{session:03}-session.json`` (SESSION_FILE_RE — e.g. ``20101`` =
+        EP 20, session 101). Session numbers are assigned chronologically within
+        an electoral period and zero-padded to three digits, so LEXICAL basename
+        order is monotone in the session date that ``_session_external_id``
+        derives from the earliest item ``dateStart`` — reverse-sorting the
+        basenames walks sessions newest-first.
+
+        ``since=None`` (full backfill) fetches ALL sessions — no floor, no early
+        stop. Handles are the basenames themselves: unique per session even when
+        two sessions share one calendar date. The stamped chunk external_id is
+        unaffected — normalize() derives YYYYMMDD per item from ``dateStart``.
+
+        Args:
+            since: Max op external_id (YYYYMMDD) already committed to Qdrant for
+                   ``parliamentary_speech``/``source="op"``, or None on first run.
+
+        Returns:
+            Session basename strings sorted ascending by (YYYYMMDD ext, name) so
+            cursor order stays oldest-first.
+        """
+        # De-duplicate + reverse-sort: newest session file first (see invariant above).
+        entries = sorted(
+            {str(e) for e in self._client.list_session_files()}, reverse=True
+        )
+        floor = _lookback_floor(since) if since is not None else None
+
+        # Tolerate instances built via object.__new__ (unit tests bypass __init__).
+        # ensure_* fetches on a cache miss and fails loud when the master data is
+        # unavailable (op shares DIP's minister/president → "unbekannt" degradation).
+        if getattr(self, "_mdb_lookup", None) is None:
+            self._mdb_lookup = ensure_mdb_lookup(_MDB_PATH)
+
+        self._sessions = {}
+        discovered: list[tuple[int, str]] = []
+
+        for name in entries:
+            try:
+                session = self._client.fetch_session_json(name)
+            except Exception as exc:  # noqa: BLE001 — a bad session file must not abort the run
+                logger.warning(
+                    "op discover: fetch failed for %s (%s) — skipping.", name, exc
+                )
+                continue
+
+            items = [it for it in (session.get("data") or []) if isinstance(it, dict)]
+            ext = _session_external_id(items)
+            if ext is None:
+                continue
+            if floor is not None and ext < floor:
+                # Descending scan: every remaining basename is older still —
+                # stop fetching entirely.
+                break
+            self._sessions[name] = {"items": items, "basename": name, "ext": ext}
+            discovered.append((ext, name))
+
+        return [handle for _ext, handle in sorted(discovered)]
+
+    # ------------------------------------------------------------------
+    # 2. fetch — read from cache; never raises (returns skip_reason on miss)
+    # ------------------------------------------------------------------
+
+    def fetch(self, external_id: str) -> dict:
+        """Return the cached raw session items for one session handle.
+
+        Never raises: a cache miss or a fetch failure returns a ``skip_reason`` dict
+        that ``normalize`` converts into a ValueError-skip.
+
+        Args:
+            external_id: Session basename string returned by discover()
+                         (e.g. ``"20101-session.json"``).
+
+        Returns:
+            ``{"external_id", "items", "mdb_lookup"}`` or ``{"skip_reason": ...}``.
+        """
+        cached = self._sessions.get(str(external_id))
+        if cached is None:
+            return {"skip_reason": f"op session {external_id} not in discover cache"}
+
+        items = cached.get("items") or []
+        basename = cached.get("basename")
+        if not items and basename:
+            try:
+                session = self._client.fetch_session_json(basename)
+            except Exception as exc:  # noqa: BLE001 — skip-and-warn, never abort
+                return {"skip_reason": f"op session {external_id} fetch failed: {exc}"}
+            items = [it for it in (session.get("data") or []) if isinstance(it, dict)]
+
+        return {
+            "external_id": external_id,
+            "items": items,
+            "mdb_lookup": self._mdb_lookup,
+        }
+
+    # ------------------------------------------------------------------
+    # 3. normalize — build ChunkRecords; alignment gate; stamp YYYYMMDD external_id
+    # ------------------------------------------------------------------
+
+    def normalize(self, raw: dict) -> list[ChunkRecord]:
+        """Build ChunkRecords from a fetched session; stamp YYYYMMDD external_id + wp.
+
+        Skip-and-warn contract:
+            - a ``skip_reason`` key → immediate ValueError;
+            - a session that yields zero usable (aligned + proceedings) speeches →
+              ValueError so the runner skip-and-continues and the cursor does
+              NOT advance past the un-aligned session.
+
+        Each usable speech becomes one whole-speech chunk stamped with
+        ``external_id = YYYYMMDD(dateStart)`` and ``wahlperiode = electoralPeriod.number``.
+
+        Args:
+            raw: fetch() payload with ``items`` (raw op speech items) + ``mdb_lookup``.
+
+        Raises:
+            ValueError: on a skip_reason or a zero-usable-speech session.
+        """
+        if raw.get("skip_reason"):
+            raise ValueError(raw["skip_reason"])
+
+        items: list[dict] = raw.get("items") or []
+        mdb_lookup: Optional[dict] = raw.get("mdb_lookup")
+
+        records: list[ChunkRecord] = []
+        for item in items:
+            recs = build_chunk_records(item, mdb_lookup)
+            if not recs:
+                # Unaligned / ASR-only / empty-text item — skip.
+                continue
+            ext = _datum_to_external_id(item.get("dateStart"))
+            ep = (item.get("electoralPeriod") or {}).get("number")
+            wahlperiode = int(ep) if ep is not None else None
+            records.extend(
+                rec.model_copy(update={"external_id": ext, "wahlperiode": wahlperiode})
+                for rec in recs
+            )
+
+        if not records:
+            raise ValueError(
+                f"op session {raw.get('external_id')}: zero usable aligned+proceedings "
+                "speeches (all unaligned, ASR-only, or empty)"
+            )
+
+        return records
+
+    # ------------------------------------------------------------------
+    # 4. post_upsert — op-owned supersede policy
+    # ------------------------------------------------------------------
+
+    def post_upsert(
+        self, qdrant: Any, collection_name: str, chunks: list[ChunkRecord]
+    ) -> int:
+        """Supersede the just-upserted op speeches' DIP twins.
+
+        Called by run_connector after each successful item upsert. Grafts each
+        matched DIP twin's transcript PDF onto the op record, then deletes the
+        twin. The policy lives here (connector-owned), not in the generic
+        runner; ``supersede_dip_duplicates`` keeps its own op source-gate.
+
+        Returns:
+            Number of DIP twins superseded.
+        """
+        return supersede_dip_duplicates(qdrant, collection_name, chunks, connector=self)

--- a/ai-backend/src/ingestion/connectors/openparliament_tv/connector.py
+++ b/ai-backend/src/ingestion/connectors/openparliament_tv/connector.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -59,6 +59,10 @@ logger = logging.getLogger(__name__)
 # deep: src/ingestion/connectors/openparliament_tv/connector.py → parents[4] = ai-backend/.
 _MDB_PATH: Path = Path(__file__).resolve().parents[4] / MDB_STAMMDATEN_FILE
 
+# Session numbers at or above this are SPECIAL files (Sondersitzungen,
+# commemorative events) whose numbering is not chronological — see discover().
+_SPECIAL_SESSION_MIN = 800
+
 
 # ---------------------------------------------------------------------------
 # Module-level helpers
@@ -118,19 +122,23 @@ class OpenParliamentTvConnector(BaseConnector):
         """Return unique session basenames to process, floored at the lookback.
 
         Enumerates the bulk ``processed/*-session.json`` basenames via the client
-        and iterates them in DESCENDING date order, stopping the per-file fetches
-        as soon as a fetched session's derived YYYYMMDD external_id drops below
-        the ``since − LOOKBACK_DAYS`` floor. Without this early stop EVERY WP20+21
-        session JSON (~260+ multi-MB files, paced) would be fetched on each
-        incremental run — defeating the cursor and the 15-min job posture.
+        and fetches them newest-first, stopping as soon as a fetched session's
+        derived YYYYMMDD external_id drops below the ``since − LOOKBACK_DAYS``
+        floor. Without this early stop EVERY WP20+21 session JSON (~260+
+        multi-MB files, paced) would be fetched on each incremental run —
+        defeating the cursor and the 15-min job posture.
 
-        Descending-order invariant: the validated basename shape is
+        Early-stop soundness: the validated basename shape is
         ``{EP:2}{session:03}-session.json`` (SESSION_FILE_RE — e.g. ``20101`` =
-        EP 20, session 101). Session numbers are assigned chronologically within
-        an electoral period and zero-padded to three digits, so LEXICAL basename
-        order is monotone in the session date that ``_session_external_id``
-        derives from the earliest item ``dateStart`` — reverse-sorting the
-        basenames walks sessions newest-first.
+        EP 20, session 101). ONLY the regular sitting numbers (< 800) are
+        assigned chronologically within an electoral period, so lexical order is
+        monotone in the session date for them. The 8xx/9xx block holds SPECIAL
+        session files whose numbering is NOT chronological (the live tree has
+        e.g. ``21902`` dated months before ``21090``) — applying the early stop
+        across them made discover() return nothing while current sessions were
+        pending. Special files are therefore ALWAYS fetched (there are only a
+        handful) and floor-filtered individually, while the early stop applies
+        to the monotone regular sequence alone.
 
         ``since=None`` (full backfill) fetches ALL sessions — no floor, no early
         stop. Handles are the basenames themselves: unique per session even when
@@ -145,11 +153,18 @@ class OpenParliamentTvConnector(BaseConnector):
             Session basename strings sorted ascending by (YYYYMMDD ext, name) so
             cursor order stays oldest-first.
         """
-        # De-duplicate + reverse-sort: newest session file first (see invariant above).
-        entries = sorted(
-            {str(e) for e in self._client.list_session_files()}, reverse=True
-        )
+        entries = sorted({str(e) for e in self._client.list_session_files()})
         floor = _lookback_floor(since) if since is not None else None
+
+        # Partition: regular sittings (session number < 800, chronological
+        # numbering → lexical order is date order) vs special files (8xx/9xx,
+        # NON-chronological numbering → no order assumption is valid).
+        regular: list[str] = []
+        special: list[str] = []
+        for name in entries:
+            digits = name.split("-", 1)[0]
+            session_no = int(digits[2:]) if len(digits) == 5 and digits.isdigit() else 0
+            (special if session_no >= _SPECIAL_SESSION_MIN else regular).append(name)
 
         # Tolerate instances built via object.__new__ (unit tests bypass __init__).
         # ensure_* fetches on a cache miss and fails loud when the master data is
@@ -160,25 +175,32 @@ class OpenParliamentTvConnector(BaseConnector):
         self._sessions = {}
         discovered: list[tuple[int, str]] = []
 
-        for name in entries:
+        def _consider(name: str, *, allow_early_stop: bool) -> bool:
+            """Fetch one session; False = below-floor (caller may early-stop)."""
             try:
                 session = self._client.fetch_session_json(name)
             except Exception as exc:  # noqa: BLE001 — a bad session file must not abort the run
                 logger.warning(
                     "op discover: fetch failed for %s (%s) — skipping.", name, exc
                 )
-                continue
-
+                return True
             items = [it for it in (session.get("data") or []) if isinstance(it, dict)]
             ext = _session_external_id(items)
             if ext is None:
-                continue
+                return True
             if floor is not None and ext < floor:
-                # Descending scan: every remaining basename is older still —
-                # stop fetching entirely.
-                break
+                return not allow_early_stop
             self._sessions[name] = {"items": items, "basename": name, "ext": ext}
             discovered.append((ext, name))
+            return True
+
+        # Newest-first over the monotone regular sequence — early stop is sound.
+        for name in reversed(regular):
+            if not _consider(name, allow_early_stop=True):
+                break
+        # Special files: no order assumption — fetch and filter each one.
+        for name in special:
+            _consider(name, allow_early_stop=False)
 
         return [handle for _ext, handle in sorted(discovered)]
 

--- a/ai-backend/src/ingestion/connectors/openparliament_tv/constants.py
+++ b/ai-backend/src/ingestion/connectors/openparliament_tv/constants.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""Connector-level constants for the openparliament_tv package.
+
+Source: the keyless OpenParliamentTV-Data-DE GitHub bulk repository. The op
+`/search/media` HTTP API is deliberately NOT used this phase — the
+GitHub `processed/` session files are BOTH the backfill and the incremental
+mechanism.
+
+Security: RAW_BASE and TREES_URL are pinned module constants — the fetch host is
+NEVER derived from a caller arg, a session-supplied URI, or any runtime input
+(mirrors bundestag_speeches/constants.BASE_URL and abgeordnetenwatch/_AW_BASE).
+The client fetches ONLY `RAW_BASE + validated-basename`; source-supplied media
+URIs (videoFileURI/audioFileURI/sourcePage) are stored as strings, never fetched
+during ingest (SSRF mitigation).
+"""
+
+from __future__ import annotations
+
+# Pinned raw-content host for individual session JSON files. Never derive from input.
+RAW_BASE = (
+    "https://raw.githubusercontent.com/"
+    "OpenParliamentTV/OpenParliamentTV-Data-DE/main/processed"
+)
+
+# GitHub Git-trees API to enumerate the repository's `processed/` directory (keyless).
+# `recursive=1` returns the full tree in one response; we filter to session files.
+TREES_URL = (
+    "https://api.github.com/repos/"
+    "OpenParliamentTV/OpenParliamentTV-Data-DE/git/trees/main?recursive=1"
+)
+
+# Match `processed/YYYYY-session.json` bulk files.
+#   WP20 sessions: 200XX / 201XX      (e.g. 20101 → EP 20, session 101)
+#   WP21 sessions: 210XX + specials   (e.g. 21005)
+# The leading `2[01]` anchors the electoral-period digit (20/21) and rejects paths
+# outside `processed/`, so only pinned-shape basenames ever reach fetch_session_json.
+SESSION_FILE_RE = r"^processed/(2[01]\d{3})-session\.json$"
+
+# Lookback floor (days) for the incremental discover() re-scan.
+# op aligns speeches ~3–4 weeks after a session; 60 days comfortably exceeds that
+# backlog lag so a session that only *just* aligned below the prior cursor is
+# still re-picked instead of being stranded forever. Re-exported from the shared
+# speech-dedup module so the op and DIP windows can never drift apart.
+from src.ingestion.speech_dedup import LOOKBACK_DAYS  # noqa: E402, F401
+
+# Finite cap on the trees listing to bound memory / parse work on a hostile or
+# runaway response (DoS mitigation). The full DE repo is a few thousand
+# session files across two legislatures — 100k entries is provably generous.
+_MAX_TREE_ENTRIES = 100_000
+
+# CORRECTED Wikidata faction id → canonical party slug map.
+# The public op source list mislabels two entries; this is the corrected mapping:
+#   Q4316268    → fraktionslos  (NOT "BSW", as the raw source list labelled it)
+#   Q127785176  → bsw           (the actual BSW group, WP21)
+# An EMPTY faction.wid (ministers / president) is intentionally absent — it must
+# fall back to an MdB match or `unbekannt` in the mapper, NEVER a real party.
+_OP_FACTION_SLUG_MAP: dict[str, str] = {
+    "Q1023134": "cdu",
+    "Q2207512": "spd",
+    "Q1007353": "gruene",
+    "Q1387991": "fdp",
+    "Q1826856": "linke",
+    "Q42575708": "afd",
+    "Q4316268": "fraktionslos",
+    "Q127785176": "bsw",
+}

--- a/ai-backend/src/ingestion/connectors/openparliament_tv/constants.py
+++ b/ai-backend/src/ingestion/connectors/openparliament_tv/constants.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/src/ingestion/connectors/openparliament_tv/mappers/__init__.py
+++ b/ai-backend/src/ingestion/connectors/openparliament_tv/mappers/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""openparliament_tv mappers package.
+
+Mirrors connectors/bundestag_speeches/mappers/: pure transforms that turn a
+parsed source item into ``ChunkRecord`` instances (no embeddings, no I/O).
+
+  corpus.py — build_chunk_records, op_party_slug
+"""

--- a/ai-backend/src/ingestion/connectors/openparliament_tv/mappers/__init__.py
+++ b/ai-backend/src/ingestion/connectors/openparliament_tv/mappers/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/src/ingestion/connectors/openparliament_tv/mappers/corpus.py
+++ b/ai-backend/src/ingestion/connectors/openparliament_tv/mappers/corpus.py
@@ -1,0 +1,322 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""Pure corpus mapper for the openparliament_tv connector.
+
+Turns ONE raw op session ``data[]`` item (JSON:API shape) into exactly ONE
+whole-speech ``ChunkRecord``: the timed sentence map, the video deep-link
+payload, the shared cross-source ``speech_key``, and a change-aware
+``content_hash``.
+
+Structural analog: ``connectors/bundestag_speeches/mappers/corpus.py``. op keeps
+the same ``ChunkRecord`` envelope but differs on:
+  - ``authority_tier = FACTUAL_RECORD`` (DIP uses ``SELF_REPORTED``);
+  - ``source = "op"`` (the discriminator; DIP writes ``"dip"``);
+  - a video-timestamped ``citation_url`` (``videoFileURI#t={ts_start}``);
+  - its OWN ``source_item_id`` derived from ``originMediaID`` — DISTINCT point IDs
+    from DIP (coexist dedups on ``speech_key``, NOT shared point IDs);
+  - a ``content_hash`` over text + sentence_map + video_uri + aligned + faction so
+    a re-alignment / transcript correction re-writes the chunk.
+
+Chunking reuses the DIP ``chunk_text`` VERBATIM (imported, not re-implemented) so
+op and DIP share identical ≤6000-tok ``cl100k_base`` semantics. A normal
+Bundestag speech is a single chunk.
+
+Party resolution:
+  - ``faction.wid`` → the CORRECTED ``_OP_FACTION_SLUG_MAP`` slug;
+  - an EMPTY ``faction.wid`` (minister / president) → MdB-Stammdaten by-name
+    fallback → ``party_to_slug`` → else ``"unbekannt"`` (NEVER empty → a real party);
+  - CSU refinement: when the faction slug is the joint ``"cdu"`` and the per-speaker
+    MdB entry resolves to ``csu``, refine to ``csu`` (tenant parity with DIP / AW).
+
+``external_id`` is intentionally left unset here — the connector's ``normalize()``
+stamps ``YYYYMMDD(dateStart)`` via ``model_copy`` (mirroring DIP).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from datetime import date as date_type
+from typing import Optional
+
+from src.ingestion.connectors.bundestag_speeches.mappers.corpus import (
+    chunk_text,
+    party_to_slug,
+)
+from src.ingestion.connectors.bundestag_speeches.mdb import mdb_party_for_speech
+from src.ingestion.connectors.openparliament_tv.constants import _OP_FACTION_SLUG_MAP
+from src.ingestion.connectors.openparliament_tv.parser import (
+    _first_proceedings,
+    _flatten_sentences,
+    _main_speaker,
+)
+from src.ingestion.connectors.openparliament_tv.schemas import OpSpeechMeta
+from src.ingestion.ids import compute_source_item_id, make_chunk_key
+from src.ingestion.schemas import AuthorityTier, ChunkRecord, SourceType
+from src.ingestion.speech_key import (
+    agenda_slug_from_official,
+    make_speech_key,
+    slugify_speaker,
+)
+
+_corpus_logger = logging.getLogger(__name__)
+
+# Connector discriminator stamped on every op chunk. Drives the
+# source-scoped cursor (run.py::get_cursor) and the op supersede /
+# DIP resurrection-guard filters, both keyed on speech_key + source.
+_OP_SOURCE = "op"
+
+# Data-source attribution label rendered by the app (ODbL).
+_OP_SOURCE_DATA = "openparliament.tv (ODbL)"
+
+# Empty MdB lookup shape so subscript access in mdb.py never KeyErrors when the
+# caller passes no lookup (or an empty dict, e.g. unit tests).
+_EMPTY_MDB_LOOKUP: dict = {"by_id": {}, "by_name": {}}
+
+
+def _normalize_mdb_lookup(mdb_lookup: Optional[dict]) -> dict:
+    """Return a lookup that always exposes ``by_id`` / ``by_name`` keys."""
+    if not mdb_lookup or "by_name" not in mdb_lookup or "by_id" not in mdb_lookup:
+        return _EMPTY_MDB_LOOKUP
+    return mdb_lookup
+
+
+def _mdb_party_for_op_person(person: dict, mdb_lookup: dict) -> Optional[str]:
+    """Resolve the speaker's party from MdB-Stammdaten via the by-name path.
+
+    op's ``people[].wid`` is a Wikidata id, NOT the MdB numeric id, so the by-id
+    path cannot match — we resolve by full name only. Reuses the DIP
+    ``mdb_party_for_speech`` (by_name) by synthesising a speech-shaped dict.
+    """
+    lookup = _normalize_mdb_lookup(mdb_lookup)
+    if lookup is _EMPTY_MDB_LOOKUP:
+        return None
+
+    firstname = person.get("firstname") or ""
+    lastname = person.get("lastname") or ""
+    name = f"{firstname} {lastname}".strip() or (person.get("label") or "")
+    if not name:
+        return None
+
+    return mdb_party_for_speech({"speaker_xml_id": None, "speaker_name": name}, lookup)
+
+
+def op_party_slug(person: dict, mdb_lookup: Optional[dict]) -> str:
+    """Resolve a canonical party slug for an op main-speaker person dict.
+
+    Order:
+      1. non-empty ``faction.wid`` → ``_OP_FACTION_SLUG_MAP`` (CORRECTED map);
+         unknown wid → ``"unbekannt"``;
+         a joint ``"cdu"`` slug is refined to ``"csu"`` when the per-speaker MdB
+         entry resolves to CSU;
+      2. empty ``faction.wid`` (minister / president) → MdB by-name fallback →
+         ``party_to_slug`` → else ``"unbekannt"``.
+
+    An empty faction NEVER maps to a real party via the faction map — only via a
+    genuine per-speaker MdB match.
+    """
+    faction = person.get("faction") or {}
+    wid = (faction.get("wid") or "").strip()
+
+    if wid:
+        slug = _OP_FACTION_SLUG_MAP.get(wid, "unbekannt")
+        # CSU refinement: joint Union label may hide an individual CSU member.
+        if slug == "cdu":
+            mdb_party = _mdb_party_for_op_person(person, mdb_lookup or {})
+            if mdb_party is not None and party_to_slug(mdb_party) == "csu":
+                return "csu"
+        return slug
+
+    # Empty faction → MdB fallback → unbekannt (never empty → a real party).
+    mdb_party = _mdb_party_for_op_person(person, mdb_lookup or {})
+    if mdb_party is not None:
+        return party_to_slug(mdb_party)
+    return "unbekannt"
+
+
+def _iso_date(date_start: Optional[str]) -> str:
+    """Return the ``YYYY-MM-DD`` prefix of an op ISO datetime (``dateStart``)."""
+    return str(date_start or "")[:10]
+
+
+def build_chunk_records(
+    item: dict, mdb_lookup: Optional[dict] = None
+) -> list[ChunkRecord]:
+    """Build ChunkRecord(s) for ONE raw op session ``data[]`` item.
+
+    Applies the usability gate directly on the raw item: an unaligned item or
+    one without a ``proceedings`` transcript yields ``[]`` (the connector treats an
+    empty result as a skip). A usable item yields exactly one whole-speech chunk
+    (or more only if the speech exceeds the shared ``chunk_text`` token budget).
+
+    Args:
+        item:       Raw op JSON:API speech item (keys: media, textContents, people,
+                    agendaItem, electoralPeriod, session, dateStart, ...).
+        mdb_lookup: MdB-Stammdaten lookup (``{by_id, by_name}``) for the empty-faction
+                    / CSU fallback. Optional — an absent lookup degrades to ``unbekannt``.
+
+    Returns:
+        List of ChunkRecord (one per token chunk). ``[]`` for unusable items.
+    """
+    media = item.get("media") or {}
+
+    # --- usability gate (mirrors parser.parse_session_json) ---
+    if not media.get("aligned"):
+        return []
+    proceedings = _first_proceedings(item.get("textContents", []))
+    if proceedings is None:
+        return []
+
+    origin_media_id = media.get("originMediaID")
+    ext = str(origin_media_id) if origin_media_id is not None else ""
+
+    whole_text, sentence_map = _flatten_sentences(proceedings, ext)
+    if not whole_text.strip():
+        return []
+
+    # --- speaker / party ---
+    person = _main_speaker(item.get("people", []))
+    faction = person.get("faction") or {}
+    faction_wid = faction.get("wid") or ""
+    party_slug = op_party_slug(person, mdb_lookup)
+
+    firstname = person.get("firstname")
+    lastname = person.get("lastname")
+    speaker_name = person.get("label") or " ".join(
+        part for part in (firstname, lastname) if part
+    )
+    speaker_wid = person.get("wid")
+
+    # --- session / agenda context ---
+    electoral_period = item.get("electoralPeriod") or {}
+    session_info = item.get("session") or {}
+    ep = electoral_period.get("number")
+    session_number = session_info.get("number")
+
+    agenda = item.get("agendaItem") or {}
+    agenda_title = agenda.get("title")
+    agenda_official = agenda.get("officialTitle")
+    agenda_type = agenda.get("type")
+
+    date_start = item.get("dateStart")
+    iso_date = _iso_date(date_start)
+
+    # --- publish_date: strict ISO parse (no eval / strptime); skip on malformed ---
+    try:
+        publish_date = date_type.fromisoformat(iso_date)
+    except (ValueError, TypeError):
+        _corpus_logger.warning(
+            "op build_chunk_records: speech %r has unparseable dateStart %r — skipping.",
+            ext,
+            date_start,
+        )
+        return []
+
+    # --- shared cross-source speech_key (byte-parity with DIP via the shared helper) ---
+    speaker_slug = slugify_speaker(firstname=firstname, lastname=lastname)
+    agenda_slug = agenda_slug_from_official(agenda_official, agenda_type)
+    speech_key: Optional[str]
+    if ep is not None and session_number is not None:
+        try:
+            speech_key = make_speech_key(
+                ep=int(ep),
+                session=int(session_number),
+                speaker_slug=speaker_slug,
+                agenda_slug=agenda_slug,
+            )
+        except (TypeError, ValueError):
+            speech_key = None
+    else:
+        speech_key = None
+
+    # --- media deep-link payload ---
+    video_uri = media.get("videoFileURI")
+    audio_uri = media.get("audioFileURI")
+    source_page = media.get("sourcePage")
+
+    # --- citation: coarse video deep-link (second-pass locator refines later) ---
+    citation_title = f"{speaker_name}, {iso_date} (Video, {agenda_official})"
+    # Only build the #t= deep-link when video_uri is truthy. The alignment gate
+    # checks aligned/proceedings, NOT videoFileURI, so video_uri may be None even
+    # for an aligned item — an unguarded f-string would store the literal
+    # "None#t=12.5" as the source url. Fall back to the source page instead.
+    if video_uri and sentence_map:
+        citation_url: Optional[str] = f"{video_uri}#t={sentence_map[0]['ts_start']}"
+    else:
+        citation_url = source_page or None
+
+    # --- source-owned nested metadata ---
+    meta = OpSpeechMeta(
+        video_uri=video_uri,
+        audio_uri=audio_uri,
+        source_page=source_page,
+        origin_media_id=ext or None,
+        agenda_item_title=agenda_title,
+        agenda_item_official=agenda_official,
+        speaker_wid=speaker_wid,
+        speaker_name=speaker_name or None,
+        transcript_type="proceedings",
+        aligned=True,
+        sentence_map=sentence_map or None,
+        creator=media.get("creator"),
+        license=media.get("license"),
+        source_data=_OP_SOURCE_DATA,
+    ).model_dump(mode="json", exclude_none=True)
+
+    # --- change-aware content_hash: re-alignment / correction re-writes the chunk ---
+    content_hash = hashlib.sha256(
+        json.dumps(
+            {
+                "text": whole_text,
+                "sentence_map": sentence_map,
+                "video_uri": video_uri,
+                "aligned": True,
+                "faction_wid": faction_wid,
+                # Include the RESOLVED party slug (indexed tenant field).
+                # The empty-faction MdB-by-name fallback and the CSU refinement can
+                # change party_id WITHOUT changing faction_wid; without this the
+                # content-hash re-write guard (run.py) would keep the stale tenant.
+                "party_slug": party_slug,
+            },
+            sort_keys=True,
+            ensure_ascii=False,
+        ).encode("utf-8")
+    ).hexdigest()
+
+    # --- deterministic op-OWN point identity (source="op" keeps it structurally
+    # distinct from the DIP twin, which shares source_type but not id space) ---
+    source_item_id = compute_source_item_id("parliamentary_speech", ext, source="op")
+
+    wahlperiode: Optional[int] = int(ep) if ep is not None else None
+
+    text_chunks = chunk_text(whole_text)
+
+    records: list[ChunkRecord] = []
+    for chunk_index, chunk_str in enumerate(text_chunks):
+        chunk_key = make_chunk_key(source_item_id, chunk_index)
+        records.append(
+            ChunkRecord(
+                chunk_key=chunk_key,
+                source_item_id=source_item_id,
+                chunk_index=chunk_index,
+                text=chunk_str,
+                party_id=party_slug,
+                region="DE",
+                authority_tier=AuthorityTier.FACTUAL_RECORD,
+                source_type=SourceType.PARLIAMENTARY_SPEECH,
+                publish_date=publish_date,
+                citation_url=citation_url,
+                citation_title=citation_title,
+                # external_id intentionally NOT set — connector.normalize() stamps YYYYMMDD.
+                wahlperiode=wahlperiode,
+                speech_key=speech_key,
+                source=_OP_SOURCE,
+                content_hash=content_hash,
+                meta=meta or None,
+            )
+        )
+
+    return records

--- a/ai-backend/src/ingestion/connectors/openparliament_tv/mappers/corpus.py
+++ b/ai-backend/src/ingestion/connectors/openparliament_tv/mappers/corpus.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -267,6 +267,13 @@ def build_chunk_records(
     ).model_dump(mode="json", exclude_none=True)
 
     # --- change-aware content_hash: re-alignment / correction re-writes the chunk ---
+    # Beyond text/timing/video, the hash covers the cross-source IDENTITY and the
+    # displayed citation/provenance: speech_key (the dedup key the supersede pass
+    # and resurrection guard filter on), speaker name/Wikidata id, agenda labels,
+    # source_page, and the emitted citation URL/title. A metadata-only upstream
+    # correction (fixed speaker attribution, renamed agenda item) must re-write
+    # the stored point — a field the user sees or dedup keys on that the hash
+    # ignores could never be refreshed.
     content_hash = hashlib.sha256(
         json.dumps(
             {
@@ -280,6 +287,14 @@ def build_chunk_records(
                 # change party_id WITHOUT changing faction_wid; without this the
                 # content-hash re-write guard (run.py) would keep the stale tenant.
                 "party_slug": party_slug,
+                "speech_key": speech_key,
+                "speaker_name": speaker_name,
+                "speaker_wid": speaker_wid,
+                "agenda_official": agenda_official,
+                "agenda_title": agenda_title,
+                "source_page": source_page,
+                "citation_url": citation_url,
+                "citation_title": citation_title,
             },
             sort_keys=True,
             ensure_ascii=False,

--- a/ai-backend/src/ingestion/connectors/openparliament_tv/parser.py
+++ b/ai-backend/src/ingestion/connectors/openparliament_tv/parser.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""parse_session_json — op bulk session JSON → list of normalized speech dicts.
+
+Role analog: bundestag_speeches/parser.parse_speeches_from_xml (raw source →
+list-of-speech-dicts). Unlike the DIP parser this consumes JSON via the caller's
+``json.loads`` (the OpTvClient already parsed it) — there is NO XML entity surface
+here, so no XML hardening layer is imported.
+
+Applies the alignment gate: a speech is only usable when
+``media.aligned`` is truthy AND it has a ``proceedings`` transcript. Rather than
+raise, each un-usable item is returned carrying a non-empty ``skip_reason`` marker
+(mirroring the bundestag_speeches fetch→normalize skip_reason envelope); the
+connector's normalize() converts that marker into a ValueError-skip.
+
+For a usable item the parser flattens
+``textContents[type=proceedings].textBody[speakerstatus=main-speaker].sentences[]``
+into a timed ``sentence_map`` of ``{text, ts_start(float), ts_end(float)}``
+and joins the main-speaker text into ``whole_text``. A malformed ``timeStart`` /
+``timeEnd`` skips-and-warns that one sentence and never crashes the parse
+(input-validation / DoS mitigation).
+
+Public API:
+  parse_session_json(session: dict) -> list[dict]
+"""
+
+from __future__ import annotations
+
+import logging as _logging
+
+_parser_logger = _logging.getLogger(__name__)
+
+
+def _main_speaker(people: list) -> dict:
+    """Return the first person with ``context == 'main-speaker'`` (else {})."""
+    if not isinstance(people, list):
+        return {}
+    for person in people:
+        if isinstance(person, dict) and person.get("context") == "main-speaker":
+            return person
+    return {}
+
+
+def _first_proceedings(text_contents: list) -> dict | None:
+    """Return the first ``type == 'proceedings'`` textContents block (else None)."""
+    if not isinstance(text_contents, list):
+        return None
+    for block in text_contents:
+        if isinstance(block, dict) and block.get("type") == "proceedings":
+            return block
+    return None
+
+
+def _flatten_sentences(proceedings: dict, ext: str) -> tuple[str, list[dict]]:
+    """Flatten main-speaker textBody into (whole_text, sentence_map).
+
+    Drops president / interjection segments (speakerstatus != 'main-speaker').
+    A malformed timeStart/timeEnd skips-and-warns that sentence (never crashes).
+    """
+    main_bodies = [
+        tb
+        for tb in proceedings.get("textBody", [])
+        if isinstance(tb, dict) and tb.get("speakerstatus") == "main-speaker"
+    ]
+
+    whole_text = " ".join(str(tb.get("text", "")) for tb in main_bodies).strip()
+
+    sentence_map: list[dict] = []
+    for body in main_bodies:
+        for sentence in body.get("sentences", []) or []:
+            if not isinstance(sentence, dict):
+                continue
+            try:
+                ts_start = float(sentence["timeStart"])
+                ts_end = float(sentence["timeEnd"])
+            except (KeyError, TypeError, ValueError):
+                _parser_logger.warning(
+                    "op parse (%s): dropping sentence with malformed timeStart/timeEnd: %r",
+                    ext,
+                    sentence.get("text", "")[:60],
+                )
+                continue
+            sentence_map.append(
+                {
+                    "text": str(sentence.get("text", "")),
+                    "ts_start": ts_start,
+                    "ts_end": ts_end,
+                }
+            )
+
+    return whole_text, sentence_map
+
+
+def parse_session_json(session: dict) -> list[dict]:
+    """Parse an op bulk session JSON dict into a list of normalized speech dicts.
+
+    One dict per ``data[]`` item. Un-usable items (unaligned or ASR-only) carry a
+    non-empty ``skip_reason`` and expose their id only under ``ext`` (never under
+    ``origin_media_id``), so downstream consumers count exactly the usable speeches.
+    Usable (aligned+proceedings) items carry ``origin_media_id``, ``whole_text``, a
+    timed ``sentence_map``, and the raw fields the corpus mapper needs.
+
+    Args:
+        session: Parsed session JSON (JSON:API `{"meta": ..., "data": [...]}` shape).
+
+    Returns:
+        List of normalized speech dicts (usable + skipped).
+    """
+    speeches: list[dict] = []
+
+    for item in session.get("data", []) or []:
+        if not isinstance(item, dict):
+            continue
+
+        media = item.get("media") or {}
+        origin_media_id = media.get("originMediaID")
+        ext = str(origin_media_id) if origin_media_id is not None else ""
+
+        electoral_period = item.get("electoralPeriod") or {}
+        session_info = item.get("session") or {}
+        ep = electoral_period.get("number")
+        session_number = session_info.get("number")
+
+        # --- alignment gate: unaligned → skippable (re-evaluate in the lookback window). ---
+        if not media.get("aligned"):
+            speeches.append(
+                {
+                    "ext": ext,
+                    "skip_reason": f"{ext}: not aligned yet — re-evaluate later",
+                    "ep": ep,
+                    "session": session_number,
+                }
+            )
+            continue
+
+        # --- alignment gate: no proceedings transcript (ASR-only 'generated') → skippable. ---
+        proceedings = _first_proceedings(item.get("textContents", []))
+        if proceedings is None:
+            speeches.append(
+                {
+                    "ext": ext,
+                    "skip_reason": f"{ext}: no proceedings transcript",
+                    "ep": ep,
+                    "session": session_number,
+                }
+            )
+            continue
+
+        # --- usable: aligned + proceedings main-speaker text ---
+        whole_text, sentence_map = _flatten_sentences(proceedings, ext)
+
+        person = _main_speaker(item.get("people", []))
+        faction = person.get("faction") or {}
+        agenda = item.get("agendaItem") or {}
+
+        speeches.append(
+            {
+                "ext": ext,
+                "skip_reason": None,
+                # identity the downstream helper/mapper keys on
+                "origin_media_id": ext,
+                # transcript
+                "whole_text": whole_text,
+                "sentence_map": sentence_map,
+                "transcript_type": "proceedings",
+                "aligned": True,
+                # session context
+                "parliament": item.get("parliament"),
+                "ep": ep,
+                "session": session_number,
+                "date_start": item.get("dateStart"),
+                # agenda
+                "agenda_title": agenda.get("title"),
+                "agenda_official": agenda.get("officialTitle"),
+                "agenda_type": agenda.get("type"),
+                # media deep-link payload (stored, NEVER fetched during ingest)
+                "video_uri": media.get("videoFileURI"),
+                "audio_uri": media.get("audioFileURI"),
+                "source_page": media.get("sourcePage"),
+                "creator": media.get("creator"),
+                "license": media.get("license"),
+                # speaker
+                "faction_wid": faction.get("wid"),
+                "speaker_wid": person.get("wid"),
+                "firstname": person.get("firstname"),
+                "lastname": person.get("lastname"),
+                "speaker_label": person.get("label"),
+            }
+        )
+
+    return speeches

--- a/ai-backend/src/ingestion/connectors/openparliament_tv/parser.py
+++ b/ai-backend/src/ingestion/connectors/openparliament_tv/parser.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/src/ingestion/connectors/openparliament_tv/schemas.py
+++ b/ai-backend/src/ingestion/connectors/openparliament_tv/schemas.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""Source-owned metadata model for the openparliament_tv connector.
+
+`OpSpeechMeta` holds the video/audio/timestamp payload that is specific to op
+speeches (the sentence-level timed map + media deep-link URIs + Bundestag/ODbL
+attribution). It is dumped into `ChunkRecord.meta` via
+``model_dump(mode="json", exclude_none=True)`` by the corpus mapper, so
+absent fields never reach Qdrant as NULLs.
+
+Design mirrors ingestion.schemas.SpeechMeta:
+  - ``model_config = ConfigDict(frozen=True, extra="forbid")`` — an unexpected key
+    raises a ValidationError (input-validation / DoS mitigation: op JSON
+    is validated through this model rather than trusted blind).
+  - All fields Optional with descriptions; the mapper populates what the source
+    provides and lets ``exclude_none=True`` drop the rest.
+
+None of these fields are Qdrant-indexed — they belong in ``meta`` per the envelope
+philosophy (indexed filters stay top-level on ChunkRecord; descriptive/source
+payload lives in the nested meta object).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class OpSpeechMeta(BaseModel):
+    """Source-owned nested metadata for openparliament.tv parliamentary_speech chunks.
+
+    Carries the video deep-link payload and the timed sentence map that the
+    second-pass citation locator (chat_service.py) uses to build
+    ``video_uri#t={ts_start}`` links, plus Bundestag/ODbL attribution.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    # --- media deep-link payload (stored as strings; NEVER fetched during ingest) ---
+    video_uri: Optional[str] = Field(
+        None,
+        description="Source-supplied video file URI (media.videoFileURI); deep-link base",
+    )
+    audio_uri: Optional[str] = Field(
+        None, description="Source-supplied audio file URI (media.audioFileURI)"
+    )
+    source_page: Optional[str] = Field(
+        None,
+        description="Human-facing source page (media.sourcePage, e.g. dbtg.tv/fvid/...)",
+    )
+    origin_media_id: Optional[str] = Field(
+        None,
+        description="Bundestag origin media id (media.originMediaID); op's stable speech id",
+    )
+
+    # --- agenda context ---
+    agenda_item_title: Optional[str] = Field(
+        None, description="Human-readable agenda item title (agendaItem.title)"
+    )
+    agenda_item_official: Optional[str] = Field(
+        None,
+        description="Official agenda item label (agendaItem.officialTitle, e.g. 'Tagesordnungspunkt 20')",
+    )
+
+    # --- speaker identity ---
+    speaker_wid: Optional[str] = Field(
+        None, description="Wikidata person id of the main speaker (people[].wid)"
+    )
+    speaker_name: Optional[str] = Field(
+        None, description="Full name / label of the main speaker (people[].label)"
+    )
+
+    # --- transcript provenance / alignment gate outcome ---
+    transcript_type: Optional[str] = Field(
+        None, description="Transcript kind on the ingested chunk — always 'proceedings'"
+    )
+    aligned: Optional[bool] = Field(
+        None, description="Video-alignment flag — always True on ingested chunks"
+    )
+
+    # --- the timed sentence map (video deep-link source) ---
+    sentence_map: Optional[list[dict]] = Field(
+        None,
+        description=(
+            "Flattened, ordered list of {text, ts_start, ts_end} for each main-speaker "
+            "sentence; ts values are per-speech-relative seconds cast to float."
+        ),
+    )
+
+    # --- attribution the app can later render (ODbL / Bundestag) ---
+    creator: Optional[str] = Field(
+        None, description="Content creator for attribution (e.g. 'Deutscher Bundestag')"
+    )
+    license: Optional[str] = Field(
+        None,
+        description="License string for attribution (e.g. Bundestag Nutzungsbedingungen)",
+    )
+    source_data: Optional[str] = Field(
+        None,
+        description="Data-source attribution label (e.g. 'openparliament.tv (ODbL)')",
+    )
+
+    # --- DIP transcript cross-link (grafted post-upsert, not set at ingest) ---
+    transcript_pdf_url: Optional[str] = Field(
+        None,
+        description=(
+            "PDF URL of the official DIP plenary-protocol transcript for the SAME "
+            "speech (matched on speech_key). Grafted onto the surviving op record by "
+            "supersede_dip_duplicates so one speech source exposes BOTH the video "
+            "deep-link and the transcript PDF. None at ingest / when no DIP "
+            "counterpart exists."
+        ),
+    )

--- a/ai-backend/src/ingestion/connectors/openparliament_tv/schemas.py
+++ b/ai-backend/src/ingestion/connectors/openparliament_tv/schemas.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/src/ingestion/connectors/openparliament_tv/supersede.py
+++ b/ai-backend/src/ingestion/connectors/openparliament_tv/supersede.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+op→DIP supersede policy — owned by the openparliament_tv connector.
+
+Relocated from the generic runner (run.py): the "op supersedes its DIP twin"
+merge is source-specific policy, not framework behavior. The runner now exposes
+a neutral ``BaseConnector.post_upsert`` hook; ``OpenParliamentTvConnector``
+implements it by calling :func:`supersede_dip_duplicates` for each just-upserted
+op item. Every other connector inherits the no-op hook.
+
+CONCURRENCY HAZARD: the DIP (bundestag_speeches) and op schedules MUST be
+serialized — never run both connectors concurrently. Interleaving
+"DIP resurrection-guard passes → op ingests+supersedes → DIP commits" strands a
+DIP twin whose source_item_id never appears in either connector's later
+new-chunk/orphan filters (op present-skips the session; DIP present-skips the
+protocol). Mitigation implemented in addition to this doctrine: the DIP
+connector's normalize() reports the siids it SKIPPED as op-superseded
+(``last_superseded_siids``) and run_connector deletes any stored points under
+them, so a stranded twin self-heals on the next serialized DIP run.
+"""
+
+from __future__ import annotations
+
+import difflib
+import sys
+
+from qdrant_client import QdrantClient, models
+
+from src.ingestion.connector import BaseConnector
+from src.ingestion.schemas import ChunkRecord
+
+# Shared with the DIP resurrection guard: a DIP twin is superseded only
+# when its normalized text matches the op speech at/above this ratio — see the
+# rationale in src/ingestion/speech_dedup.py.
+from src.ingestion.speech_dedup import (
+    SUPERSEDE_TEXT_MATCH_RATIO as _SUPERSEDE_TEXT_MATCH_RATIO,
+)
+from src.ingestion.speech_dedup import norm_speech_text as _norm_speech_text
+
+
+def _join_indexed_texts(texts: list[tuple[int, str]]) -> str:
+    """Join (chunk_index, text) pairs in chunk_index order.
+
+    A 2+-chunk speech scrolled out of order would otherwise concatenate as
+    "B+A" and SequenceMatcher("A+B", "B+A") ≈ 0.5 < 0.85 — a silent supersede
+    miss followed by a resurrection-guard re-insert.
+    """
+    return " ".join(t for _idx, t in sorted(texts, key=lambda pair: pair[0]))
+
+
+def supersede_dip_duplicates(
+    qdrant: QdrantClient,
+    collection_name: str,
+    op_chunks: list[ChunkRecord],
+    *,
+    connector: BaseConnector,
+) -> int:
+    """Merge the true DIP twin into an op speech, then delete ONLY that twin.
+
+    NARROW, op-gated hook: fires ONLY when ``getattr(connector, "source", None) == "op"``.
+    Called per just-upserted op item (all chunks of ONE op speech), so exactly one
+    op speech is superseding here; the ambiguity is only ever on the DIP side.
+
+    ``speech_key`` (``de-{ep}-{session}-{speaker}-{agenda}``) is NOT unique per
+    speech and there is no exact shared op↔DIP id, so the old
+    "delete every DIP row whose speech_key op just ingested" would delete a
+    DISTINCT DIP speech that merely shares the key (a speaker's second turn under
+    the same agenda item that op did NOT align) — a permanent grounding loss.
+    Instead we identify the true twin by TEXT: the op speech carries the full
+    proceedings text, so its genuine DIP twin is the same-key DIP speech whose
+    normalized text matches (``ratio >= _SUPERSEDE_TEXT_MATCH_RATIO``). Distinct
+    same-key DIP speeches score far lower and are left untouched.
+
+    Per matched twin it then:
+      1. **Grafts the transcript PDF** — copies the DIP twin's ``citation_url``
+         (the plenary-protocol PDF) onto THIS op record (matched precisely on the
+         op ``source_item_id``) as ``meta.transcript_pdf_url``, durably (wait=True)
+         BEFORE the delete, so a crash can never lose the PDF with its source gone.
+      2. **Deletes the DIP twin** by its ``source_item_id`` (all its chunks) —
+         never by the shared, non-unique speech_key.
+
+    Non-op / no-source connectors return 0 immediately (every other connector runs
+    byte-for-byte unchanged). Returns the number of DIP twins superseded.
+
+    Args:
+        qdrant:          Initialised QdrantClient.
+        collection_name: Target Qdrant collection.
+        op_chunks:       The just-upserted op ChunkRecords (all chunks of one op
+                         speech; may be several for a long speech).
+        connector:       The connector being run — used only for the op source-gate.
+    """
+    if getattr(connector, "source", None) != "op":
+        return 0
+
+    # Group the just-upserted op chunks into distinct op speeches (by source_item_id),
+    # each with its speech_key and full concatenated text.
+    # ChunkRecord.source_item_id is a uuid.UUID — key by str(sid) consistently so the
+    # downstream MatchValue graft filter (which accepts only bool/int/str) never
+    # receives a raw UUID (that ValidationError silently disabled the merge forever:
+    # the per-item except fired AFTER the upsert, so the next run present-skipped).
+    op_speeches: dict[str, dict] = {}
+    for chunk in op_chunks:
+        # op_chunks are real ChunkRecord instances; every field below is declared
+        # on the model, so plain attribute access is correct (getattr would only
+        # imply a dict-like path that does not exist here).
+        key = chunk.speech_key
+        sid = chunk.source_item_id
+        if key is None or sid is None:
+            continue
+        entry = op_speeches.setdefault(str(sid), {"key": key, "texts": []})
+        entry["texts"].append((chunk.chunk_index or 0, chunk.text or ""))
+    if not op_speeches:
+        return 0
+
+    keys = sorted({e["key"] for e in op_speeches.values()})
+
+    # Collect DIP candidates under those keys, grouped into distinct DIP speeches
+    # (by source_item_id, stringified — stored payloads serialize it to str) with
+    # their (chunk_index, text) pairs + protocol-PDF citation_url. chunk_index is
+    # fetched so a multi-chunk speech joins in chunk order, not scroll order.
+    dip_speeches: dict[str, dict] = {}
+    next_offset = None
+    while True:
+        points, next_offset = qdrant.scroll(
+            collection_name=collection_name,
+            scroll_filter=models.Filter(
+                must=[
+                    models.FieldCondition(
+                        key="speech_key", match=models.MatchAny(any=keys)
+                    ),
+                    models.FieldCondition(
+                        key="source", match=models.MatchValue(value="dip")
+                    ),
+                ]
+            ),
+            with_payload=[
+                "speech_key",
+                "source_item_id",
+                "citation_url",
+                "text",
+                "chunk_index",
+            ],
+            with_vectors=False,
+            limit=256,
+            offset=next_offset,
+        )
+        for point in points:
+            payload = point.payload or {}
+            dsid = payload.get("source_item_id")
+            if dsid is None:
+                continue
+            entry = dip_speeches.setdefault(
+                str(dsid),
+                {
+                    "key": payload.get("speech_key"),
+                    "texts": [],
+                    "citation_url": payload.get("citation_url"),
+                },
+            )
+            entry["texts"].append(
+                (payload.get("chunk_index") or 0, payload.get("text") or "")
+            )
+        if next_offset is None:
+            break
+
+    # Match each op speech to its true DIP twin by normalized-text similarity.
+    graft_ops: list[tuple[str, str]] = []  # (op_source_item_id, pdf_url)
+    delete_dip_sids: list[str] = []
+    for op_sid, op in op_speeches.items():
+        op_norm = _norm_speech_text(_join_indexed_texts(op["texts"]))
+        if not op_norm:
+            continue
+        for dsid, dip in dip_speeches.items():
+            if dip["key"] != op["key"] or dsid in delete_dip_sids:
+                continue
+            dip_norm = _norm_speech_text(_join_indexed_texts(dip["texts"]))
+            if not dip_norm:
+                continue
+            ratio = difflib.SequenceMatcher(None, op_norm, dip_norm).ratio()
+            if ratio >= _SUPERSEDE_TEXT_MATCH_RATIO:
+                if dip["citation_url"]:
+                    # str() is load-bearing: MatchValue accepts only bool/int/str.
+                    graft_ops.append((str(op_sid), dip["citation_url"]))
+                delete_dip_sids.append(dsid)
+                break  # one op speech has at most one DIP twin
+
+    if not delete_dip_sids:
+        return 0
+
+    # 1. Graft each twin's transcript PDF onto its specific op record (by
+    #    source_item_id, not the shared key), durably before the delete.
+    if graft_ops:
+        qdrant.batch_update_points(
+            collection_name=collection_name,
+            update_operations=[
+                models.SetPayloadOperation(
+                    set_payload=models.SetPayload(
+                        payload={"transcript_pdf_url": pdf_url},
+                        key="meta",
+                        filter=models.Filter(
+                            must=[
+                                models.FieldCondition(
+                                    key="source_item_id",
+                                    match=models.MatchValue(value=op_sid),
+                                ),
+                                models.FieldCondition(
+                                    key="source", match=models.MatchValue(value="op")
+                                ),
+                            ]
+                        ),
+                    )
+                )
+                for op_sid, pdf_url in graft_ops
+            ],
+            wait=True,
+        )
+
+    # 2. Delete ONLY the matched DIP twins, by their source_item_id (all chunks).
+    #    Distinct same-key DIP speeches op did not match are never touched.
+    qdrant.delete(
+        collection_name=collection_name,
+        points_selector=models.FilterSelector(
+            filter=models.Filter(
+                must=[
+                    models.FieldCondition(
+                        key="source_item_id", match=models.MatchAny(any=delete_dip_sids)
+                    ),
+                    models.FieldCondition(
+                        key="source", match=models.MatchValue(value="dip")
+                    ),
+                ]
+            )
+        ),
+        wait=True,
+    )
+    # operator visibility on the merge + duplicate deletion.
+    print(
+        f"supersede: grafted DIP transcript PDF onto {len(graft_ops)} op speech(es), "
+        f"then deleted {len(delete_dip_sids)} matched DIP twin(s)",
+        file=sys.stderr,
+    )
+    return len(delete_dip_sids)

--- a/ai-backend/src/ingestion/connectors/openparliament_tv/supersede.py
+++ b/ai-backend/src/ingestion/connectors/openparliament_tv/supersede.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -179,7 +179,16 @@ def supersede_dip_duplicates(
             dip_norm = _norm_speech_text(_join_indexed_texts(dip["texts"]))
             if not dip_norm:
                 continue
-            ratio = difflib.SequenceMatcher(None, op_norm, dip_norm).ratio()
+            # autojunk=False is load-bearing: the default auto-junk heuristic
+            # treats characters occurring in >1% of a 200+-char sequence as
+            # junk, which on long normalized speech text collapses real twins
+            # to ratios far below the threshold (official 21/90 data: only
+            # 15/76 same-key pairs cleared 0.85 with autojunk on; all 76 score
+            # 0.92+ with it off). Must stay symmetric with the DIP
+            # resurrection guard's comparator.
+            ratio = difflib.SequenceMatcher(
+                None, op_norm, dip_norm, autojunk=False
+            ).ratio()
             if ratio >= _SUPERSEDE_TEXT_MATCH_RATIO:
                 if dip["citation_url"]:
                     # str() is load-bearing: MatchValue accepts only bool/int/str.

--- a/ai-backend/tests/ingestion/connectors/openparliament_tv/__init__.py
+++ b/ai-backend/tests/ingestion/connectors/openparliament_tv/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0

--- a/ai-backend/tests/ingestion/connectors/openparliament_tv/__init__.py
+++ b/ai-backend/tests/ingestion/connectors/openparliament_tv/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0

--- a/ai-backend/tests/ingestion/connectors/openparliament_tv/conftest.py
+++ b/ai-backend/tests/ingestion/connectors/openparliament_tv/conftest.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Shared pytest fixtures for the openparliament_tv connector test suite.
+
+Provides:
+  - session_json_text: raw text of the trimmed op bulk session-JSON fixture
+  - session_json:      json.loads(...) of the same fixture (JSON:API shape)
+
+The fixture loads from the local `fixtures/` directory — no I/O guard needed as
+it is a committed static file (not network or live-service dependent).
+
+Pattern mirrors tests/ingestion/connectors/bundestag_speeches/conftest.py:
+  _FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+Fixture content (`20101-session.trimmed.json`) — FOUR data[] speech items
+spanning every alignment branch:
+  (a) ALIGNED + `proceedings` CDU/CSU main speaker (faction.wid="Q1023134"),
+      officialTitle "Tagesordnungspunkt 20", EP 20 / session 101, first sentence
+      timeStart "1.000" (string, per-speech-relative seconds).
+  (b) UNALIGNED item (media.aligned=false, empty textContents).
+  (c) ASR-only item (media.aligned=true but textContents[0].type="generated").
+  (d) MINISTER item (aligned+proceedings, people[].faction.wid="") to exercise
+      the MdB / `unbekannt` fallback.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_FIXTURES_DIR = Path(__file__).parent / "fixtures"
+_SESSION_FIXTURE = _FIXTURES_DIR / "20101-session.trimmed.json"
+
+
+@pytest.fixture()
+def session_json_text() -> str:
+    """Return the raw text of the trimmed op bulk session-JSON fixture.
+
+    Used by parser/corpus/discover tests. Static committed file.
+    """
+    return _SESSION_FIXTURE.read_text(encoding="utf-8")
+
+
+@pytest.fixture()
+def session_json() -> dict[str, Any]:
+    """Return the parsed (json.loads) trimmed op bulk session-JSON fixture.
+
+    JSON:API shape `{"meta": {...}, "data": [<4 speech items>]}`.
+    """
+    return json.loads(_SESSION_FIXTURE.read_text(encoding="utf-8"))

--- a/ai-backend/tests/ingestion/connectors/openparliament_tv/conftest.py
+++ b/ai-backend/tests/ingestion/connectors/openparliament_tv/conftest.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/tests/ingestion/connectors/openparliament_tv/fixtures/20101-session.trimmed.json
+++ b/ai-backend/tests/ingestion/connectors/openparliament_tv/fixtures/20101-session.trimmed.json
@@ -1,0 +1,232 @@
+{
+  "meta": {
+    "source": "openparliament.tv bulk processed/20101-session.json (TRIMMED test fixture)",
+    "note": "Hand-authored subset of a real op session file. FOUR data[] speech items covering every transcript-alignment branch: (a) aligned+proceedings CDU/CSU main speaker, (b) unaligned, (c) ASR-only (generated), (d) minister with empty faction. Timestamps are per-speech-relative seconds as STRINGS (first sentence '1.000') exactly like the live bulk data.",
+    "parliament": "DE",
+    "electoralPeriod": 20,
+    "session": 101
+  },
+  "data": [
+    {
+      "parliament": "DE",
+      "electoralPeriod": { "number": 20 },
+      "session": { "number": 101, "dateStart": "2023-04-28T09:00:05+02:00", "dateEnd": "2023-04-28T14:30:00+02:00" },
+      "agendaItem": {
+        "title": "Stärkung der Aus- und Weiterbildungsförderung",
+        "officialTitle": "Tagesordnungspunkt 20",
+        "type": "regular"
+      },
+      "dateStart": "2023-04-28T10:12:00+02:00",
+      "dateEnd": "2023-04-28T10:18:30+02:00",
+      "media": {
+        "videoFileURI": "https://cldf-od.r53.cdn.tv1.eu/1000153copo/ondemand/app144277506/145293313/7553315/7553315_h264_1920_1080_5000kb_baseline_de_5000.mp4",
+        "audioFileURI": "https://cldf-od.r53.cdn.tv1.eu/1000153copo/ondemand/app144277506/145293313/7553315/7553315.mp3",
+        "sourcePage": "http://dbtg.tv/fvid/7553315",
+        "originMediaID": "7553315",
+        "duration": 390,
+        "creator": "Deutscher Bundestag",
+        "license": "&lt;a href=\"https://www.bundestag.de/nutzungsbedingungen\"&gt;Nutzungsbedingungen&lt;/a&gt;",
+        "aligned": true
+      },
+      "people": [
+        {
+          "type": "memberOfParliament",
+          "label": "Mareike Lotte Wulf",
+          "firstname": "Mareike Lotte",
+          "lastname": "Wulf",
+          "context": "main-speaker",
+          "faction": { "wid": "Q1023134", "label": "CDU/CSU", "wtype": "ORG" },
+          "wid": "Q41569156",
+          "wtype": "PERSON"
+        }
+      ],
+      "speechIndex": 3,
+      "textContents": [
+        {
+          "type": "proceedings",
+          "sourceURI": "https://de.openparliament.tv/api/v1/media/DE-0200101003",
+          "creator": "Deutscher Bundestag",
+          "license": "Public Domain",
+          "language": "de",
+          "originTextID": "DE-0200101003",
+          "textBody": [
+            {
+              "type": "speech",
+              "speaker": "Mareike Lotte Wulf",
+              "speakerstatus": "main-speaker",
+              "text": "Sehr geehrte Frau Präsidentin! Wir stärken die Aus- und Weiterbildungsförderung.",
+              "sentences": [
+                { "text": "Sehr geehrte Frau Präsidentin!", "timeStart": "1.000", "timeEnd": "2.800", "entities": [] },
+                { "text": "Wir stärken die Aus- und Weiterbildungsförderung.", "timeStart": "2.800", "timeEnd": "6.400", "entities": [] }
+              ]
+            },
+            {
+              "type": "comment",
+              "speaker": "Präsidentin",
+              "speakerstatus": "president",
+              "text": "(Beifall bei der CDU/CSU)",
+              "sentences": []
+            }
+          ]
+        }
+      ],
+      "documents": [],
+      "originalLanguage": "de"
+    },
+    {
+      "parliament": "DE",
+      "electoralPeriod": { "number": 20 },
+      "session": { "number": 101, "dateStart": "2023-04-28T09:00:05+02:00", "dateEnd": "2023-04-28T14:30:00+02:00" },
+      "agendaItem": {
+        "title": "Aktuelle Stunde zur Energiepolitik",
+        "officialTitle": "Tagesordnungspunkt 21",
+        "type": "regular"
+      },
+      "dateStart": "2023-04-28T11:05:00+02:00",
+      "dateEnd": "2023-04-28T11:12:00+02:00",
+      "media": {
+        "videoFileURI": "https://cldf-od.r53.cdn.tv1.eu/1000153copo/ondemand/app144277506/145293313/7553320/7553320_h264_1920_1080_5000kb_baseline_de_5000.mp4",
+        "audioFileURI": "https://cldf-od.r53.cdn.tv1.eu/1000153copo/ondemand/app144277506/145293313/7553320/7553320.mp3",
+        "sourcePage": "http://dbtg.tv/fvid/7553320",
+        "originMediaID": "7553320",
+        "duration": 420,
+        "creator": "Deutscher Bundestag",
+        "license": "&lt;a href=\"https://www.bundestag.de/nutzungsbedingungen\"&gt;Nutzungsbedingungen&lt;/a&gt;",
+        "aligned": false
+      },
+      "people": [
+        {
+          "type": "memberOfParliament",
+          "label": "Timon Gremmels",
+          "firstname": "Timon",
+          "lastname": "Gremmels",
+          "context": "main-speaker",
+          "faction": { "wid": "Q2207512", "label": "SPD", "wtype": "ORG" },
+          "wid": "Q1613538",
+          "wtype": "PERSON"
+        }
+      ],
+      "speechIndex": 7,
+      "textContents": [],
+      "documents": [],
+      "originalLanguage": "de"
+    },
+    {
+      "parliament": "DE",
+      "electoralPeriod": { "number": 20 },
+      "session": { "number": 101, "dateStart": "2023-04-28T09:00:05+02:00", "dateEnd": "2023-04-28T14:30:00+02:00" },
+      "agendaItem": {
+        "title": "Fragestunde",
+        "officialTitle": "Tagesordnungspunkt 22",
+        "type": "regular"
+      },
+      "dateStart": "2023-04-28T12:00:00+02:00",
+      "dateEnd": "2023-04-28T12:04:00+02:00",
+      "media": {
+        "videoFileURI": "https://cldf-od.r53.cdn.tv1.eu/1000153copo/ondemand/app144277506/145293313/7553330/7553330_h264_1920_1080_5000kb_baseline_de_5000.mp4",
+        "audioFileURI": "https://cldf-od.r53.cdn.tv1.eu/1000153copo/ondemand/app144277506/145293313/7553330/7553330.mp3",
+        "sourcePage": "http://dbtg.tv/fvid/7553330",
+        "originMediaID": "7553330",
+        "duration": 240,
+        "creator": "Deutscher Bundestag",
+        "license": "&lt;a href=\"https://www.bundestag.de/nutzungsbedingungen\"&gt;Nutzungsbedingungen&lt;/a&gt;",
+        "aligned": true
+      },
+      "people": [
+        {
+          "type": "memberOfParliament",
+          "label": "Peter Boehringer",
+          "firstname": "Peter",
+          "lastname": "Boehringer",
+          "context": "main-speaker",
+          "faction": { "wid": "Q42575708", "label": "AfD", "wtype": "ORG" },
+          "wid": "Q17123769",
+          "wtype": "PERSON"
+        }
+      ],
+      "speechIndex": 11,
+      "textContents": [
+        {
+          "type": "generated",
+          "sourceURI": "https://de.openparliament.tv/api/v1/media/DE-0200101011",
+          "creator": "openparliament.tv ASR",
+          "license": "Public Domain",
+          "language": "de",
+          "originTextID": "DE-0200101011-asr",
+          "textBody": [
+            {
+              "type": "speech",
+              "speaker": "Peter Boehringer",
+              "speakerstatus": "main-speaker",
+              "text": "Ich habe eine Frage an die Bundesregierung zur Haushaltslage.",
+              "sentences": [
+                { "text": "Ich habe eine Frage an die Bundesregierung zur Haushaltslage.", "timeStart": "1.000", "timeEnd": "5.200", "entities": [] }
+              ]
+            }
+          ]
+        }
+      ],
+      "documents": [],
+      "originalLanguage": "de"
+    },
+    {
+      "parliament": "DE",
+      "electoralPeriod": { "number": 20 },
+      "session": { "number": 101, "dateStart": "2023-04-28T09:00:05+02:00", "dateEnd": "2023-04-28T14:30:00+02:00" },
+      "agendaItem": {
+        "title": "Regierungserklärung zur Arbeitsmarktpolitik",
+        "officialTitle": "Tagesordnungspunkt 23",
+        "type": "regular"
+      },
+      "dateStart": "2023-04-28T13:00:00+02:00",
+      "dateEnd": "2023-04-28T13:10:00+02:00",
+      "media": {
+        "videoFileURI": "https://cldf-od.r53.cdn.tv1.eu/1000153copo/ondemand/app144277506/145293313/7553340/7553340_h264_1920_1080_5000kb_baseline_de_5000.mp4",
+        "audioFileURI": "https://cldf-od.r53.cdn.tv1.eu/1000153copo/ondemand/app144277506/145293313/7553340/7553340.mp3",
+        "sourcePage": "http://dbtg.tv/fvid/7553340",
+        "originMediaID": "7553340",
+        "duration": 600,
+        "creator": "Deutscher Bundestag",
+        "license": "&lt;a href=\"https://www.bundestag.de/nutzungsbedingungen\"&gt;Nutzungsbedingungen&lt;/a&gt;",
+        "aligned": true
+      },
+      "people": [
+        {
+          "type": "memberOfGovernment",
+          "label": "Hubertus Heil",
+          "firstname": "Hubertus",
+          "lastname": "Heil",
+          "context": "main-speaker",
+          "faction": { "wid": "", "label": "", "wtype": "ORG" },
+          "wid": "Q1636634",
+          "wtype": "PERSON"
+        }
+      ],
+      "speechIndex": 15,
+      "textContents": [
+        {
+          "type": "proceedings",
+          "sourceURI": "https://de.openparliament.tv/api/v1/media/DE-0200101015",
+          "creator": "Deutscher Bundestag",
+          "license": "Public Domain",
+          "language": "de",
+          "originTextID": "DE-0200101015",
+          "textBody": [
+            {
+              "type": "speech",
+              "speaker": "Hubertus Heil",
+              "speakerstatus": "main-speaker",
+              "text": "Als Bundesminister für Arbeit lege ich Ihnen die Eckpunkte vor. Wir schaffen sichere Arbeitsplätze.",
+              "sentences": [
+                { "text": "Als Bundesminister für Arbeit lege ich Ihnen die Eckpunkte vor.", "timeStart": "1.000", "timeEnd": "4.900", "entities": [] },
+                { "text": "Wir schaffen sichere Arbeitsplätze.", "timeStart": "4.900", "timeEnd": "7.300", "entities": [] }
+              ]
+            }
+          ]
+        }
+      ],
+      "documents": [],
+      "originalLanguage": "de"
+    }
+  ]
+}

--- a/ai-backend/tests/ingestion/connectors/openparliament_tv/test_client.py
+++ b/ai-backend/tests/ingestion/connectors/openparliament_tv/test_client.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/tests/ingestion/connectors/openparliament_tv/test_client.py
+++ b/ai-backend/tests/ingestion/connectors/openparliament_tv/test_client.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""OpTvClient._get_json fallback tests.
+
+Focus: on a persistent non-2xx the curl fallback error must carry the original
+HTTP status context (e.g. 404) so bulk-backfill failures are triageable. No
+network / no real curl — the requests.Session and curl_get are stubbed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+client_mod = pytest.importorskip(
+    "src.ingestion.connectors.openparliament_tv.client",
+    reason="op client not yet implemented",
+)
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+
+    def json(self) -> dict:  # pragma: no cover - not reached on non-200
+        return {}
+
+
+class _FakeSession:
+    """Always returns the same non-2xx response (drives the curl fallback)."""
+
+    def __init__(self, status_code: int) -> None:
+        self._status_code = status_code
+        self.headers = {}
+
+    def get(self, url: str, timeout: int = 60) -> _FakeResponse:
+        return _FakeResponse(self._status_code)
+
+
+def test_get_json_fallback_includes_http_status(monkeypatch) -> None:
+    """a 404 loop whose curl fallback also fails surfaces HTTP 404 in the error."""
+    op = client_mod.OpTvClient(sleep=0)
+    op.session = _FakeSession(404)
+
+    # curl fallback also fails → raises OpTvChallengeError with only stderr.
+    def _boom(url: str, accept: str = "*/*") -> str:
+        raise client_mod.OpTvChallengeError(
+            "curl: (22) The requested URL returned error"
+        )
+
+    monkeypatch.setattr(client_mod, "curl_get", _boom)
+    monkeypatch.setattr(client_mod.time, "sleep", lambda *_: None)
+
+    with pytest.raises(client_mod.OpTvChallengeError) as excinfo:
+        op._get_json(
+            "https://raw.githubusercontent.com/x/y/processed/20101-session.json"
+        )
+
+    msg = str(excinfo.value)
+    assert "404" in msg, f"fallback error must carry the HTTP status; got {msg!r}"
+    assert "curl fallback also failed" in msg
+
+
+def test_get_json_fallback_succeeds_when_curl_recovers(monkeypatch) -> None:
+    """A non-2xx whose curl fallback SUCCEEDS still returns parsed JSON (no regression)."""
+    op = client_mod.OpTvClient(sleep=0)
+    op.session = _FakeSession(503)
+
+    monkeypatch.setattr(
+        client_mod, "curl_get", lambda url, accept="*/*": '{"ok": true}'
+    )
+    monkeypatch.setattr(client_mod.time, "sleep", lambda *_: None)
+
+    assert op._get_json(
+        "https://raw.githubusercontent.com/x/y/processed/20101-session.json"
+    ) == {"ok": True}

--- a/ai-backend/tests/ingestion/connectors/openparliament_tv/test_corpus.py
+++ b/ai-backend/tests/ingestion/connectors/openparliament_tv/test_corpus.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Tests for openparliament_tv.mappers.corpus (idempotency).
+
+The module-under-test does not exist yet. The top-level
+`pytest.importorskip(...)` makes this whole file SKIP cleanly until the corpus
+mapper lands, at which point the real assertions run.
+
+Covers:
+  - test_one_chunk_and_sentence_map: exactly ONE ChunkRecord per aligned speech;
+    meta["sentence_map"] is a non-empty list of {text, ts_start(float), ts_end(float)}.
+  - test_faction_map: Q1023134→cdu, Q4316268→fraktionslos, Q127785176→bsw, empty→unbekannt.
+  - test_idempotent_ids: same speech twice → identical compute_chunk_id; a changed
+    transcript changes content_hash.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# SKIP until the op corpus mapper exists.
+corpus = pytest.importorskip(
+    "src.ingestion.connectors.openparliament_tv.mappers.corpus",
+    reason="op corpus mapper not yet implemented",
+)
+
+
+def _aligned_proceedings_items(session_json: dict) -> list[dict]:
+    """Return the fixture's two aligned+proceedings speech items."""
+    out = []
+    for item in session_json["data"]:
+        if not item["media"].get("aligned"):
+            continue
+        if not any(
+            tc.get("type") == "proceedings" for tc in item.get("textContents", [])
+        ):
+            continue
+        out.append(item)
+    return out
+
+
+def _build(item: dict):
+    """Call the mapper's speech→ChunkRecord builder, tolerant of the entry-point name."""
+    build = getattr(corpus, "build_chunk_records", None) or getattr(
+        corpus, "build_chunk_records_from_speech"
+    )
+    return build(item)
+
+
+def test_one_chunk_and_sentence_map(session_json: dict) -> None:
+    """ONE chunk per aligned speech + a timed sentence_map in meta."""
+    item = _aligned_proceedings_items(session_json)[0]
+    records = _build(item)
+    assert len(records) == 1, "op ingests exactly ONE whole-speech chunk"
+
+    meta = records[0].meta or {}
+    sentence_map = meta.get("sentence_map")
+    assert isinstance(sentence_map, list) and sentence_map, (
+        "meta.sentence_map must be non-empty"
+    )
+    for s in sentence_map:
+        assert set(s) >= {"text", "ts_start", "ts_end"}
+        assert isinstance(s["ts_start"], float)
+        assert isinstance(s["ts_end"], float)
+    # First sentence starts at the per-speech-relative 1.000s (string→float cast).
+    assert sentence_map[0]["ts_start"] == pytest.approx(1.0)
+
+
+def test_faction_map(session_json: dict) -> None:
+    """faction.wid → party slug, incl. the corrected BSW / Fraktionslos map.
+
+    Empty faction.wid (ministers/president) must fall back to `unbekannt`
+    (or an MdB match) — NEVER a real party.
+    """
+    slug_of = getattr(corpus, "op_party_slug", None) or getattr(
+        corpus, "party_slug_for_faction"
+    )
+
+    def _slug(wid: str) -> str:
+        return slug_of({"faction": {"wid": wid}}, {})
+
+    assert _slug("Q1023134") == "cdu"
+    assert (
+        _slug("Q4316268") == "fraktionslos"
+    )  # CORRECTED (was labelled BSW in source list)
+    assert _slug("Q127785176") == "bsw"  # CORRECTED (BSW group, WP21)
+    assert _slug("") == "unbekannt", "empty faction must never map to a real party"
+
+
+def test_content_hash_includes_party_slug(session_json: dict, monkeypatch) -> None:
+    """a party correction (same faction_wid) must change content_hash.
+
+    The empty-faction MdB fallback / CSU refinement can change the resolved
+    party_slug WITHOUT changing faction.wid. Since the runner's re-write guard
+    keys on content_hash, party_slug MUST be in the hash — otherwise a corrected
+    party would keep the stale (mis-tenanted) indexed party_id. Monkeypatching
+    op_party_slug changes ONLY the resolved slug; every other hashed input (text,
+    sentence_map, video_uri, faction_wid) comes from the identical item.
+    """
+    item = _aligned_proceedings_items(session_json)[0]
+
+    monkeypatch.setattr(corpus, "op_party_slug", lambda person, lookup: "cdu")
+    rec_cdu = _build(item)[0]
+
+    monkeypatch.setattr(corpus, "op_party_slug", lambda person, lookup: "csu")
+    rec_csu = _build(item)[0]
+
+    assert rec_cdu.party_id == "cdu" and rec_csu.party_id == "csu"
+    assert rec_cdu.content_hash != rec_csu.content_hash, (
+        "content_hash must change when the resolved party_slug changes"
+    )
+
+
+def test_citation_url_falls_back_when_video_uri_absent(session_json: dict) -> None:
+    """a None videoFileURI must NOT produce a literal 'None#t=...' url.
+
+    The alignment gate checks aligned/proceedings, not videoFileURI, so an aligned item
+    can still carry videoFileURI=None. The citation_url must then fall back to the
+    source page (or None) rather than the broken 'None#t=<ts>' string.
+    """
+    import copy
+
+    item = copy.deepcopy(_aligned_proceedings_items(session_json)[0])
+    item["media"]["videoFileURI"] = None
+    source_page = item["media"].get("sourcePage")
+
+    rec = _build(item)[0]
+
+    assert rec.citation_url is None or not rec.citation_url.startswith("None"), (
+        f"citation_url must not be a literal 'None#t=...' string; got {rec.citation_url!r}"
+    )
+    assert "#t=" not in (rec.citation_url or ""), (
+        "no deep-link fragment without a video uri"
+    )
+    assert rec.citation_url == (source_page or None)
+
+
+def test_idempotent_ids(session_json: dict) -> None:
+    """Same speech twice → identical chunk id; a changed transcript → changed content_hash."""
+    item = _aligned_proceedings_items(session_json)[0]
+
+    rec_a = _build(item)[0]
+    rec_b = _build(item)[0]
+
+    from src.ingestion.ids import compute_chunk_id
+
+    id_a = compute_chunk_id(rec_a.source_item_id, rec_a.chunk_index)
+    id_b = compute_chunk_id(rec_b.source_item_id, rec_b.chunk_index)
+    assert id_a == id_b, "re-running the same speech must yield the same point id"
+
+    # Mutate the transcript text → content_hash must change (change-aware re-upsert).
+    import copy
+
+    mutated = copy.deepcopy(item)
+    proceedings = next(
+        tc for tc in mutated["textContents"] if tc["type"] == "proceedings"
+    )
+    proceedings["textBody"][0]["text"] += " Zusätzlicher, korrigierter Satz."
+    rec_c = _build(mutated)[0]
+    assert rec_c.content_hash != rec_a.content_hash, (
+        "a changed transcript must change content_hash so the runner re-writes the chunk"
+    )

--- a/ai-backend/tests/ingestion/connectors/openparliament_tv/test_corpus.py
+++ b/ai-backend/tests/ingestion/connectors/openparliament_tv/test_corpus.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/tests/ingestion/connectors/openparliament_tv/test_discover.py
+++ b/ai-backend/tests/ingestion/connectors/openparliament_tv/test_discover.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -175,3 +175,43 @@ def test_same_date_sessions_both_discovered_and_fetchable() -> None:
     assert titles == {"Sitzung 101", "Sitzung 102"}, (
         "each handle must resolve to ITS OWN session's speeches"
     )
+
+
+def test_special_session_files_do_not_stop_discovery() -> None:
+    """The live tree lists special files (8xx/9xx session numbers) whose lexical
+    order is NOT chronological — e.g. `21902` months older than `21090`. A
+    newest-first early-stop over the raw basename order previously hit the old
+    special file first, broke immediately, and returned [] while current
+    regular sessions were pending."""
+    sessions = {
+        # Old special session — lexically HIGHEST basename.
+        "21902-session.json": _session("2026-02-23T09:00:00+01:00"),
+        # Current regular sessions (newer than the special, lexically lower).
+        "21089-session.json": _session("2026-07-09T09:00:00+02:00"),
+        "21090-session.json": _session("2026-07-10T09:00:00+02:00"),
+    }
+    conn = _make_connector(sessions)
+
+    # Cursor at 2026-07-10: the floor (since − LOOKBACK) is ~2026-05-11 — the
+    # special file is below it, the regular sessions are not.
+    discovered = conn.discover(since=20260710)
+
+    assert "21090-session.json" in discovered and "21089-session.json" in discovered, (
+        "current regular sessions must be discovered even though an OLD special "
+        f"file sorts lexically above them; got {discovered!r}"
+    )
+    assert "21902-session.json" not in discovered, (
+        "the below-floor special file itself stays excluded"
+    )
+
+
+def test_recent_special_session_is_discovered() -> None:
+    """A special file INSIDE the window is picked up (specials are always
+    fetched and floor-filtered individually, never early-stopped)."""
+    sessions = {
+        "21900-session.json": _session("2026-07-01T10:00:00+02:00"),
+        "21090-session.json": _session("2026-07-10T09:00:00+02:00"),
+    }
+    conn = _make_connector(sessions)
+    discovered = conn.discover(since=20260710)
+    assert "21900-session.json" in discovered

--- a/ai-backend/tests/ingestion/connectors/openparliament_tv/test_discover.py
+++ b/ai-backend/tests/ingestion/connectors/openparliament_tv/test_discover.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Tests for OpenParliamentTvConnector.discover() — basename enumeration + lookback
+and the descending early stop.
+
+The client contract is basenames only (``YYYYY-session.json``) — the former
+int/direct-ext fast path served only test fakes and was deleted; the
+fakes here return basenames, matching OpTvClient.list_session_files().
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# SKIP until the op connector exists.
+connector_mod = pytest.importorskip(
+    "src.ingestion.connectors.openparliament_tv.connector",
+    reason="op connector not yet implemented",
+)
+
+OpenParliamentTvConnector = getattr(connector_mod, "OpenParliamentTvConnector")
+
+
+class _FakeOpBasenameClient:
+    """Op-bulk client stand-in enumerating basename session files.
+
+    Mirrors OpTvClient: list_session_files() → basenames;
+    fetch_session_json(name) → JSON:API dict. Records fetches so the
+    early-stop can be asserted.
+    """
+
+    def __init__(self, sessions: dict[str, dict]) -> None:
+        self._sessions = sessions
+        self.fetched: list[str] = []
+
+    def list_session_files(self) -> list[str]:
+        return list(self._sessions)
+
+    def fetch_session_json(self, name: str) -> dict:
+        self.fetched.append(name)
+        return self._sessions[name]
+
+
+def _session(date_start: str, title: str = "Sitzung") -> dict:
+    return {"data": [{"dateStart": date_start, "title": title}]}
+
+
+def _make_connector(sessions: dict[str, dict]):
+    """Build an OpenParliamentTvConnector with __init__ bypassed (no network)."""
+    conn = object.__new__(OpenParliamentTvConnector)
+    conn._client = _FakeOpBasenameClient(sessions)  # type: ignore[attr-defined]
+    # Pre-seed an (empty) lookup so discover() skips ensure_mdb_lookup: these
+    # tests exercise basename enumeration, not party resolution, and must not
+    # hit the network.
+    conn._mdb_lookup = {"by_id": {}, "by_name": {}}  # type: ignore[attr-defined]
+    return conn
+
+
+def test_lookback_realigns() -> None:
+    """discover() re-scans below the prior cursor by the LOOKBACK window.
+
+    Prior op cursor advanced to 20230601 (a later-dated speech aligned first).
+    An earlier session dated 2023-05-01 only just aligned — it sits BELOW the
+    cursor. With a forward-only floor it would be stranded forever; with the
+    `since − LOOKBACK (≥60 days)` floor it is re-picked.
+    """
+    sessions = {
+        "20098-session.json": _session("2023-05-01T09:00:00+02:00"),
+        "20099-session.json": _session("2023-06-01T09:00:00+02:00"),
+        "20100-session.json": _session("2023-06-15T09:00:00+02:00"),
+    }
+    conn = _make_connector(sessions)
+
+    discovered = conn.discover(since=20230601)
+
+    assert "20098-session.json" in discovered, (
+        "an out-of-order newly-aligned session below the cursor must be re-picked "
+        "via the lookback floor (since − LOOKBACK)"
+    )
+    assert set(discovered) == set(sessions)
+
+
+def test_discover_stops_fetching_below_the_floor() -> None:
+    """discover() iterates basenames DESCENDING (basename order is monotone
+    in date) and stops fetching once a fetched session's ext < floor — the
+    previous full-corpus scan fetched every WP20+21 session JSON per run."""
+    sessions = {
+        "20001-session.json": _session("2023-01-10T09:00:00+01:00"),  # far below floor
+        "20002-session.json": _session("2023-02-10T09:00:00+01:00"),  # below floor
+        "20099-session.json": _session("2023-05-20T09:00:00+02:00"),
+        "20100-session.json": _session("2023-06-01T09:00:00+02:00"),
+    }
+    conn = _make_connector(sessions)
+
+    # since=20230701 → floor = 2023-05-02 (60-day lookback).
+    discovered = conn.discover(since=20230701)
+
+    assert discovered == ["20099-session.json", "20100-session.json"]
+    client = conn._client  # type: ignore[attr-defined]
+    assert "20001-session.json" not in client.fetched, (
+        "after the first below-floor session the scan must STOP — older basenames "
+        "are never fetched"
+    )
+    # The stop is triggered by the first below-floor fetch (20002); 20001 is skipped.
+    assert client.fetched == [
+        "20100-session.json",
+        "20099-session.json",
+        "20002-session.json",
+    ]
+
+
+def test_discover_since_none_fetches_all() -> None:
+    """the full backfill (since=None) still fetches every session file."""
+    sessions = {
+        "20001-session.json": _session("2023-01-10T09:00:00+01:00"),
+        "20100-session.json": _session("2023-06-01T09:00:00+02:00"),
+    }
+    conn = _make_connector(sessions)
+
+    discovered = conn.discover(since=None)
+
+    assert discovered == ["20001-session.json", "20100-session.json"]
+    assert set(conn._client.fetched) == set(sessions)  # type: ignore[attr-defined]
+
+
+def test_discover_returns_ascending_by_date() -> None:
+    """Handles come back oldest-first (cursor order) despite the descending scan."""
+    sessions = {
+        "20100-session.json": _session("2023-06-01T09:00:00+02:00"),
+        "20099-session.json": _session("2023-05-20T09:00:00+02:00"),
+        "20101-session.json": _session("2023-06-15T09:00:00+02:00"),
+    }
+    conn = _make_connector(sessions)
+
+    discovered = conn.discover(since=None)
+
+    assert discovered == [
+        "20099-session.json",
+        "20100-session.json",
+        "20101-session.json",
+    ]
+
+
+def test_same_date_sessions_both_discovered_and_fetchable() -> None:
+    """(f) Two sessions whose earliest dateStart falls on the SAME calendar date
+    must BOTH appear in discover() output and both be fetchable — previously the
+    str(ext) cache key collided and one session's speeches were never ingested."""
+    sessions = {
+        "20101-session.json": {
+            "data": [{"dateStart": "2023-04-28T09:00:00+02:00", "title": "Sitzung 101"}]
+        },
+        "20102-session.json": {
+            "data": [{"dateStart": "2023-04-28T14:00:00+02:00", "title": "Sitzung 102"}]
+        },
+    }
+    conn = _make_connector(sessions)
+
+    handles = conn.discover(since=None)
+
+    assert len(handles) == 2, (
+        f"both same-date sessions must be discovered, got handles: {handles}"
+    )
+    assert len(set(handles)) == 2, "handles must be unique"
+
+    titles = set()
+    for handle in handles:
+        raw = conn.fetch(handle)
+        assert "skip_reason" not in raw, f"handle {handle!r} must be fetchable"
+        items = raw["items"]
+        assert items, f"handle {handle!r} must carry its session's items"
+        titles.add(items[0]["title"])
+    assert titles == {"Sitzung 101", "Sitzung 102"}, (
+        "each handle must resolve to ITS OWN session's speeches"
+    )

--- a/ai-backend/tests/ingestion/connectors/openparliament_tv/test_normalize.py
+++ b/ai-backend/tests/ingestion/connectors/openparliament_tv/test_normalize.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Tests for OpenParliamentTvConnector.normalize() — the skip-and-warn contract:
+a skip_reason payload and a zero-usable-speech session must both raise
+ValueError so run_connector skip-and-continues without advancing the cursor.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+connector_mod = pytest.importorskip(
+    "src.ingestion.connectors.openparliament_tv.connector",
+    reason="op connector not yet implemented",
+)
+
+OpenParliamentTvConnector = getattr(connector_mod, "OpenParliamentTvConnector")
+
+
+def _make_connector():
+    return object.__new__(OpenParliamentTvConnector)
+
+
+def test_normalize_raises_on_skip_reason() -> None:
+    """A fetch() skip_reason dict converts to an immediate ValueError."""
+    conn = _make_connector()
+    with pytest.raises(ValueError, match="not in discover cache"):
+        conn.normalize({"skip_reason": "op session 20101 not in discover cache"})
+
+
+def test_normalize_raises_on_zero_usable_speeches() -> None:
+    """A session whose items are all unaligned / ASR-only / empty (alignment gate)
+    yields zero ChunkRecords → ValueError so the cursor does NOT advance past
+    the un-aligned session."""
+    conn = _make_connector()
+    raw = {
+        "external_id": "20101-session.json",
+        "items": [
+            # Unaligned item — the alignment gate drops it inside build_chunk_records.
+            {"media": {"aligned": False}, "textContents": []},
+            # Aligned but ASR-only (no proceedings transcript).
+            {
+                "media": {"aligned": True},
+                "textContents": [{"type": "generated", "textBody": []}],
+            },
+        ],
+        "mdb_lookup": None,
+    }
+    with pytest.raises(ValueError, match="zero usable"):
+        conn.normalize(raw)
+
+
+def test_normalize_raises_on_empty_item_list() -> None:
+    """An empty session (no items at all) is also a zero-usable ValueError."""
+    conn = _make_connector()
+    with pytest.raises(ValueError, match="zero usable"):
+        conn.normalize(
+            {"external_id": "20102-session.json", "items": [], "mdb_lookup": None}
+        )

--- a/ai-backend/tests/ingestion/connectors/openparliament_tv/test_normalize.py
+++ b/ai-backend/tests/ingestion/connectors/openparliament_tv/test_normalize.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/tests/ingestion/connectors/openparliament_tv/test_parser.py
+++ b/ai-backend/tests/ingestion/connectors/openparliament_tv/test_parser.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Tests for openparliament_tv.parser (aligned+proceedings gate).
+
+The module-under-test does not exist yet. The top-level
+`pytest.importorskip(...)` makes this whole file SKIP cleanly until the parser
+lands, at which point the real assertions run.
+
+Covers:
+  - test_skip_unaligned_and_asr: parser yields a usable speech ONLY for
+    aligned+proceedings items; unaligned (media.aligned=false) and ASR-only
+    (textContents[0].type=="generated") items are marked skippable / dropped.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# SKIP until src.ingestion.connectors.openparliament_tv.parser exists.
+parser = pytest.importorskip(
+    "src.ingestion.connectors.openparliament_tv.parser",
+    reason="op parser not yet implemented",
+)
+
+
+def _aligned_proceedings_media_ids(parsed: list[dict]) -> set[str]:
+    """Collect origin media IDs from parsed speech dicts, tolerant of key names."""
+    ids: set[str] = set()
+    for sp in parsed:
+        media = sp.get("media") or sp.get("item", {}).get("media") or {}
+        mid = media.get("originMediaID") or sp.get("origin_media_id")
+        if mid:
+            ids.add(str(mid))
+    return ids
+
+
+def test_skip_unaligned_and_asr(session_json: dict) -> None:
+    """only aligned+proceedings speeches survive; unaligned + ASR-only are skipped.
+
+    The trimmed fixture has 4 items:
+      - originMediaID 7553315: aligned + proceedings  → KEEP
+      - originMediaID 7553320: media.aligned=false     → SKIP (not aligned yet)
+      - originMediaID 7553330: aligned + generated-only → SKIP (no proceedings)
+      - originMediaID 7553340: aligned + proceedings    → KEEP (minister)
+    The parser (or the normalize gate it feeds) must yield usable speech records
+    for exactly the two aligned+proceedings items and never for the other two.
+    """
+    parse = getattr(parser, "parse_session_json", None) or getattr(
+        parser, "parse_speeches_from_session"
+    )
+    parsed = parse(session_json)
+    assert isinstance(parsed, list)
+
+    kept = _aligned_proceedings_media_ids(parsed)
+    # Both aligned+proceedings speeches are kept ...
+    assert "7553315" in kept
+    assert "7553340" in kept
+    # ... and neither the unaligned nor the ASR-only speech is kept.
+    assert "7553320" not in kept, "unaligned speech must be skipped"
+    assert "7553330" not in kept, "ASR-only (generated) speech must be skipped"
+    assert len(kept) == 2

--- a/ai-backend/tests/ingestion/connectors/openparliament_tv/test_parser.py
+++ b/ai-backend/tests/ingestion/connectors/openparliament_tv/test_parser.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/tests/ingestion/test_deeplink_locator.py
+++ b/ai-backend/tests/ingestion/test_deeplink_locator.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Second-pass video deep-link locator — verbatim → fuzzy → speech-start fallback.
+
+At citation time the locator picks the sentence in `meta.sentence_map` best
+matching the model's quoted text and builds `video_uri#t={ts_start}`. Verbatim
+substring match wins; a fuzzy near-match still resolves; a no-match falls back
+to `sentence_map[0]["ts_start"]` and NEVER raises.
+
+The citation-refinement helpers live in `src.deeplink`. The top-level
+`pytest.importorskip(...)` makes this file SKIP cleanly if that module fails to
+import, then runs the real assertions.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+deeplink = pytest.importorskip(
+    "src.deeplink",
+    reason="src.deeplink import failed",
+)
+
+_locate = getattr(deeplink, "locate_deeplink", None)
+
+pytestmark = pytest.mark.skipif(
+    _locate is None,
+    reason="locate_deeplink not present in src.deeplink",
+)
+
+
+_VIDEO = "https://cdn.example/7553315.mp4"
+_SENTENCE_MAP = [
+    {"text": "Sehr geehrte Frau Präsidentin!", "ts_start": 1.0, "ts_end": 2.8},
+    {
+        "text": "Wir stärken die Aus- und Weiterbildungsförderung.",
+        "ts_start": 2.8,
+        "ts_end": 6.4,
+    },
+    {
+        "text": "Das ist ein wichtiger Schritt für die Fachkräftesicherung.",
+        "ts_start": 6.4,
+        "ts_end": 10.2,
+    },
+]
+
+
+def test_verbatim_match_returns_that_sentence_ts() -> None:
+    """A verbatim quote resolves to that sentence's ts_start."""
+    url = _locate(
+        "Wir stärken die Aus- und Weiterbildungsförderung.", _SENTENCE_MAP, _VIDEO
+    )
+    assert url == f"{_VIDEO}#t=2.8"
+
+
+def test_fuzzy_near_match_still_resolves() -> None:
+    """A near (non-exact) match still resolves to the closest sentence's ts_start."""
+    url = _locate(
+        "Wir staerken die Aus und Weiterbildungsfoerderung", _SENTENCE_MAP, _VIDEO
+    )
+    assert url == f"{_VIDEO}#t=2.8"
+
+
+def test_no_match_falls_back_to_speech_start_and_never_raises() -> None:
+    """A no-match quote falls back to sentence_map[0].ts_start without raising."""
+    url = _locate("Völlig unrelated text über Verkehrspolitik", _SENTENCE_MAP, _VIDEO)
+    assert url == f"{_VIDEO}#t=1.0"
+
+
+def test_missing_ts_start_never_raises_and_never_emits_literal_none() -> None:
+    """Regression: a sentence lacking ``ts_start`` must not raise KeyError and
+    must never render as the literal ``#t=None`` (contract: "never raises")."""
+    # First sentence has no ts_start; matched sentence also lacks it → bare uri.
+    broken = [
+        {"text": "Sehr geehrte Frau Präsidentin!"},  # no ts_start
+        {"text": "Wir stärken die Weiterbildung."},  # no ts_start
+    ]
+    assert _locate("Wir stärken die Weiterbildung.", broken, _VIDEO) == _VIDEO
+    assert _locate("", broken, _VIDEO) == _VIDEO
+    # A matched sentence WITH a ts_start still resolves even if sibling lacks one.
+    mixed = [
+        {"text": "opener"},  # no ts_start
+        {"text": "Wir stärken die Weiterbildung.", "ts_start": 4.2},
+    ]
+    assert _locate("Wir stärken die Weiterbildung.", mixed, _VIDEO) == f"{_VIDEO}#t=4.2"
+
+
+# ---------------------------------------------------------------------------
+# Query-relevance fallback (regression): at citation-assembly time only the
+# paraphrased RAG query is available (not a verbatim quote), so the locator
+# must still land the deep-link on the topically-relevant sentence rather than
+# always the speech-start. Guards the "every video opens at 0:00" bug.
+# ---------------------------------------------------------------------------
+
+_deeplink_url = getattr(deeplink, "_speech_deeplink_url", None)
+
+_relevance_skip = pytest.mark.skipif(
+    _deeplink_url is None,
+    reason="_speech_deeplink_url not present",
+)
+
+_OP_PAYLOAD = {
+    "source": "op",
+    "citation_url": f"{_VIDEO}#t=1.0",
+    "meta": {
+        "video_uri": _VIDEO,
+        "sentence_map": [
+            {
+                "text": "Frau Präsidentin! Meine Damen und Herren!",
+                "ts_start": 1.0,
+                "ts_end": 3.0,
+            },
+            {
+                "text": "Fast jedes fünfte Kind in unserem Land lebt in Armut.",
+                "ts_start": 45.2,
+                "ts_end": 50.0,
+            },
+            {
+                "text": "Wir investieren in Bildung und Chancengleichheit.",
+                "ts_start": 70.5,
+                "ts_end": 75.0,
+            },
+        ],
+    },
+}
+
+
+@_relevance_skip
+def test_query_relevance_lands_on_topical_sentence() -> None:
+    """A paraphrased query lands the deep-link on the most relevant sentence's ts."""
+    assert (
+        _deeplink_url(
+            _OP_PAYLOAD, "Was sagt die Partei zu Kinderarmut und Armut von Kindern?"
+        )
+        == f"{_VIDEO}#t=45.2"
+    )
+    assert (
+        _deeplink_url(_OP_PAYLOAD, "Position zu Bildung und Chancengleichheit")
+        == f"{_VIDEO}#t=70.5"
+    )
+
+
+@_relevance_skip
+def test_query_relevance_falls_back_to_speech_start_when_no_overlap() -> None:
+    """No content-word overlap → coarse speech-start link (never 0:00-crash)."""
+    assert (
+        _deeplink_url(_OP_PAYLOAD, "Außenpolitik Nato Verteidigung Panzer")
+        == f"{_VIDEO}#t=1.0"
+    )
+
+
+@_relevance_skip
+def test_dip_speech_url_unchanged() -> None:
+    """DIP speeches (no video/sentence_map) keep their stored citation_url."""
+    dip = {"source": "dip", "citation_url": "https://dip.example/protocol.pdf"}
+    assert _deeplink_url(dip, "irgendeine Frage") == "https://dip.example/protocol.pdf"
+
+
+# ---------------------------------------------------------------------------
+# Post-generation deep-link refinement: once the answer exists, re-point
+# the video deep-link at the sentence the model actually cited, not the RAG query.
+# ---------------------------------------------------------------------------
+
+_cited_claim = getattr(deeplink, "_cited_claim_for_index", None)
+_refine = getattr(deeplink, "_refine_speech_deeplinks", None)
+_postgen_skip = pytest.mark.skipif(
+    _cited_claim is None or _refine is None,
+    reason="post-generation deep-link refinement not present",
+)
+
+
+@_postgen_skip
+def test_cited_claim_extracts_clause_for_index() -> None:
+    answer = (
+        "Die Partei will Kinderarmut entschlossen bekämpfen [2]. "
+        "Zur Bildung äußert sie sich ausführlich [0]."
+    )
+    assert "Kinderarmut" in _cited_claim(answer, 2)
+    assert "Bildung" in _cited_claim(answer, 0)
+    assert _cited_claim(answer, 5) is None  # source not cited
+
+
+@_postgen_skip
+def test_refine_repoints_video_deeplink_to_cited_claim() -> None:
+    """The op speech at index 2 is cited for a Kinderarmut claim → its deep-link
+    moves off the coarse speech-start (#t=1.0) onto the Kinderarmut sentence."""
+    sources = [
+        {"url": "manifesto"},
+        {"url": "vote"},
+        {"url": f"{_VIDEO}#t=1.0", "video_url": f"{_VIDEO}#t=1.0"},  # op speech, coarse
+    ]
+    speech_refs = [(2, _OP_PAYLOAD)]
+    answer = "Fast jedes fünfte Kind lebt in Armut — so die Partei zur Kinderarmut [2]."
+
+    assert _refine(sources, speech_refs, answer) is True
+    assert sources[2]["url"] == f"{_VIDEO}#t=45.2"
+    assert sources[2]["video_url"] == f"{_VIDEO}#t=45.2"
+
+
+@_postgen_skip
+def test_refine_noop_when_source_not_cited() -> None:
+    """A speech the answer never cites keeps its coarse pre-answer link (no change)."""
+    sources = [{"url": f"{_VIDEO}#t=1.0", "video_url": f"{_VIDEO}#t=1.0"}]
+    speech_refs = [(0, _OP_PAYLOAD)]
+    assert _refine(sources, speech_refs, "Eine Antwort ganz ohne Belegmarker.") is False
+    assert sources[0]["url"] == f"{_VIDEO}#t=1.0"

--- a/ai-backend/tests/ingestion/test_deeplink_locator.py
+++ b/ai-backend/tests/ingestion/test_deeplink_locator.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -207,3 +207,50 @@ def test_refine_noop_when_source_not_cited() -> None:
     speech_refs = [(0, _OP_PAYLOAD)]
     assert _refine(sources, speech_refs, "Eine Antwort ganz ohne Belegmarker.") is False
     assert sources[0]["url"] == f"{_VIDEO}#t=1.0"
+
+
+class TestMalformedPersistedPayloads:
+    """Persisted meta is untrusted: corrupt shapes degrade, never raise."""
+
+    def test_sentence_map_as_string_degrades_to_stored_citation(self) -> None:
+        from src.deeplink import _speech_deeplink_url
+
+        payload = {
+            "source": "op",
+            "citation_url": "https://example.com/stored",
+            "meta": {"sentence_map": "corrupt", "video_uri": "https://v.example/x.mp4"},
+        }
+        assert _speech_deeplink_url(payload, "irgendein Zitat") == (
+            "https://example.com/stored"
+        )
+
+    def test_non_dict_entries_are_ignored(self) -> None:
+        from src.deeplink import locate_deeplink
+
+        sentence_map = [
+            "corrupt-entry",
+            None,
+            {"text": "Der Klimaschutz ist zentral.", "ts_start": 12.5},
+        ]
+        url = locate_deeplink(
+            "Der Klimaschutz ist zentral.", sentence_map, "https://v.example/x.mp4"
+        )
+        assert url == "https://v.example/x.mp4#t=12.5"
+
+    def test_meta_as_string_degrades_to_stored_citation(self) -> None:
+        from src.deeplink import _speech_deeplink_url
+
+        payload = {
+            "source": "op",
+            "citation_url": "https://example.com/stored",
+            "meta": "corrupt",
+        }
+        assert _speech_deeplink_url(payload, "Zitat") == "https://example.com/stored"
+
+    def test_all_corrupt_entries_yield_bare_video_uri(self) -> None:
+        from src.deeplink import locate_deeplink
+
+        assert (
+            locate_deeplink("Zitat", ["a", 1, None], "https://v.example/x.mp4")
+            == "https://v.example/x.mp4"
+        )

--- a/ai-backend/tests/ingestion/test_op_setup_indexes.py
+++ b/ai-backend/tests/ingestion/test_op_setup_indexes.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Qdrant index-set test for the new `speech_key` + `source` keyword indexes.
+
+The source-scoped cursor and the supersede / resurrection-guard filters
+all depend on `source` and `speech_key` being INDEXED keyword
+payload fields. `setup_collection._REQUIRED_INDEXES` is the source of truth.
+
+The indexes are not added yet. This file collects
+cleanly and skips until `_REQUIRED_INDEXES` grows to include them,
+then asserts membership.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.ingestion import setup_collection
+
+
+def test_speech_key_and_source_indexes() -> None:
+    """{"speech_key", "source"} ⊆ setup_collection._REQUIRED_INDEXES."""
+    required = getattr(setup_collection, "_REQUIRED_INDEXES", frozenset())
+    needed = {"speech_key", "source"}
+    if not needed <= set(required):
+        pytest.skip(
+            "speech_key/source keyword indexes not yet added to setup_collection"
+        )
+    assert needed <= set(required), (
+        f"speech_key and source must both be required keyword indexes; have {sorted(required)}"
+    )

--- a/ai-backend/tests/ingestion/test_op_setup_indexes.py
+++ b/ai-backend/tests/ingestion/test_op_setup_indexes.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 

--- a/ai-backend/tests/ingestion/test_supersede.py
+++ b/ai-backend/tests/ingestion/test_supersede.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 wahl.chat
+# SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
@@ -389,3 +389,57 @@ def test_supersede_merge_end_to_end_in_memory() -> None:
 
     # The dip duplicate (id=1) is deleted → one merged record remains.
     assert client.retrieve("wahlchat_chunks_dev", ids=[1], with_payload=True) == []
+
+
+def test_long_text_twins_clear_threshold_without_autojunk() -> None:
+    """Real-length near-identical transcripts must clear the 0.85 supersede
+    threshold. The default SequenceMatcher auto-junk heuristic marks frequent
+    characters as junk on long normalized strings and scored real twins from
+    official session data far below the bar (median ≈0.57); with
+    autojunk=False the same pairs score 0.92+."""
+    import difflib
+
+    from src.ingestion.speech_dedup import (
+        RESURRECTION_TEXT_MATCH_RATIO,
+        norm_speech_text,
+    )
+
+    # Build a realistic multi-thousand-character speech and a twin differing
+    # only by transcription artifacts (casing/punctuation differences survive
+    # normalization as small edits).
+    topics = (
+        "Klimaschutz",
+        "Digitalisierung",
+        "Bildung",
+        "Verkehr",
+        "Gesundheit",
+        "Wohnungsbau",
+        "Energie",
+        "Forschung",
+        "Landwirtschaft",
+        "Verteidigung",
+    )
+    base_sentences = [
+        f"Die Bundesregierung hat im Bereich {topic} im Jahr {2010 + i} "
+        f"insgesamt {i + 3} umfangreiche Massnahmen beschlossen und wird diese "
+        "im kommenden Haushaltsjahr konsequent umsetzen, meine sehr geehrten "
+        "Damen und Herren."
+        for i, topic in enumerate(topics * 4)
+    ]
+    dip_text = norm_speech_text(" ".join(base_sentences))
+    op_sentences = list(base_sentences)
+    op_sentences[3] = op_sentences[3].replace("konsequent", "zügig")
+    op_sentences[17] = op_sentences[17].replace("umfangreiche", "weitreichende")
+    op_text = norm_speech_text(" ".join(op_sentences))
+
+    assert len(dip_text) > 4000, "regression must use real-length text"
+
+    with_autojunk = difflib.SequenceMatcher(None, op_text, dip_text).ratio()
+    without = difflib.SequenceMatcher(None, op_text, dip_text, autojunk=False).ratio()
+
+    assert without >= RESURRECTION_TEXT_MATCH_RATIO, (
+        f"real twins must clear the threshold with autojunk=False, got {without:.3f}"
+    )
+    # Documents WHY autojunk=False is load-bearing: the default heuristic
+    # scores the same pair far lower on long strings.
+    assert without >= with_autojunk

--- a/ai-backend/tests/ingestion/test_supersede.py
+++ b/ai-backend/tests/ingestion/test_supersede.py
@@ -1,0 +1,391 @@
+# SPDX-FileCopyrightText: 2025 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+Supersede-delete integration tests — fake Qdrant.
+
+When op ingests an aligned+proceedings speech, the op connector's post_upsert
+hook (the policy lives in the connector package, not the generic runner)
+must graft the DIP twin's transcript PDF and issue a delete scoped to the
+twin's source_item_id AND source == "dip". Duplication is transient.
+"""
+
+from __future__ import annotations
+
+import types
+import uuid
+
+from src.ingestion.connectors.openparliament_tv.supersede import (
+    supersede_dip_duplicates,
+)
+
+
+def _filter_mentions(obj: object, needles: tuple[str, ...]) -> bool:
+    """Recursively stringify a filter/selector and check every needle appears."""
+    blob = repr(obj)
+    return all(n in blob for n in needles)
+
+
+def _op_chunk(
+    speech_key: str, source_item_id, text: str, chunk_index: int = 0
+) -> types.SimpleNamespace:
+    """A stub op ChunkRecord (supersede reads .speech_key/.source_item_id/.text/.chunk_index)."""
+    return types.SimpleNamespace(
+        speech_key=speech_key,
+        source_item_id=source_item_id,
+        text=text,
+        chunk_index=chunk_index,
+    )
+
+
+# The proceedings text op ingested and its byte-for-byte DIP twin. Identical here
+# (ratio 1.0 ≥ the 0.85 supersede threshold) so the twin is matched and deleted.
+_SPEECH_TEXT = (
+    "Sehr geehrte Frau Präsidentin! Liebe Kolleginnen und Kollegen! "
+    "Wir stärken die Aus- und Weiterbildungsförderung in diesem Land."
+)
+
+
+def test_supersede_deletes_dip_duplicate() -> None:
+    """op ingest deletes ONLY its text-matched DIP twin, by the twin's
+    source_item_id (never by the non-unique speech_key)."""
+    speech_key = "de-20-101-mareike-lotte-wulf-top20"
+    dip_point = types.SimpleNamespace(
+        payload={
+            "speech_key": speech_key,
+            "source_item_id": "dip-1",
+            "citation_url": "https://dserver.bundestag.de/btp/20/20101.pdf",
+            "text": _SPEECH_TEXT,
+        }
+    )
+    qdrant = _MergeRecordingQdrant([dip_point])
+    stub_connector = types.SimpleNamespace(
+        source="op", source_type="parliamentary_speech"
+    )
+
+    supersede_dip_duplicates(
+        qdrant,
+        "wahlchat_chunks_dev",
+        [_op_chunk(speech_key, "op-1", _SPEECH_TEXT)],
+        connector=stub_connector,
+    )
+
+    assert qdrant.deletes, "op ingest must delete the matched DIP twin"
+    assert any(_filter_mentions(d, ("dip-1", "dip")) for d in qdrant.deletes), (
+        "delete must be scoped to the twin's source_item_id AND source == 'dip'"
+    )
+
+
+def test_supersede_grafts_with_real_uuid_source_item_id() -> None:
+    """Regression: ChunkRecord.source_item_id is a real uuid.UUID in production.
+
+    The graft filter's MatchValue accepts only bool/int/str — a raw UUID raised a
+    ValidationError AFTER the successful upsert, permanently disabling the op→DIP
+    merge (the next run present-skipped the item). The supersede pass must
+    stringify the op source_item_id before building the graft filter.
+    """
+    speech_key = "de-20-101-mareike-lotte-wulf-top20"
+    pdf_url = "https://dserver.bundestag.de/btp/20/20101.pdf"
+    dip_point = types.SimpleNamespace(
+        payload={
+            "speech_key": speech_key,
+            "source_item_id": "dip-1",
+            "citation_url": pdf_url,
+            "text": _SPEECH_TEXT,
+        }
+    )
+    qdrant = _MergeRecordingQdrant([dip_point])
+    stub_connector = types.SimpleNamespace(
+        source="op", source_type="parliamentary_speech"
+    )
+
+    op_sid = uuid.uuid4()  # a REAL UUID, exactly as ChunkRecord carries it
+    superseded = supersede_dip_duplicates(
+        qdrant,
+        "wahlchat_chunks_dev",
+        [_op_chunk(speech_key, op_sid, _SPEECH_TEXT)],
+        connector=stub_connector,
+    )
+
+    assert superseded == 1, "UUID source_item_id must not break the merge"
+    assert qdrant.batch_updates, "the graft must be issued (no ValidationError)"
+    graft = qdrant.batch_updates[0]
+    assert _filter_mentions(graft.get("update_operations"), (pdf_url, str(op_sid))), (
+        "graft filter must carry the STRINGIFIED op source_item_id"
+    )
+    assert any(_filter_mentions(d, ("dip-1", "dip")) for d in qdrant.deletes)
+
+
+def test_supersede_keeps_distinct_dip_speech_sharing_the_key() -> None:
+    """A DISTINCT DIP speech that merely shares the non-unique speech_key
+    (different text — a speaker's second turn op never aligned) must NOT be deleted."""
+    speech_key = "de-20-101-mareike-lotte-wulf-top20"
+    # DIP row under the same key but a completely different speech → must survive.
+    other = types.SimpleNamespace(
+        payload={
+            "speech_key": speech_key,
+            "source_item_id": "dip-other",
+            "citation_url": "https://dserver.bundestag.de/btp/20/20101.pdf",
+            "text": "Zur Geschäftsordnung: ich beantrage eine namentliche Abstimmung.",
+        }
+    )
+    qdrant = _MergeRecordingQdrant([other])
+    stub_connector = types.SimpleNamespace(
+        source="op", source_type="parliamentary_speech"
+    )
+
+    superseded = supersede_dip_duplicates(
+        qdrant,
+        "wahlchat_chunks_dev",
+        [_op_chunk(speech_key, "op-1", _SPEECH_TEXT)],
+        connector=stub_connector,
+    )
+    assert superseded == 0, "no text match → nothing superseded"
+    assert not qdrant.deletes, "a distinct same-key DIP speech must never be deleted"
+
+
+def test_supersede_multichunk_dip_twin_joined_in_chunk_order() -> None:
+    """Regression: a 2-chunk DIP twin served by scroll() in REVERSE chunk
+    order must still match (texts joined by chunk_index, not scroll order) —
+    "B+A" vs "A+B" would score ≈0.5 and silently miss the supersede."""
+    speech_key = "de-20-101-mareike-lotte-wulf-top20"
+    part_a = "Sehr geehrte Frau Präsidentin! Liebe Kolleginnen und Kollegen im Saal!"
+    part_b = "Wir stärken die Aus- und Weiterbildungsförderung in diesem ganzen Land."
+    pdf_url = "https://dserver.bundestag.de/btp/20/2000101.pdf"
+
+    # Scroll serves chunk_index=1 FIRST — deliberately out of order.
+    dip_points = [
+        types.SimpleNamespace(
+            payload={
+                "speech_key": speech_key,
+                "source_item_id": "dip-2c",
+                "citation_url": pdf_url,
+                "text": part_b,
+                "chunk_index": 1,
+            }
+        ),
+        types.SimpleNamespace(
+            payload={
+                "speech_key": speech_key,
+                "source_item_id": "dip-2c",
+                "citation_url": pdf_url,
+                "text": part_a,
+                "chunk_index": 0,
+            }
+        ),
+    ]
+    qdrant = _MergeRecordingQdrant(dip_points)
+    stub_connector = types.SimpleNamespace(
+        source="op", source_type="parliamentary_speech"
+    )
+
+    # The op side carries the same speech as TWO chunks, listed out of order too.
+    op_chunks = [
+        _op_chunk(speech_key, "op-2c", part_b, chunk_index=1),
+        _op_chunk(speech_key, "op-2c", part_a, chunk_index=0),
+    ]
+
+    superseded = supersede_dip_duplicates(
+        qdrant, "wahlchat_chunks_dev", op_chunks, connector=stub_connector
+    )
+
+    assert superseded == 1, (
+        "multi-chunk twin must match when joined in chunk_index order"
+    )
+    assert any(_filter_mentions(d, ("dip-2c", "dip")) for d in qdrant.deletes)
+
+
+class _MergeRecordingQdrant:
+    """Fake QdrantClient that serves DIP points from scroll() and records the
+    batch graft + delete calls."""
+
+    def __init__(self, dip_points: list) -> None:
+        self._dip_points = dip_points
+        self._scrolled = False
+        self.batch_updates: list[dict] = []
+        self.deletes: list[dict] = []
+
+    def scroll(self, *a, **k):  # noqa: ANN002, ANN003, ANN201
+        # First page returns the DIP duplicates, then exhausted (offset=None).
+        if not self._scrolled:
+            self._scrolled = True
+            return (self._dip_points, None)
+        return ([], None)
+
+    def batch_update_points(self, *a, **k) -> None:  # noqa: ANN002, ANN003
+        self.batch_updates.append(k)
+
+    def upsert(self, *a, **k) -> None:  # noqa: ANN002, ANN003
+        pass
+
+    def delete(self, *a, **k) -> None:  # noqa: ANN002, ANN003
+        self.deletes.append({"args": a, "kwargs": k})
+
+
+def test_supersede_grafts_dip_pdf_onto_op_before_delete() -> None:
+    """Merge (not replace): op ingest harvests the DIP duplicate's transcript PDF and
+    grafts it onto the op record (meta.transcript_pdf_url) in a durable batch BEFORE
+    deleting the DIP point, so one speech source keeps both the video and the PDF."""
+    speech_key = "de-20-101-mareike-lotte-wulf-top20"
+    pdf_url = "https://dserver.bundestag.de/btp/20/2000101.pdf"
+    dip_point = types.SimpleNamespace(
+        payload={
+            "speech_key": speech_key,
+            "source_item_id": "dip-1",
+            "citation_url": pdf_url,
+            "text": _SPEECH_TEXT,
+        }
+    )
+    qdrant = _MergeRecordingQdrant([dip_point])
+    stub_connector = types.SimpleNamespace(
+        source="op",
+        source_type="parliamentary_speech",
+    )
+
+    supersede_dip_duplicates(
+        qdrant,
+        "wahlchat_chunks_dev",
+        [_op_chunk(speech_key, "op-1", _SPEECH_TEXT)],
+        connector=stub_connector,
+    )
+
+    # Grafted the harvested PDF onto THIS op record (by its source_item_id) under
+    # meta, durably (wait=True).
+    assert qdrant.batch_updates, "must graft the DIP transcript PDF onto the op record"
+    graft = qdrant.batch_updates[0]
+    assert graft.get("wait") is True, (
+        "graft must be durable before the destructive delete"
+    )
+    assert _filter_mentions(graft.get("update_operations"), (pdf_url, "op-1", "op")), (
+        "graft must set transcript_pdf_url on the op source_item_id AND source == 'op'"
+    )
+    # And still deletes the now-redundant DIP twin (by its source_item_id).
+    assert qdrant.deletes
+    assert any(_filter_mentions(d, ("dip-1", "dip")) for d in qdrant.deletes)
+
+
+def test_op_connector_post_upsert_calls_supersede() -> None:
+    """OpenParliamentTvConnector.post_upsert drives the supersede policy —
+    the generic runner only calls the neutral hook."""
+    from src.ingestion.connectors.openparliament_tv.connector import (
+        OpenParliamentTvConnector,
+    )
+
+    conn = object.__new__(OpenParliamentTvConnector)  # bypass __init__ (no network)
+    speech_key = "de-20-101-mareike-lotte-wulf-top20"
+    dip_point = types.SimpleNamespace(
+        payload={
+            "speech_key": speech_key,
+            "source_item_id": "dip-1",
+            "citation_url": "https://dserver.bundestag.de/btp/20/20101.pdf",
+            "text": _SPEECH_TEXT,
+        }
+    )
+    qdrant = _MergeRecordingQdrant([dip_point])
+
+    superseded = conn.post_upsert(
+        qdrant, "wahlchat_chunks_dev", [_op_chunk(speech_key, "op-1", _SPEECH_TEXT)]
+    )
+
+    assert superseded == 1
+    assert any(_filter_mentions(d, ("dip-1", "dip")) for d in qdrant.deletes)
+
+
+def test_base_connector_post_upsert_is_noop() -> None:
+    """Every other connector inherits the no-op hook — no Qdrant calls."""
+    from src.ingestion.connector import BaseConnector
+
+    class _Stub(BaseConnector):
+        source_type = "vote_record"
+
+        def discover(self, since):  # noqa: ANN001, ANN201
+            return []
+
+        def fetch(self, external_id):  # noqa: ANN001, ANN201
+            return {}
+
+        def normalize(self, raw):  # noqa: ANN001, ANN201
+            return []
+
+    qdrant = _MergeRecordingQdrant([])
+    assert _Stub().post_upsert(qdrant, "wahlchat_chunks_dev", []) == 0
+    assert not qdrant.deletes and not qdrant.batch_updates
+
+
+def test_supersede_merge_end_to_end_in_memory() -> None:
+    """End-to-end against a real in-memory Qdrant: with a dip + op point sharing a
+    speech_key, supersede grafts the dip PDF into the op record's meta (WITHOUT
+    clobbering video_uri/sentence_map) and deletes the dip point — one merged record
+    survives carrying both links."""
+    import pytest
+
+    pytest.importorskip("qdrant_client")
+    from qdrant_client import models
+
+    # Import the REAL client from the submodule to bypass conftest's module-level
+    # `qdrant_client.QdrantClient` MagicMock patch (same escape hatch conftest uses).
+    from qdrant_client.qdrant_client import QdrantClient as RealQdrantClient
+
+    client = RealQdrantClient(":memory:")
+    client.create_collection(
+        "wahlchat_chunks_dev",
+        vectors_config={
+            "dense": models.VectorParams(size=3, distance=models.Distance.COSINE)
+        },
+    )
+    speech_key = "de-20-101-mareike-lotte-wulf-top20"
+    pdf_url = "https://dserver.bundestag.de/btp/20/2000101.pdf"
+    client.upsert(
+        "wahlchat_chunks_dev",
+        points=[
+            models.PointStruct(
+                id=1,
+                vector={"dense": [0.1, 0.2, 0.3]},
+                payload={
+                    "speech_key": speech_key,
+                    "source": "dip",
+                    "source_item_id": "dip-1",
+                    "citation_url": pdf_url,
+                    "text": _SPEECH_TEXT,
+                },
+            ),
+            models.PointStruct(
+                id=2,
+                vector={"dense": [0.1, 0.2, 0.3]},
+                payload={
+                    "speech_key": speech_key,
+                    "source": "op",
+                    "source_item_id": "op-2",
+                    "text": _SPEECH_TEXT,
+                    "citation_url": "https://cdn.example/clip.mp4#t=87.5",
+                    "meta": {
+                        "video_uri": "https://cdn.example/clip.mp4",
+                        "sentence_map": [{"text": "a", "ts_start": 87.5}],
+                    },
+                },
+            ),
+        ],
+    )
+
+    stub_connector = types.SimpleNamespace(
+        source="op", source_type="parliamentary_speech"
+    )
+    supersede_dip_duplicates(
+        client,
+        "wahlchat_chunks_dev",
+        [_op_chunk(speech_key, "op-2", _SPEECH_TEXT)],
+        connector=stub_connector,
+    )
+
+    # The op point (id=2) survives with BOTH links; video meta is intact.
+    op_point = client.retrieve("wahlchat_chunks_dev", ids=[2], with_payload=True)[0]
+    op_meta = op_point.payload["meta"]
+    assert op_meta["transcript_pdf_url"] == pdf_url, "DIP PDF must be grafted onto op"
+    assert op_meta["video_uri"] == "https://cdn.example/clip.mp4", (
+        "video_uri must survive the graft"
+    )
+    assert op_meta["sentence_map"], "sentence_map must survive the graft"
+
+    # The dip duplicate (id=1) is deleted → one merged record remains.
+    assert client.retrieve("wahlchat_chunks_dev", ids=[1], with_payload=True) == []


### PR DESCRIPTION
V2 stack 6/9 — openparliament.tv speech enrichment (`parliamentary_speech`, `source="op"`).

- **Keyless bulk connector** over openparliament.tv's published data — the same Bundestag speeches as DIP, but with sentence-level timing and a video deep-link per speech.
- **Cross-source supersede**: duplicates are detected via the shared `speech_key`; the richer op.tv version supersedes its DIP twin, grafting the DIP transcript PDF onto it first so nothing is lost. Speech `source_item_id`s carry the connector source (`dip`/`op`), so the two id spaces structurally can't collide.
- **`src/deeplink.py`** — the sentence-level video-timestamp locator the chat backend uses to seek the plenary video to the cited moment.

Verified: ruff, mypy, 525 tests, GDPR wall guard.
