### PR TITLE
fix(speeches): open transcript PDFs on the cited printed page

### DIFF
--- a/ai-backend/src/chat_service.py
+++ b/ai-backend/src/chat_service.py
@@ -261,6 +261,13 @@ def _append_document_source(
             pdf_page = _pdf_page_from_url(primary_url)
             if pdf_page is not None:
                 entry["page"] = pdf_page
+        # Printed plenary page for DISPLAY: `page` is the physical PDF page the
+        # viewer jumps to, which differs from the printed Wahlperiode-wide
+        # number the citation text shows (front matter shifts them apart). The
+        # isdigit guard also excludes op records, whose source_page is a URL.
+        printed_page = meta.get("source_page")
+        if isinstance(printed_page, str) and printed_page.isdigit():
+            entry["page_label"] = printed_page
         entry.update(_speech_attribution(payload))
         if payload.get("source") == "op" and meta.get("sentence_map"):
             speech_refs.append((len(sources), payload))
@@ -912,6 +919,14 @@ async def fetch_party_response_stream(
                         pdf_page = _pdf_page_from_url(primary_url)
                         if pdf_page is not None:
                             source_entry["page"] = pdf_page
+                    # Printed plenary page for DISPLAY (see
+                    # _append_document_source): physical `page` drives the
+                    # viewer jump; the printed number matches the citation
+                    # text. The isdigit guard excludes op records, whose
+                    # source_page is a URL.
+                    printed_page = meta.get("source_page")
+                    if isinstance(printed_page, str) and printed_page.isdigit():
+                        source_entry["page_label"] = printed_page
                     source_entry.update(_speech_attribution(speech_payload))
                     # Record op speeches with a timed sentence_map so their video
                     # deep-link can be refined post-generation from the cited claim.

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/client.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/client.py
@@ -14,6 +14,7 @@ Public API:
   DipClient(api_key, sleep=0.2)  — paced session; .get(endpoint, params) and .pages(endpoint, params)
   fetch_text(url) -> str          — fetch XML text, curl fallback on challenge redirect
   curl_get(url, accept) -> str    — fixed-arg subprocess curl, no shell=True
+  curl_get_bytes(url, accept) -> bytes — binary twin (protocol PDFs)
 """
 
 from __future__ import annotations
@@ -201,5 +202,21 @@ def curl_get(url: str, accept: str = "*/*") -> str:
     if result.returncode != 0:
         raise DipChallengeError(
             result.stderr.strip() or "curl could not fetch the official Bundestag URL"
+        )
+    return result.stdout
+
+
+def curl_get_bytes(url: str, accept: str = "*/*") -> bytes:
+    """Binary twin of curl_get (protocol PDF downloads); same fixed-arg posture.
+
+    Raises:
+        DipChallengeError: if curl exits non-zero.
+    """
+    command = ["curl", "-sS", "-L", "--fail", "-H", f"Accept: {accept}", url]
+    result = subprocess.run(command, capture_output=True, timeout=90)
+    if result.returncode != 0:
+        raise DipChallengeError(
+            result.stderr.decode(errors="replace").strip()
+            or "curl could not fetch the official Bundestag URL"
         )
     return result.stdout

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/connector.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/connector.py
@@ -65,6 +65,10 @@ from src.ingestion.connectors.bundestag_speeches.mdb import (
     mdb_record_for_speaker_name,
 )
 from src.ingestion.connectors.bundestag_speeches.parser import parse_speeches_from_xml
+from src.ingestion.connectors.bundestag_speeches.pdf_pages import (
+    fetch_pdf_reader,
+    resolve_page_offset,
+)
 from src.ingestion.connectors.bundestag_speeches.utils import normalize_party
 from src.ingestion.ids import compute_source_item_id
 from src.ingestion.schemas import ChunkRecord, SourceType
@@ -80,6 +84,28 @@ from src.ingestion.speech_dedup import datum_to_external_id as _datum_to_externa
 from src.ingestion.speech_dedup import norm_speech_text as _norm_speech_text
 
 logger = logging.getLogger(__name__)
+
+
+def _page_offset_samples(speeches: list[dict], limit: int = 3) -> list[tuple[int, int]]:
+    """Up to *limit* (printed page, estimated pdf page) pairs with distinct
+    printed pages — the validation samples for ``resolve_page_offset``."""
+    samples: list[tuple[int, int]] = []
+    seen: set[int] = set()
+    for speech in speeches:
+        printed = speech.get("source_page")
+        estimate = speech.get("pdf_page")
+        if (
+            isinstance(printed, str)
+            and printed.isdigit()
+            and isinstance(estimate, int)
+            and int(printed) not in seen
+        ):
+            seen.add(int(printed))
+            samples.append((int(printed), estimate))
+            if len(samples) >= limit:
+                break
+    return samples
+
 
 # ---------------------------------------------------------------------------
 # Module-level path for MdB-Stammdaten XML
@@ -637,6 +663,29 @@ class BundestagSpeechesConnector(BaseConnector):
                 "speeches": [],
                 "skip_reason": f"xml parse failed for protocol {external_id}: {exc}",
             }
+
+        # The parser's pdf_page is an arithmetic estimate that ignores the PDF's
+        # unnumbered front matter (title + table of contents), so its deep links
+        # land short by that many pages. Resolve the protocol-wide offset from
+        # the PDF itself (one download per protocol, validated against sampled
+        # printed pages). Failures keep the estimates — a close-but-shifted
+        # deep link beats none, and a protocol is never skipped over citation
+        # polish.
+        pdf_url = fundstelle.get("pdf_url") or None
+        samples = _page_offset_samples(speeches)
+        if pdf_url and samples:
+            reader = fetch_pdf_reader(pdf_url)
+            offset = resolve_page_offset(reader, samples) if reader else None
+            if offset:
+                for speech in speeches:
+                    if isinstance(speech.get("pdf_page"), int):
+                        speech["pdf_page"] += offset
+            elif offset is None:
+                logger.warning(
+                    "protocol %s: front-matter offset undeterminable — "
+                    "keeping arithmetic pdf_page estimates",
+                    external_id,
+                )
 
         return {
             "protocol": protocol,

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/pdf_pages.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/pdf_pages.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: 2026 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""Printed-page → physical-PDF-page resolution for plenary protocol PDFs.
+
+Protocol PDFs prepend unnumbered front matter (title + table of contents)
+before the first content page, whose printed number continues the
+Wahlperiode-wide pagination. ``#page=N`` deep links address PHYSICAL pages,
+so the arithmetic estimate ``printed − start + 1`` lands short by the
+front-matter length — and only the PDF itself can reveal that length.
+
+``resolve_page_offset`` tries page labels first, then a header text scan.
+Label-derived offsets are always validated against known (printed, estimate)
+sample pairs: many protocol PDFs carry plain ``1…N`` labels (physical
+numbering), where a lookup finds the printed number at the wrong position.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+
+import requests
+from pypdf import PdfReader
+
+logger = logging.getLogger(__name__)
+
+_FETCH_TIMEOUT_S = 60
+
+# Front matter is a handful of pages; a wider search risks false header
+# matches. Interior label runs get a looser bound (16-page front matter has
+# been observed).
+_MAX_OFFSET = 15
+_MAX_INTERIOR_OFFSET = 30
+
+# Header/footer tokens inspected per page for the printed page number.
+_EDGE_TOKENS = 30
+
+
+def fetch_pdf_reader(pdf_url: str) -> PdfReader | None:
+    """Download a protocol PDF (fragment stripped); None on any failure —
+    page resolution is citation polish, never a reason to drop a protocol."""
+    url = pdf_url.split("#", 1)[0]
+    try:
+        response = requests.get(url, timeout=_FETCH_TIMEOUT_S)
+        response.raise_for_status()
+        return PdfReader(io.BytesIO(response.content))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("could not fetch/read protocol PDF %s: %s", url, exc)
+        return None
+
+
+def read_page_labels(reader: PdfReader) -> list[str] | None:
+    """The PDF's page labels, or None when unavailable/unreadable."""
+    try:
+        labels = list(reader.page_labels)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("could not read PDF page labels: %s", exc)
+        return None
+    return labels if labels else None
+
+
+def front_matter_offset(labels: list[str]) -> int | None:
+    """Start index of the trailing contiguous printed run (= front-matter
+    length), walking BACK from the last label.
+
+    Walking backwards matters: stray numeric labels can occur inside the
+    front matter (Protokoll 21/4 labels a title page ``4``). Plain ``1…N``
+    label sets walk back to 0 — indistinguishable from "no front matter",
+    hence the sample validation in ``offset_from_labels``.
+    """
+    if not labels or not labels[-1].isdigit():
+        return None
+    run_start = len(labels) - 1
+    while run_start > 0:
+        prev = labels[run_start - 1]
+        if not prev.isdigit() or int(prev) != int(labels[run_start]) - 1:
+            break
+        run_start -= 1
+    return run_start
+
+
+def offset_from_labels(labels: list[str], samples: list[tuple[int, int]]) -> int | None:
+    """Label-derived offset, accepted only when every (printed, estimate)
+    sample resolves to exactly ``estimate + offset`` — rejects plain ``1…N``
+    label sets."""
+    if not samples:
+        return None
+    anchor = front_matter_offset(labels)
+    if anchor is None or not 0 <= anchor <= _MAX_OFFSET:
+        return None
+    for printed, estimate in samples:
+        try:
+            physical = labels.index(str(printed), anchor) + 1
+        except ValueError:
+            return None
+        if physical != estimate + anchor:
+            return None
+    return anchor
+
+
+def _page_edge_tokens(reader: PdfReader, physical_page: int) -> list[str]:
+    """Header/footer tokens of a 1-based physical page ([] when unreadable)."""
+    if physical_page < 1 or physical_page > len(reader.pages):
+        return []
+    try:
+        text = reader.pages[physical_page - 1].extract_text() or ""
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("could not extract text of PDF page %d: %s", physical_page, exc)
+        return []
+    tokens = text.split()
+    return tokens[:_EDGE_TOKENS] + tokens[-_EDGE_TOKENS:]
+
+
+def offset_from_header_scan(
+    reader: PdfReader, samples: list[tuple[int, int]]
+) -> int | None:
+    """Offset from the printed number in page headers: scan forward from the
+    first sample's estimate; every further sample must confirm the same
+    offset on its own page."""
+    if not samples:
+        return None
+    first_printed, first_estimate = samples[0]
+    found: int | None = None
+    for offset in range(0, _MAX_OFFSET + 1):
+        if str(first_printed) in _page_edge_tokens(reader, first_estimate + offset):
+            found = offset
+            break
+    if found is None:
+        return None
+    for printed, estimate in samples[1:]:
+        if str(printed) not in _page_edge_tokens(reader, estimate + found):
+            return None
+    return found
+
+
+def _longest_numeric_run_start(labels: list[str]) -> int | None:
+    """Start of the longest strictly-consecutive numeric label run (≥3, so a
+    stray pair can never win)."""
+    best_start, best_len = None, 0
+    i, n = 0, len(labels)
+    while i < n:
+        if labels[i].isdigit():
+            j = i
+            while (
+                j + 1 < n
+                and labels[j + 1].isdigit()
+                and int(labels[j + 1]) == int(labels[j]) + 1
+            ):
+                j += 1
+            if j - i + 1 > best_len:
+                best_start, best_len = i, j - i + 1
+            i = j + 1
+        else:
+            i += 1
+    return best_start if best_len >= 3 else None
+
+
+def offset_from_interior_label_run(
+    labels: list[str], samples: list[tuple[int, int]]
+) -> int | None:
+    """Sample-validated offset from the longest printed run — tolerates label
+    trees polluted by stray physical numbers, which break the tail-anchored
+    walk of ``front_matter_offset``."""
+    if not samples:
+        return None
+    start = _longest_numeric_run_start(labels)
+    if start is None or not 0 <= start <= _MAX_INTERIOR_OFFSET:
+        return None
+    for printed, estimate in samples:
+        try:
+            physical = labels.index(str(printed), start) + 1
+        except ValueError:
+            return None
+        if physical != estimate + start:
+            return None
+    return start
+
+
+def resolve_page_offset(
+    reader: PdfReader, samples: list[tuple[int, int]]
+) -> int | None:
+    """Front-matter offset for one protocol PDF, or None when undeterminable.
+
+    ``samples`` are (printed, estimated physical) pairs — use a few with
+    distinct printed pages; without samples the offset is undeterminable.
+    """
+    if not samples:
+        return None
+    labels = read_page_labels(reader)
+    if labels is not None:
+        offset = offset_from_labels(labels, samples)
+        if offset is not None:
+            return offset
+    offset = offset_from_header_scan(reader, samples)
+    if offset is not None:
+        return offset
+    if labels is not None:
+        return offset_from_interior_label_run(labels, samples)
+    return None

--- a/ai-backend/src/ingestion/connectors/bundestag_speeches/pdf_pages.py
+++ b/ai-backend/src/ingestion/connectors/bundestag_speeches/pdf_pages.py
@@ -24,6 +24,8 @@ import logging
 import requests
 from pypdf import PdfReader
 
+from src.ingestion.connectors.bundestag_speeches.client import curl_get_bytes
+
 logger = logging.getLogger(__name__)
 
 _FETCH_TIMEOUT_S = 60
@@ -44,8 +46,14 @@ def fetch_pdf_reader(pdf_url: str) -> PdfReader | None:
     url = pdf_url.split("#", 1)[0]
     try:
         response = requests.get(url, timeout=_FETCH_TIMEOUT_S)
-        response.raise_for_status()
-        return PdfReader(io.BytesIO(response.content))
+        if ".enodia/challenge" in response.url:
+            # Same WAF fallback as client.fetch_text — the challenge redirect
+            # answers 200 with HTML, so raise_for_status() cannot catch it.
+            pdf_bytes = curl_get_bytes(url, accept="application/pdf")
+        else:
+            response.raise_for_status()
+            pdf_bytes = response.content
+        return PdfReader(io.BytesIO(pdf_bytes))
     except Exception as exc:  # noqa: BLE001
         logger.warning("could not fetch/read protocol PDF %s: %s", url, exc)
         return None

--- a/ai-backend/tests/ingestion/connectors/bundestag_speeches/test_pdf_pages.py
+++ b/ai-backend/tests/ingestion/connectors/bundestag_speeches/test_pdf_pages.py
@@ -14,7 +14,10 @@ numbers AND has a gap in its printed run.
 
 from __future__ import annotations
 
+from src.ingestion.connectors.bundestag_speeches import pdf_pages
+from src.ingestion.connectors.bundestag_speeches.client import DipChallengeError
 from src.ingestion.connectors.bundestag_speeches.pdf_pages import (
+    fetch_pdf_reader,
     front_matter_offset,
     offset_from_header_scan,
     offset_from_interior_label_run,
@@ -161,3 +164,79 @@ class TestResolvePageOffset:
         # Every mode validates against samples — none means no verdict.
         reader = _FakeReader(None, _protocol_pages(front=3, start_printed=50, count=10))
         assert resolve_page_offset(reader, []) is None
+
+
+class _FakeResponse:
+    def __init__(self, url: str, content: bytes) -> None:
+        self.url = url
+        self.content = content
+
+    def raise_for_status(self) -> None:
+        pass
+
+
+class TestFetchPdfReader:
+    """The .enodia/challenge WAF answers 200 with HTML, so raise_for_status()
+    cannot catch it — fetch_pdf_reader must fall back to curl like fetch_text."""
+
+    def test_challenge_redirect_falls_back_to_curl(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            pdf_pages.requests,
+            "get",
+            lambda url, timeout: _FakeResponse(
+                "https://www.bundestag.de/.enodia/challenge?uri=x", b"<html>"
+            ),
+        )
+        curl_args: dict = {}
+
+        def _fake_curl(url: str, accept: str = "*/*") -> bytes:
+            curl_args["call"] = (url, accept)
+            return b"%PDF-fake"
+
+        monkeypatch.setattr(pdf_pages, "curl_get_bytes", _fake_curl)
+        seen: dict = {}
+        monkeypatch.setattr(
+            pdf_pages, "PdfReader", lambda buf: seen.setdefault("bytes", buf.getvalue())
+        )
+
+        result = fetch_pdf_reader(
+            "https://dserver.bundestag.de/btp/21/21004.pdf#page=5"
+        )
+
+        assert result == b"%PDF-fake"  # the fake PdfReader echoes its input
+        assert seen["bytes"] == b"%PDF-fake"
+        assert curl_args["call"] == (
+            "https://dserver.bundestag.de/btp/21/21004.pdf",  # fragment stripped
+            "application/pdf",
+        )
+
+    def test_no_challenge_uses_response_content(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            pdf_pages.requests,
+            "get",
+            lambda url, timeout: _FakeResponse(url, b"%PDF-direct"),
+        )
+
+        def _fail_curl(url: str, accept: str = "*/*") -> bytes:
+            raise AssertionError("curl fallback must not run without a challenge")
+
+        monkeypatch.setattr(pdf_pages, "curl_get_bytes", _fail_curl)
+        monkeypatch.setattr(pdf_pages, "PdfReader", lambda buf: buf.getvalue())
+
+        result = fetch_pdf_reader("https://dserver.bundestag.de/btp/21/21004.pdf")
+        assert result == b"%PDF-direct"
+
+    def test_failed_curl_fallback_returns_none(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            pdf_pages.requests,
+            "get",
+            lambda url, timeout: _FakeResponse(
+                "https://www.bundestag.de/.enodia/challenge?uri=x", b"<html>"
+            ),
+        )
+
+        def _raise(url: str, accept: str = "*/*") -> bytes:
+            raise DipChallengeError("curl could not fetch")
+
+        monkeypatch.setattr(pdf_pages, "curl_get_bytes", _raise)
+        assert fetch_pdf_reader("https://dserver.bundestag.de/btp/21/21004.pdf") is None

--- a/ai-backend/tests/ingestion/connectors/bundestag_speeches/test_pdf_pages.py
+++ b/ai-backend/tests/ingestion/connectors/bundestag_speeches/test_pdf_pages.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: 2026 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""Printed→physical page resolution against protocol PDF page labels/headers.
+
+Label shapes mirror real protocols: Protokoll 20/175 has six roman-labeled
+front-matter pages before the printed run; Protokoll 21/4 additionally labels
+a front-matter page with a bare digit (``4``); a large share of protocol PDFs
+carry plain ``1…N`` labels (physical numbering), which must be rejected by
+sample validation; and Protokoll 20/203 both pollutes its labels with physical
+numbers AND has a gap in its printed run.
+"""
+
+from __future__ import annotations
+
+from src.ingestion.connectors.bundestag_speeches.pdf_pages import (
+    front_matter_offset,
+    offset_from_header_scan,
+    offset_from_interior_label_run,
+    offset_from_labels,
+    resolve_page_offset,
+)
+
+# Protokoll 20/175 shape: 6 roman pages, printed run starts at 22551.
+_ROMAN_FRONT = ["I", "II", "III", "IV", "V", "VI"] + [
+    str(n) for n in range(22551, 22561)
+]
+
+# Protokoll 21/4 shape: a stray numeric label INSIDE the front matter.
+_STRAY_DIGIT_FRONT = ["I", "II", "III", "4"] + [str(n) for n in range(177, 183)]
+
+# Plain physical labels — indistinguishable from "no front matter" by labels
+# alone; only sample validation can reject them.
+_PLAIN = [str(n) for n in range(1, 11)]
+
+# Protokoll 20/203 shape: printed-style labels polluted by PHYSICAL numbers —
+# one right before the printed run and one as the very last label — which
+# breaks the tail-anchored walk but not the longest-run search.
+_POLLUTED = ["I", "II", "III", "16"] + [str(n) for n in range(26123, 26133)] + ["15"]
+
+
+class _FakePage:
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def extract_text(self) -> str:
+        return self._text
+
+
+class _FakeReader:
+    """Minimal stand-in for PdfReader: page_labels + pages[i].extract_text()."""
+
+    def __init__(self, labels: list[str] | None, page_texts: list[str]) -> None:
+        self._labels = labels
+        self.pages = [_FakePage(t) for t in page_texts]
+
+    @property
+    def page_labels(self) -> list[str]:
+        if self._labels is None:
+            raise KeyError("no /PageLabels")
+        return self._labels
+
+
+def _protocol_pages(front: int, start_printed: int, count: int) -> list[str]:
+    """Front-matter pages then content pages with a printed header number."""
+    pages = ["Inhaltsverzeichnis" for _ in range(front)]
+    for n in range(start_printed, start_printed + count):
+        pages.append(f"Deutscher Bundestag – 20. Wahlperiode {n} Sitzungsbericht text")
+    return pages
+
+
+class TestFrontMatterOffset:
+    def test_roman_front_matter(self) -> None:
+        assert front_matter_offset(_ROMAN_FRONT) == 6
+
+    def test_stray_digit_in_front_matter_is_not_part_of_the_run(self) -> None:
+        # Counting non-numeric labels from the front would say 3; the backward
+        # contiguous walk correctly stops at the 4→177 discontinuity.
+        assert front_matter_offset(_STRAY_DIGIT_FRONT) == 4
+
+    def test_plain_labels_walk_back_to_zero(self) -> None:
+        assert front_matter_offset(_PLAIN) == 0
+
+    def test_trailing_non_numeric_label_means_no_anchor(self) -> None:
+        assert front_matter_offset(["1", "2", "Anlage"]) is None
+
+    def test_empty(self) -> None:
+        assert front_matter_offset([]) is None
+
+
+class TestOffsetFromLabels:
+    def test_printed_labels_validate_and_resolve(self) -> None:
+        # printed 22552 was estimated at physical 2 (22552-22551+1); labels put
+        # it at physical 8 → offset 6, consistent with the front-matter walk.
+        assert offset_from_labels(_ROMAN_FRONT, [(22552, 2)]) == 6
+
+    def test_stray_digit_case(self) -> None:
+        assert offset_from_labels(_STRAY_DIGIT_FRONT, [(178, 2)]) == 4
+
+    def test_plain_labels_are_rejected_by_sample_validation(self) -> None:
+        # Plain 1…N labels contain the printed number as a LABEL, but at the
+        # wrong physical position — the sample (printed 7 estimated at 5)
+        # must reject them instead of "confirming" offset 0.
+        assert offset_from_labels(_PLAIN, [(7, 5)]) is None
+
+    def test_missing_printed_page_rejects(self) -> None:
+        assert offset_from_labels(_ROMAN_FRONT, [(99999, 3)]) is None
+
+    def test_no_samples_rejects(self) -> None:
+        assert offset_from_labels(_ROMAN_FRONT, []) is None
+
+
+class TestOffsetFromHeaderScan:
+    def test_finds_offset_in_window(self) -> None:
+        reader = _FakeReader(
+            None, _protocol_pages(front=5, start_printed=880, count=20)
+        )
+        # printed 883 estimated at physical 4 (883-880+1); truly at 4+5.
+        assert offset_from_header_scan(reader, [(883, 4)]) == 5
+
+    def test_second_sample_must_confirm(self) -> None:
+        pages = _protocol_pages(front=5, start_printed=880, count=20)
+        # Corrupt the header of the page where the second sample must confirm:
+        # printed 889 estimated at 10 → physical 15 (index 14).
+        pages[14] = "kein Kopf"
+        reader = _FakeReader(None, pages)
+        assert offset_from_header_scan(reader, [(883, 4), (889, 10)]) is None
+
+    def test_no_match_in_window_returns_none(self) -> None:
+        reader = _FakeReader(None, ["nichts" for _ in range(30)])
+        assert offset_from_header_scan(reader, [(883, 4)]) is None
+
+
+class TestOffsetFromInteriorLabelRun:
+    def test_polluted_labels_resolve_via_longest_run(self) -> None:
+        # Tail-anchored walk fails on the trailing physical "15"; the longest
+        # consecutive run (26123…) starts at index 4 → offset 4, and the
+        # sample (printed 26125 estimated at 3 → physical 7) validates it.
+        assert front_matter_offset(_POLLUTED) == len(_POLLUTED) - 1  # useless
+        assert offset_from_interior_label_run(_POLLUTED, [(26125, 3)]) == 4
+
+    def test_sample_disagreement_rejects(self) -> None:
+        assert offset_from_interior_label_run(_POLLUTED, [(26125, 9)]) is None
+
+    def test_no_samples_rejects(self) -> None:
+        assert offset_from_interior_label_run(_POLLUTED, []) is None
+
+
+class TestResolvePageOffset:
+    def test_prefers_validated_labels(self) -> None:
+        reader = _FakeReader(_ROMAN_FRONT, ["x" for _ in range(len(_ROMAN_FRONT))])
+        assert resolve_page_offset(reader, [(22552, 2)]) == 6
+
+    def test_falls_back_to_header_scan_for_plain_labels(self) -> None:
+        pages = _protocol_pages(front=5, start_printed=880, count=20)
+        reader = _FakeReader([str(n) for n in range(1, len(pages) + 1)], pages)
+        assert resolve_page_offset(reader, [(883, 4)]) == 5
+
+    def test_no_samples_returns_none(self) -> None:
+        # Every mode validates against samples — none means no verdict.
+        reader = _FakeReader(None, _protocol_pages(front=3, start_printed=50, count=10))
+        assert resolve_page_offset(reader, []) is None

--- a/web/lib/stores/chat-store.types.ts
+++ b/web/lib/stores/chat-store.types.ts
@@ -13,6 +13,10 @@ import type { WritableDraft } from 'immer';
 export type Source = {
   source: string;
   page: number;
+  // Printed page number for DISPLAY (speech transcripts): the citation text
+  // cites the printed Wahlperiode-wide plenary page, while `page` is the
+  // physical PDF page the viewer jumps to — front matter shifts them apart.
+  page_label?: string;
   url: string;
   source_document: string;
   document_publish_date: string;

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -272,12 +272,16 @@ export function sourceBadgeLabel(source: {
   video_url?: string;
   pdf_url?: string;
   page: number;
+  page_label?: string;
 }): string {
   const primary = getSourceMediaLinks(source)[0];
   if (primary?.kind === 'video') {
     return primary.label;
   }
-  return `S. ${source.page}`;
+  // Prefer the printed page the citation text cites (speech transcripts);
+  // `page` is the physical PDF page for the viewer jump, which differs when
+  // the PDF has front matter.
+  return `S. ${source.page_label ?? source.page}`;
 }
 
 /** True when a URL is a playable video (a `#t=` deep-link or a `.mp4` file). */


### PR DESCRIPTION
## Why
     
Speech citations carry the printed plenary page from the protocol XML (e.g. `Protokoll 20/175, S. 22694`). But `#page=` deep links address *physical* PDF pages and protocol PDFs prepend an unnumbered front matter section (title page + table of contents, typically 3–8 pages). Our arithmetic anchor (`printed − start-seitennr + 1`) ignored that section, so the viewer opened exactly that many pages before the cited one, e.g. `S. 22694` landed on `S. 22688` for a protocol with a six-page table of contents.

The XML cannot reveal the front-matter length; only the PDF itself can.

## What

**Connector (ingest time):** 
After parsing a protocol, download its PDF once and determine the front-matter length from the PDF itself, using three methods in order (none worked universally across all speeches, hence three): 
1. the PDF's page labels, when they name content pages by their printed numbers
2. scanning forward from our estimated position until a known printed page number appears in the page-header text
3. for PDFs whose labels contain junk entries, locating the long consecutive stretch of printed numbers in the
    label list.

If no method survives verification, the old estimate is kept: a close deep link beats none and a protocol is never skipped over citation polish.

**Sources UI:** 
Speech sources now also carry the printed page as `page_label`, so the source chip shows the same number the citation text cites, while the physical page keeps driving the viewer jump.

The already-ingested corpus was repaired in place with a one-shot script (not part of this PR); this change keeps future ingests correct.