### PR TITLE
User-directed source-type filtering

### DIFF
--- a/ai-backend/src/chat_service.py
+++ b/ai-backend/src/chat_service.py
@@ -147,12 +147,8 @@ _CURRENT_MANIFESTO_LIMIT = 4
 _CURRENT_SPEECH_LIMIT = 2  # normal cap (ranked last)
 _CURRENT_SPEECH_FALLBACK = 5  # adaptive ceiling when official data is sparse
 
-# User-requested source-type filter (detect_source_filter): when the user
-# explicitly scopes the answer to specific source types, the requested sources
-# carry the WHOLE answer, so their current-bucket budgets are raised. The score
-# threshold is unchanged — the extra slots only fill with results that clear the
-# same relevance bar. The adaptive speech trim is skipped under a filter (an
-# explicitly requested source is never demoted to "supporting material").
+# Raised current-bucket budgets under a user source filter — the requested
+# sources carry the whole answer. Score threshold unchanged.
 _FILTERED_VOTE_LIMIT = 10
 _FILTERED_MANIFESTO_LIMIT = 8
 _FILTERED_SPEECH_LIMIT = 6
@@ -560,12 +556,10 @@ async def _retrieve_party_buckets(
     concurrently and a single source failure degrades to empty. WAHL_CHAT_PARTY has no
     corpus data → all buckets empty. log_prefix labels the failure logs per caller.
 
-    source_filter (detect_source_filter values) restricts retrieval to the
-    user-requested source types: only requested legs run (the others return empty
-    buckets untouched) and each requested leg gets the raised _FILTERED_* budget.
-    "videos" runs the speech leg with a Qdrant-level source=="op" provenance
-    filter so only video-bearing speeches return — a post-fetch filter would
-    starve videos whenever transcript-only speeches dominate the top-k.
+    source_filter restricts retrieval to the user-requested source types: only
+    requested legs run, each with the raised _FILTERED_* budget. "videos" adds a
+    Qdrant-level source=="op" filter — post-fetch filtering would starve videos
+    whenever transcript-only speeches dominate the top-k.
     """
     if party.party_id == WAHL_CHAT_PARTY.party_id:
         return _RetrievedBuckets([], [], [], [], [], [])
@@ -899,8 +893,8 @@ async def fetch_party_response_stream(
             # bar" — enough to instruct a marked historic section. Drives has_historic
             # threaded into generation below.
             has_historic = bool(manifesto_historic or speech_historic or vote_historic)
-            # Adaptive speech trim — skipped under a user source filter: an
-            # explicitly requested source keeps its raised (filtered) budget.
+            # Trim skipped under a source filter — requested speeches keep
+            # their raised budget.
             if not source_filter and not votes_absent and not manifesto_absent:
                 speech_current = speech_current[:_CURRENT_SPEECH_LIMIT]
 
@@ -1316,8 +1310,6 @@ async def process_party(
     votes_absent, manifesto_absent = _official_coverage(
         vote_docs_current, manifesto_current
     )
-    # Adaptive speech trim — skipped under a user source filter (mirrors the
-    # single-party path).
     if not source_filter and not votes_absent and not manifesto_absent:
         speech_current = speech_current[:_CURRENT_SPEECH_LIMIT]
 
@@ -1569,10 +1561,8 @@ async def generate_chat_stream(  # type: ignore[no-untyped-def]
             chat_history_without_last, all_parties
         )
 
-        # Source-filter intent detection ("zeig mir nur Videos/Abstimmungen zu …")
-        # runs CONCURRENTLY with the target/type classification — both need only
-        # the message + history, so the extra LLM call adds no latency.
-        # detect_source_filter is fail-open: [] means no restriction (all sources).
+        # Source-filter detection runs concurrently with the target/type
+        # classification — no added latency. Fail-open: [] = all sources.
         source_filter_task = asyncio.create_task(
             detect_source_filter(user_message.content, chat_history_str)
         )
@@ -1687,10 +1677,8 @@ async def generate_chat_stream(  # type: ignore[no-untyped-def]
                 # quick_replies (forgeable). First turn uses the server-verified
                 # proposed-question check; follow-ups are gated against the
                 # quick_replies the server recorded last turn for this session.
-                # A source-filtered turn is never cacheable: the cache entry does
-                # not encode the (LLM-detected) filter, so a filtered answer
-                # could be replayed for a differently-classified turn. Curated
-                # proposed questions never carry a filter, so nothing is lost.
+                # Filtered turns are never cacheable — the cache entry doesn't
+                # encode the (non-deterministic) LLM-detected filter.
                 group_chat_session.is_cacheable = (
                     _evaluate_cache_eligibility(
                         body.session_id,

--- a/ai-backend/src/chat_service.py
+++ b/ai-backend/src/chat_service.py
@@ -49,6 +49,7 @@ from langchain_core.documents import Document
 from src.chatbot_async import (
     generate_chat_title_and_chick_replies,
     get_question_targets_and_type,
+    detect_source_filter,
     generate_improvement_rag_query,
     generate_streaming_chatbot_response,
     generate_streaming_chatbot_comparing_response,
@@ -146,6 +147,16 @@ _CURRENT_MANIFESTO_LIMIT = 4
 _CURRENT_SPEECH_LIMIT = 2  # normal cap (ranked last)
 _CURRENT_SPEECH_FALLBACK = 5  # adaptive ceiling when official data is sparse
 
+# User-requested source-type filter (detect_source_filter): when the user
+# explicitly scopes the answer to specific source types, the requested sources
+# carry the WHOLE answer, so their current-bucket budgets are raised. The score
+# threshold is unchanged — the extra slots only fill with results that clear the
+# same relevance bar. The adaptive speech trim is skipped under a filter (an
+# explicitly requested source is never demoted to "supporting material").
+_FILTERED_VOTE_LIMIT = 10
+_FILTERED_MANIFESTO_LIMIT = 8
+_FILTERED_SPEECH_LIMIT = 6
+
 
 # ---------------------------------------------------------------------------
 # Payload → numbered-Document builders (shared by the single-party and
@@ -188,6 +199,7 @@ def _mk_manifesto_docs(payloads: list[dict]) -> list[Document]:
                 "page": _meta_dict(p).get("page_start"),
                 "source_document": p.get("citation_title"),
                 "authority_tier": p.get("authority_tier"),
+                "source_type": "party_manifesto",
             },
         )
         for p in payloads
@@ -210,6 +222,7 @@ def _mk_speech_docs(payloads: list[dict], improved_rag_query: str) -> list[Docum
                 "page": 1,
                 "source_document": p.get("citation_title"),
                 "authority_tier": p.get("authority_tier"),
+                "source_type": "parliamentary_speech",
                 "_source_payload": p,
             },
         )
@@ -240,6 +253,8 @@ def _append_document_source(
         "url": md.get("url"),
         "source_document": md.get("source_document"),
     }
+    if md.get("source_type") is not None:
+        entry["source_type"] = md.get("source_type")
     if party_id is not None:
         entry["party_id"] = party_id
 
@@ -527,6 +542,7 @@ async def _retrieve_party_buckets(
     election_level: Optional[str],
     term_window: Optional[tuple[datetime, datetime]],
     manifesto_term_start: Optional[datetime],
+    source_filter: Optional[list[str]] = None,
     log_prefix: str = "retrieve",
 ) -> _RetrievedBuckets:
     """Retrieve vote + manifesto + speech payloads for ONE party into current/historic
@@ -543,14 +559,48 @@ async def _retrieve_party_buckets(
     specific region only (level-exclusive, see below). All three sources run
     concurrently and a single source failure degrades to empty. WAHL_CHAT_PARTY has no
     corpus data → all buckets empty. log_prefix labels the failure logs per caller.
+
+    source_filter (detect_source_filter values) restricts retrieval to the
+    user-requested source types: only requested legs run (the others return empty
+    buckets untouched) and each requested leg gets the raised _FILTERED_* budget.
+    "videos" runs the speech leg with a Qdrant-level source=="op" provenance
+    filter so only video-bearing speeches return — a post-fetch filter would
+    starve videos whenever transcript-only speeches dominate the top-k.
     """
     if party.party_id == WAHL_CHAT_PARTY.party_id:
         return _RetrievedBuckets([], [], [], [], [], [])
 
     # Per-source failures recorded by the _safe_* helpers. Per-source
     # degradation stays (a single failed source yields empty buckets), but
-    # when EVERY source failed the turn must fail — see RetrievalUnavailableError.
+    # when EVERY REQUESTED source failed the turn must fail — see
+    # RetrievalUnavailableError.
     retrieval_failures: list = []
+
+    filter_active = bool(source_filter)
+    _filter = source_filter or []
+    want_votes = not filter_active or "votes" in _filter
+    want_manifesto = not filter_active or "manifesto" in _filter
+    want_speeches = not filter_active or "speeches" in _filter or "videos" in _filter
+    # videos-only → hard provenance filter; "speeches" alongside "videos" keeps
+    # the unfiltered speech leg (op results already rank first via prefer-op dedup).
+    speech_source = (
+        "op"
+        if filter_active and "videos" in _filter and "speeches" not in _filter
+        else None
+    )
+    requested_count = sum([want_votes, want_manifesto, want_speeches])
+
+    vote_limit = _FILTERED_VOTE_LIMIT if filter_active else _CURRENT_VOTE_LIMIT
+    manifesto_limit = (
+        _FILTERED_MANIFESTO_LIMIT if filter_active else _CURRENT_MANIFESTO_LIMIT
+    )
+    speech_limit = _FILTERED_SPEECH_LIMIT if filter_active else _CURRENT_SPEECH_FALLBACK
+
+    async def _empty_two_pass() -> dict[str, list[dict]]:
+        return {"current": [], "historic": []}
+
+    async def _empty_single() -> list[dict]:
+        return []
 
     # Manifestos are exclusive to the election's own level: a chat grounds in the
     # manifesto written FOR that election, never a parent level's — a state chat
@@ -575,14 +625,16 @@ async def _retrieve_party_buckets(
                 party_ids_contains=party.party_id,
                 term_start=term_start,
                 term_end=term_end,
-                current_limit=_CURRENT_VOTE_LIMIT,
+                current_limit=vote_limit,
                 historic_limit=_HISTORIC_LIMITS["vote"],
                 current_score_threshold=_CHAT_SCORE_THRESHOLD,
                 historic_score_threshold=_HISTORIC_SCORE_THRESHOLD,
                 region_path=region_path,
                 legislature_period_id=legislature_period_id,
                 level=election_level,  # vote-only
-            ),
+            )
+            if want_votes
+            else _empty_two_pass(),
             _safe_two_pass(
                 improved_rag_query,
                 _log_prefix=f"{log_prefix}_two_pass",
@@ -596,12 +648,14 @@ async def _retrieve_party_buckets(
                     else term_start
                 ),
                 term_end=term_end,
-                current_limit=_CURRENT_MANIFESTO_LIMIT,
+                current_limit=manifesto_limit,
                 historic_limit=_HISTORIC_LIMITS["manifesto"],
                 current_score_threshold=_CHAT_SCORE_THRESHOLD,
                 historic_score_threshold=_HISTORIC_SCORE_THRESHOLD,
                 region_path=manifesto_region_path,
-            ),
+            )
+            if want_manifesto
+            else _empty_two_pass(),
             _safe_two_pass(
                 improved_rag_query,
                 _log_prefix=f"{log_prefix}_two_pass",
@@ -609,19 +663,22 @@ async def _retrieve_party_buckets(
                 query_vector=rag_query_vector,
                 source_type="parliamentary_speech",
                 party_id=party.party_id,
+                source=speech_source,
                 term_start=term_start,
                 term_end=term_end,
-                current_limit=_CURRENT_SPEECH_FALLBACK,
+                current_limit=speech_limit,
                 historic_limit=_HISTORIC_LIMITS["speech"],
                 current_score_threshold=_CHAT_SCORE_THRESHOLD,
                 historic_score_threshold=_HISTORIC_SCORE_THRESHOLD,
                 region_path=region_path,
-            ),
+            )
+            if want_speeches
+            else _empty_two_pass(),
         )
-        if len(retrieval_failures) >= 3:
+        if len(retrieval_failures) >= requested_count:
             raise RetrievalUnavailableError(
-                f"all retrieval sources failed for party {party.party_id}: "
-                f"{retrieval_failures!r}"
+                f"all requested retrieval sources failed for party "
+                f"{party.party_id}: {retrieval_failures!r}"
             )
         return _RetrievedBuckets(
             vote_current=vote_buckets["current"],
@@ -641,12 +698,14 @@ async def _retrieve_party_buckets(
             query_vector=rag_query_vector,
             source_type="vote_record",
             party_ids_contains=party.party_id,
-            limit=_CURRENT_VOTE_LIMIT,
+            limit=vote_limit,
             score_threshold=_CHAT_SCORE_THRESHOLD,
             region_path=region_path,
             legislature_period_id=legislature_period_id,
             level=election_level,  # vote-only
-        ),
+        )
+        if want_votes
+        else _empty_single(),
         _safe_retrieve(
             improved_rag_query,
             _log_prefix=log_prefix,
@@ -654,10 +713,12 @@ async def _retrieve_party_buckets(
             query_vector=rag_query_vector,
             source_type="party_manifesto",
             party_id=party.party_id,
-            limit=_CURRENT_MANIFESTO_LIMIT,
+            limit=manifesto_limit,
             score_threshold=_CHAT_SCORE_THRESHOLD,
             region_path=manifesto_region_path,
-        ),
+        )
+        if want_manifesto
+        else _empty_single(),
         _safe_retrieve(
             improved_rag_query,
             _log_prefix=log_prefix,
@@ -665,15 +726,18 @@ async def _retrieve_party_buckets(
             query_vector=rag_query_vector,
             source_type="parliamentary_speech",
             party_id=party.party_id,
-            limit=_CURRENT_SPEECH_FALLBACK,
+            source=speech_source,
+            limit=speech_limit,
             score_threshold=_CHAT_SCORE_THRESHOLD,
             region_path=region_path,
-        ),
+        )
+        if want_speeches
+        else _empty_single(),
     )
-    if len(retrieval_failures) >= 3:
+    if len(retrieval_failures) >= requested_count:
         raise RetrievalUnavailableError(
-            f"all retrieval sources failed for party {party.party_id}: "
-            f"{retrieval_failures!r}"
+            f"all requested retrieval sources failed for party "
+            f"{party.party_id}: {retrieval_failures!r}"
         )
     return _RetrievedBuckets(
         vote_current=vote_current,
@@ -704,6 +768,7 @@ async def fetch_party_response_stream(
     election_level: Optional[str] = None,
     term_window: Optional[tuple[datetime, datetime]] = None,
     manifesto_term_start: Optional[datetime] = None,
+    source_filter: Optional[list[str]] = None,
 ) -> AsyncGenerator[str, None]:
     """Yield SSE events for a single party's RAG response.
 
@@ -780,6 +845,7 @@ async def fetch_party_response_stream(
                 conversation_history_str,
                 question_for_party,
                 context_id=group_chat_session.context_id,
+                source_filter=source_filter,
             )
             # Embed the rag query ONCE and reuse the vector for all three
             # source retrievals (vote, manifesto, speech). This avoids three
@@ -803,6 +869,7 @@ async def fetch_party_response_stream(
                 election_level=election_level,
                 term_window=term_window,
                 manifesto_term_start=manifesto_term_start,
+                source_filter=source_filter,
                 log_prefix="retrieve",
             )
             vote_current = _buckets.vote_current
@@ -832,7 +899,9 @@ async def fetch_party_response_stream(
             # bar" — enough to instruct a marked historic section. Drives has_historic
             # threaded into generation below.
             has_historic = bool(manifesto_historic or speech_historic or vote_historic)
-            if not votes_absent and not manifesto_absent:
+            # Adaptive speech trim — skipped under a user source filter: an
+            # explicitly requested source keeps its raised (filtered) budget.
+            if not source_filter and not votes_absent and not manifesto_absent:
                 speech_current = speech_current[:_CURRENT_SPEECH_LIMIT]
 
             # combined_docs is the single list passed to generate_streaming_chatbot_response.
@@ -867,6 +936,7 @@ async def fetch_party_response_stream(
                             ),
                             "url": manifesto_payload.get("citation_url"),
                             "source_document": manifesto_payload.get("citation_title"),
+                            "source_type": "party_manifesto",
                         }
                     )
 
@@ -887,6 +957,7 @@ async def fetch_party_response_stream(
                         "document_publish_date": speech_payload.get("publish_date"),
                         "url": primary_url,
                         "source_document": speech_payload.get("citation_title"),
+                        "source_type": "parliamentary_speech",
                     }
                     # Dual-format links (merge, not replace): a speech renders as ONE
                     # source exposing both the op video deep-link and the DIP
@@ -941,6 +1012,7 @@ async def fetch_party_response_stream(
                             "document_publish_date": vote_payload.get("publish_date"),
                             "url": vote_payload.get("citation_url"),
                             "source_document": vote_payload.get("citation_title"),
+                            "source_type": "vote_record",
                             "region": vote_payload.get(
                                 "region"
                             ),  # structural origin marker
@@ -1021,6 +1093,7 @@ async def fetch_party_response_stream(
                     len(speech_current) > 0,
                 ),
                 has_historic=has_historic,
+                source_filter=source_filter,
             )
         else:
             # Comparison keeps its own by-party structure; only the historic
@@ -1037,6 +1110,7 @@ async def fetch_party_response_stream(
                 use_premium_llms=use_premium_llms,
                 election_level=election_level,
                 has_historic=_has_historic_docs(relevant_docs_dict, term_window),
+                source_filter=source_filter,
             )
 
         # v5 text block — one id for the whole party answer's deltas.
@@ -1192,6 +1266,7 @@ async def process_party(
     election_level: Optional[str] = None,
     term_window: Optional[tuple[datetime, datetime]] = None,
     manifesto_term_start: Optional[datetime] = None,
+    source_filter: Optional[list[str]] = None,
 ) -> None:
     """Fetch relevant docs for one party in a comparison question (no emit).
 
@@ -1199,7 +1274,11 @@ async def process_party(
     documents from the single wahlchat_chunks store, mirroring the single-party path.
     """
     improved_rag_query = await generate_improvement_rag_query(
-        party, chat_history_str, general_question, context_id=context_id
+        party,
+        chat_history_str,
+        general_question,
+        context_id=context_id,
+        source_filter=source_filter,
     )
     # Embed once, reuse for all three sources (same pattern as single-party path).
     rag_query_vector = await embed.aembed_query(improved_rag_query)
@@ -1216,6 +1295,7 @@ async def process_party(
         election_level=election_level,
         term_window=term_window,
         manifesto_term_start=manifesto_term_start,
+        source_filter=source_filter,
         log_prefix="comparison retrieve",
     )
     vote_current = _buckets.vote_current
@@ -1236,7 +1316,9 @@ async def process_party(
     votes_absent, manifesto_absent = _official_coverage(
         vote_docs_current, manifesto_current
     )
-    if not votes_absent and not manifesto_absent:
+    # Adaptive speech trim — skipped under a user source filter (mirrors the
+    # single-party path).
+    if not source_filter and not votes_absent and not manifesto_absent:
         speech_current = speech_current[:_CURRENT_SPEECH_LIMIT]
 
     # Merge current-first, historic-after in manifesto → vote → speech order
@@ -1487,6 +1569,14 @@ async def generate_chat_stream(  # type: ignore[no-untyped-def]
             chat_history_without_last, all_parties
         )
 
+        # Source-filter intent detection ("zeig mir nur Videos/Abstimmungen zu …")
+        # runs CONCURRENTLY with the target/type classification — both need only
+        # the message + history, so the extra LLM call adds no latency.
+        # detect_source_filter is fail-open: [] means no restriction (all sources).
+        source_filter_task = asyncio.create_task(
+            detect_source_filter(user_message.content, chat_history_str)
+        )
+
         try:
             (
                 party_id_list,
@@ -1499,6 +1589,7 @@ async def generate_chat_stream(  # type: ignore[no-untyped-def]
                 currently_selected_parties=pre_selected_parties,
             )
         except openai.BadRequestError as e:
+            source_filter_task.cancel()
             logger.error(f"Error identifying question targets: {e}", exc_info=True)
             # Fallback to wahl-chat
             party_id_list = [WAHL_CHAT_PARTY.party_id]
@@ -1525,6 +1616,14 @@ async def generate_chat_stream(  # type: ignore[no-untyped-def]
             yield _finish()
             yield _DONE
             return
+
+        source_filter: list[str] = await source_filter_task
+        if source_filter:
+            logger.info(
+                "User source filter active for session %s: %r",
+                body.session_id,
+                source_filter,
+            )
 
         if not party_id_list:
             party_id_list = ["wahl-chat"]
@@ -1588,11 +1687,18 @@ async def generate_chat_stream(  # type: ignore[no-untyped-def]
                 # quick_replies (forgeable). First turn uses the server-verified
                 # proposed-question check; follow-ups are gated against the
                 # quick_replies the server recorded last turn for this session.
-                group_chat_session.is_cacheable = _evaluate_cache_eligibility(
-                    body.session_id,
-                    user_message.content,
-                    is_beginning_of_chat,
-                    is_proposed_question,
+                # A source-filtered turn is never cacheable: the cache entry does
+                # not encode the (LLM-detected) filter, so a filtered answer
+                # could be replayed for a differently-classified turn. Curated
+                # proposed questions never carry a filter, so nothing is lost.
+                group_chat_session.is_cacheable = (
+                    _evaluate_cache_eligibility(
+                        body.session_id,
+                        user_message.content,
+                        is_beginning_of_chat,
+                        is_proposed_question,
+                    )
+                    and not source_filter
                 )
                 party_generators.append(
                     fetch_party_response_stream(
@@ -1610,6 +1716,7 @@ async def generate_chat_stream(  # type: ignore[no-untyped-def]
                         election_level=election_level,
                         term_window=term_window,
                         manifesto_term_start=manifesto_term_start,
+                        source_filter=source_filter,
                     )
                 )
         else:
@@ -1632,6 +1739,7 @@ async def generate_chat_stream(  # type: ignore[no-untyped-def]
                     election_level=election_level,
                     term_window=term_window,
                     manifesto_term_start=manifesto_term_start,
+                    source_filter=source_filter,
                 )
                 for p in parties_being_compared
             ]
@@ -1680,6 +1788,7 @@ async def generate_chat_stream(  # type: ignore[no-untyped-def]
                     legislature_period_id=legislature_period_id,
                     election_level=election_level,
                     term_window=term_window,
+                    source_filter=source_filter,
                 )
             ]
 

--- a/ai-backend/src/chatbot_async.py
+++ b/ai-backend/src/chatbot_async.py
@@ -286,10 +286,8 @@ async def detect_source_filter(
 ) -> List[str]:
     """Classify whether the user explicitly scopes the answer to source types.
 
-    Returns the requested SourceFilterLiteral values ("manifesto" / "votes" /
-    "speeches" / "videos") in canonical order, or [] when no restriction was
-    requested. Fail-open: any classification error returns [] so a broken
-    classifier degrades to today's default-all retrieval, never a blocked turn.
+    Returns SourceFilterLiteral values in canonical order; [] = no restriction.
+    Fail-open: any error returns [], degrading to default-all retrieval.
     """
     messages = [
         SystemMessage(content=determine_source_filter_system_prompt.format()),
@@ -332,9 +330,6 @@ async def generate_improvement_rag_query(
     else:
         system_prompt = system_prompt_improvement_template.format(party_name=party.name)
     if source_filter:
-        # Retrieval is already hard-filtered to the requested source types; the
-        # query must target the topic, never the media format (a query built
-        # around "Videoaufnahmen" retrieves documents ABOUT video technology).
         system_prompt += RAG_QUERY_SOURCE_FILTER_NOTE_DE.format(
             requested_sources=source_filter_labels_de(source_filter)
         )
@@ -698,15 +693,8 @@ def _federal_origin_disclosure_note(election_level: Optional[str]) -> str:
 
 
 def _source_filter_note(source_filter: Optional[List[str]]) -> str:
-    """Guideline block for a user-requested source-type filter.
-
-    Returns "" when no filter is active, so untouched callers reproduce today's
-    prompt byte-for-byte. Otherwise names the requested source types, mandates
-    the honest no-fallback empty answer, and — when video recordings were
-    requested — adds the "the [N] citations ARE the videos" instruction. Used by
-    both the single-party and comparison response paths so the scoping wording
-    cannot diverge.
-    """
+    """Guideline block naming the user-requested source scope; "" when no filter
+    is active. Shared by the single-party and comparison paths."""
     if not source_filter:
         return ""
     note = SOURCE_FILTER_NOTE_DE.format(

--- a/ai-backend/src/chatbot_async.py
+++ b/ai-backend/src/chatbot_async.py
@@ -81,6 +81,7 @@ from src.prompts import (
     SOURCE_FILTER_NOTE_DE,
     SOURCE_FILTER_VIDEO_NOTE_DE,
     RAG_QUERY_SOURCE_FILTER_NOTE_DE,
+    LEVEL_SEPARATION_NOTE_DE,
 )
 
 from src.models.chat import Message
@@ -692,7 +693,7 @@ def _federal_origin_disclosure_note(election_level: Optional[str]) -> str:
         "'Parlament: Bundestag (Bundesebene)'), weise explizit darauf hin, dass es sich "
         "um eine Bundestagsabstimmung handelt — nicht um eine Abstimmung des lokalen "
         "Landtags. Wähler:innen müssen klar erkennen können, auf welcher politischen "
-        "Ebene die Abstimmung stattgefunden hat."
+        "Ebene die Abstimmung stattgefunden hat." + LEVEL_SEPARATION_NOTE_DE
     )
 
 

--- a/ai-backend/src/chatbot_async.py
+++ b/ai-backend/src/chatbot_async.py
@@ -52,6 +52,8 @@ from src.prompts import (
     determine_question_targets_user_prompt,
     determine_question_type_system_prompt,
     determine_question_type_user_prompt,
+    determine_source_filter_system_prompt,
+    determine_source_filter_user_prompt,
     generate_chat_summary_system_prompt,
     generate_chat_summary_user_prompt,
     generate_chat_title_and_quick_replies_system_prompt,
@@ -75,6 +77,10 @@ from src.prompts import (
     SOURCE_LABEL_MANIFESTO_DE,
     SOURCE_LABEL_VOTES_DE,
     SOURCE_LABEL_SPEECHES_DE,
+    SOURCE_FILTER_LABELS_DE,
+    SOURCE_FILTER_NOTE_DE,
+    SOURCE_FILTER_VIDEO_NOTE_DE,
+    RAG_QUERY_SOURCE_FILTER_NOTE_DE,
 )
 
 from src.models.chat import Message
@@ -83,6 +89,8 @@ from src.models.structured_outputs import (
     GroupChatTitleQuickReplyGenerator,
     QuestionTypeClassifier,
     RerankingOutput,
+    SOURCE_FILTER_VALUES,
+    SourceFilterClassifier,
     create_party_list_generator,
 )
 
@@ -261,11 +269,57 @@ async def get_question_targets_and_type(
     return (party_id_list, question_for_parties, is_comparing_question)
 
 
+def source_filter_labels_de(source_filter: List[str]) -> str:
+    """German ``a, b und c`` list of the requested source-type labels."""
+    labels = [
+        SOURCE_FILTER_LABELS_DE[value]
+        for value in SOURCE_FILTER_VALUES
+        if value in source_filter
+    ]
+    return _join_sources_de(labels)
+
+
+async def detect_source_filter(
+    user_message: str,
+    previous_chat_history: str,
+) -> List[str]:
+    """Classify whether the user explicitly scopes the answer to source types.
+
+    Returns the requested SourceFilterLiteral values ("manifesto" / "votes" /
+    "speeches" / "videos") in canonical order, or [] when no restriction was
+    requested. Fail-open: any classification error returns [] so a broken
+    classifier degrades to today's default-all retrieval, never a blocked turn.
+    """
+    messages = [
+        SystemMessage(content=determine_source_filter_system_prompt.format()),
+        HumanMessage(
+            content=determine_source_filter_user_prompt.format(
+                previous_chat_history=previous_chat_history,
+                user_message=user_message,
+            )
+        ),
+    ]
+    try:
+        response = await get_structured_output_from_llms(
+            PRE_AND_POST_PROCESSING_LLMS, messages, SourceFilterClassifier
+        )
+        requested = {
+            str(value)
+            for value in getattr(response, "requested_source_types", [])
+            if str(value) in SOURCE_FILTER_VALUES
+        }
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"Source filter detection failed — defaulting to all: {e}")
+        return []
+    return [value for value in SOURCE_FILTER_VALUES if value in requested]
+
+
 async def generate_improvement_rag_query(
     party: ContextParty,
     conversation_history: str,
     last_user_message: str,
     context_id: str = DEFAULT_CONTEXT_ID,
+    source_filter: Optional[List[str]] = None,
 ) -> str:
     if party.party_id == WAHL_CHAT_PARTY.party_id:
         # Fetch context to get the context name for the template
@@ -276,6 +330,13 @@ async def generate_improvement_rag_query(
         )
     else:
         system_prompt = system_prompt_improvement_template.format(party_name=party.name)
+    if source_filter:
+        # Retrieval is already hard-filtered to the requested source types; the
+        # query must target the topic, never the media format (a query built
+        # around "Videoaufnahmen" retrieves documents ABOUT video technology).
+        system_prompt += RAG_QUERY_SOURCE_FILTER_NOTE_DE.format(
+            requested_sources=source_filter_labels_de(source_filter)
+        )
     user_prompt = user_prompt_improvement_template.format(
         conversation_history=conversation_history,
         last_user_message=last_user_message,
@@ -459,6 +520,7 @@ def build_vote_documents(
                     "page": 1,
                     "source_document": subject,
                     "authority_tier": payload.get("authority_tier"),
+                    "source_type": "vote_record",
                 },
             )
         )
@@ -523,6 +585,7 @@ async def generate_streaming_chatbot_response(
     election_level: Optional[str] = None,
     present_sources: Optional[tuple[bool, bool, bool]] = None,
     has_historic: bool = False,
+    source_filter: Optional[List[str]] = None,
 ) -> AsyncIterator[BaseMessageChunk]:
     # relevant_docs is combined_docs from chat_service.py (manifesto + vote +
     # speech Documents); get_rag_context numbers them sequentially so the LLM
@@ -583,6 +646,7 @@ async def generate_streaming_chatbot_response(
                 votes_present,
                 speeches_present,
             )
+        answer_guidelines += _source_filter_note(source_filter)
         system_prompt = party_response_system_prompt_template.format(
             party_name=party.name,
             party_long_name=party.long_name,
@@ -630,6 +694,26 @@ def _federal_origin_disclosure_note(election_level: Optional[str]) -> str:
         "Landtags. Wähler:innen müssen klar erkennen können, auf welcher politischen "
         "Ebene die Abstimmung stattgefunden hat."
     )
+
+
+def _source_filter_note(source_filter: Optional[List[str]]) -> str:
+    """Guideline block for a user-requested source-type filter.
+
+    Returns "" when no filter is active, so untouched callers reproduce today's
+    prompt byte-for-byte. Otherwise names the requested source types, mandates
+    the honest no-fallback empty answer, and — when video recordings were
+    requested — adds the "the [N] citations ARE the videos" instruction. Used by
+    both the single-party and comparison response paths so the scoping wording
+    cannot diverge.
+    """
+    if not source_filter:
+        return ""
+    note = SOURCE_FILTER_NOTE_DE.format(
+        requested_sources=source_filter_labels_de(source_filter)
+    )
+    if "videos" in source_filter:
+        note += SOURCE_FILTER_VIDEO_NOTE_DE
+    return note
 
 
 def _join_sources_de(labels: list[str]) -> str:
@@ -705,6 +789,7 @@ async def generate_streaming_chatbot_comparing_response(
     use_premium_llms: bool = False,
     election_level: Optional[str] = None,
     has_historic: bool = False,
+    source_filter: Optional[List[str]] = None,
 ) -> AsyncIterator[BaseMessageChunk]:
     rag_context = get_rag_comparison_context(relevant_docs, relevant_parties)
 
@@ -722,6 +807,7 @@ async def generate_streaming_chatbot_comparing_response(
     # comparison never presents historic material as the current record.
     if has_historic:
         answer_guidelines += HISTORIC_SECTION_NOTE_DE
+    answer_guidelines += _source_filter_note(source_filter)
 
     parties_being_compared = [party.name for party in relevant_parties]
 

--- a/ai-backend/src/ingestion/retrieve.py
+++ b/ai-backend/src/ingestion/retrieve.py
@@ -137,9 +137,7 @@ AuthorityTierLiteral = Literal[
     "promotional",
 ]
 
-# Provenance of a chunk within its source_type: op speeches carry video,
-# dip speeches only the transcript PDF, upload manifestos come from the
-# manifesto_uploads connector. Indexed keyword (setup_collection.py).
+# Chunk provenance within a source_type (op speeches carry video). Indexed keyword.
 SourceLiteral = Literal["op", "dip", "upload"]
 
 
@@ -388,14 +386,12 @@ def retrieve(
                         LARGE for federal-untagged), re-sorts and truncates to ``limit``.
                         Non-vote sources are unaffected.
         limit:          Maximum number of results (default 5).
-        source:         Keyword-only provenance filter within a source_type
-                        (``"op"`` | ``"dip"`` | ``"upload"``). Used for explicit
-                        user-driven scoping — e.g. ``source="op"`` returns only
-                        speeches that carry a video recording. Deliberately NOT
-                        part of ``RetrieveSchema`` and never set by the default
-                        chat path: the prefer-op dedup (``dedup_prefer_op``)
-                        stays a post-fetch pass so un-scoped retrieval keeps its
-                        dip fallback. NOT selective alone.
+        source:         Keyword-only provenance filter (e.g. ``"op"`` = only
+                        video-bearing speeches), for explicit user-driven
+                        scoping. NOT part of ``RetrieveSchema``, never set by
+                        the default chat path (prefer-op dedup stays post-fetch
+                        so un-scoped retrieval keeps its dip fallback). NOT
+                        selective alone.
         publish_range:  Keyword-only bounded/strict ``publish_date`` window as a
                         single ``DatetimeRange`` — e.g. ``DatetimeRange(gte=t0, lte=t1)``
                         for a closed window or ``DatetimeRange(lt=t0)`` for a strict
@@ -736,9 +732,7 @@ def retrieve_two_pass(
         source_type:    Content category filter (see retrieve()). Selective.
         party_id:       Tenant filter (see retrieve()). Selective.
         party_ids_contains: Vote membership filter (see retrieve()). Selective.
-        source:         Provenance filter (see retrieve()). Forwarded to both
-                        passes — an explicit "videos only" request scopes the
-                        historic bucket the same way as the current one.
+        source:         Provenance filter (see retrieve()); forwarded to both passes.
         region_path:    Election region path (MatchAny). Forwarded to both passes.
         level:          Governance level; forwarded to both passes so the
                         vote-level down-rank composes WITHIN each pass.

--- a/ai-backend/src/ingestion/retrieve.py
+++ b/ai-backend/src/ingestion/retrieve.py
@@ -137,6 +137,11 @@ AuthorityTierLiteral = Literal[
     "promotional",
 ]
 
+# Provenance of a chunk within its source_type: op speeches carry video,
+# dip speeches only the transcript PDF, upload manifestos come from the
+# manifesto_uploads connector. Indexed keyword (setup_collection.py).
+SourceLiteral = Literal["op", "dip", "upload"]
+
 
 # ---------------------------------------------------------------------------
 # Vote-level re-rank tuning constants.
@@ -319,6 +324,7 @@ def retrieve(
     level: Optional[str] = None,
     limit: int = 5,
     *,
+    source: Optional[SourceLiteral] = None,
     publish_range: Optional[DatetimeRange] = None,
     query_vector: Optional[list[float]] = None,
     score_threshold: Optional[float] = None,
@@ -382,6 +388,14 @@ def retrieve(
                         LARGE for federal-untagged), re-sorts and truncates to ``limit``.
                         Non-vote sources are unaffected.
         limit:          Maximum number of results (default 5).
+        source:         Keyword-only provenance filter within a source_type
+                        (``"op"`` | ``"dip"`` | ``"upload"``). Used for explicit
+                        user-driven scoping — e.g. ``source="op"`` returns only
+                        speeches that carry a video recording. Deliberately NOT
+                        part of ``RetrieveSchema`` and never set by the default
+                        chat path: the prefer-op dedup (``dedup_prefer_op``)
+                        stays a post-fetch pass so un-scoped retrieval keeps its
+                        dip fallback. NOT selective alone.
         publish_range:  Keyword-only bounded/strict ``publish_date`` window as a
                         single ``DatetimeRange`` — e.g. ``DatetimeRange(gte=t0, lte=t1)``
                         for a closed window or ``DatetimeRange(lt=t0)`` for a strict
@@ -478,6 +492,9 @@ def retrieve(
 
     if party_id is not None:
         must.append(FieldCondition(key="party_id", match=MatchValue(value=party_id)))
+
+    if source is not None:
+        must.append(FieldCondition(key="source", match=MatchValue(value=source)))
 
     if party_ids_contains is not None:
         # Membership test on the party_ids array: a single MatchValue against an
@@ -693,6 +710,7 @@ def retrieve_two_pass(
     source_type: Optional[SourceTypeLiteral] = None,
     party_id: Optional[str] = None,
     party_ids_contains: Optional[str] = None,
+    source: Optional[SourceLiteral] = None,
     region_path: Optional[list[str]] = None,
     level: Optional[str] = None,
     legislature_period_id: Optional[int] = None,
@@ -718,6 +736,9 @@ def retrieve_two_pass(
         source_type:    Content category filter (see retrieve()). Selective.
         party_id:       Tenant filter (see retrieve()). Selective.
         party_ids_contains: Vote membership filter (see retrieve()). Selective.
+        source:         Provenance filter (see retrieve()). Forwarded to both
+                        passes — an explicit "videos only" request scopes the
+                        historic bucket the same way as the current one.
         region_path:    Election region path (MatchAny). Forwarded to both passes.
         level:          Governance level; forwarded to both passes so the
                         vote-level down-rank composes WITHIN each pass.
@@ -750,6 +771,7 @@ def retrieve_two_pass(
         source_type=source_type,
         party_id=party_id,
         party_ids_contains=party_ids_contains,
+        source=source,
         region_path=region_path,
         legislature_period_id=legislature_period_id,
         level=level,
@@ -772,6 +794,7 @@ def retrieve_two_pass(
         source_type=source_type,
         party_id=party_id,
         party_ids_contains=party_ids_contains,
+        source=source,
         region_path=region_path,
         legislature_period_id=None,
         level=level,

--- a/ai-backend/src/models/structured_outputs.py
+++ b/ai-backend/src/models/structured_outputs.py
@@ -63,6 +63,26 @@ class QuestionTypeClassifier(BaseModel):
     )
 
 
+# User-facing source categories a chat answer can be explicitly scoped to.
+# "videos" is speeches WITH a video recording (source=="op"), not its own
+# corpus source_type — the retrieval layer maps it to a provenance filter.
+SourceFilterLiteral = Literal["manifesto", "votes", "speeches", "videos"]
+
+SOURCE_FILTER_VALUES: tuple[str, ...] = ("manifesto", "votes", "speeches", "videos")
+
+
+class SourceFilterClassifier(BaseModel):
+    """Output of the Source Filter Classifier."""
+
+    requested_source_types: list[SourceFilterLiteral] = Field(
+        description=(
+            "Quellenarten, auf die der Nutzer die Antwort EXPLIZIT beschränken "
+            "möchte. Leere Liste, wenn keine Beschränkung verlangt wird "
+            "(Standard: alle Quellenarten)."
+        )
+    )
+
+
 class ChatSummaryGenerator(BaseModel):
     """Output of the Chat Summary Generator."""
 

--- a/ai-backend/src/models/structured_outputs.py
+++ b/ai-backend/src/models/structured_outputs.py
@@ -63,9 +63,8 @@ class QuestionTypeClassifier(BaseModel):
     )
 
 
-# User-facing source categories a chat answer can be explicitly scoped to.
-# "videos" is speeches WITH a video recording (source=="op"), not its own
-# corpus source_type — the retrieval layer maps it to a provenance filter.
+# User-facing source categories for scoping answers. "videos" is not a corpus
+# source_type — retrieval maps it to parliamentary_speech with source=="op".
 SourceFilterLiteral = Literal["manifesto", "votes", "speeches", "videos"]
 
 SOURCE_FILTER_VALUES: tuple[str, ...] = ("manifesto", "votes", "speeches", "videos")

--- a/ai-backend/src/prompts.py
+++ b/ai-backend/src/prompts.py
@@ -477,6 +477,7 @@ Wenn der Nutzer explizit alle Parteien fordert, gib alle Parteien die aktuell im
 Wähle Kleinparteien nur aus, wenn diese bereits in den Chat eingeladen wurden oder explizit gefordert werden.
 Beachte bei dieser Entscheidung ausschließlich die Parteien in den Hintergrundinformationen und NICHT die Parteien im bisherigen Chatverlauf.
 Allgemeine Fragen zur Wahl, zum Wahlsystem oder zum Chatbot "wahl.chat" (auch "Wahl Chat", "KI Chat", etc.) sollen an "wahl-chat" gerichtet werden.
+Fragen nach verfügbaren Quellen oder Quellenarten zu einem politischen Thema (z.B. "Gibt es Videos zu diesem Thema?", "Habt ihr Abstimmungen dazu?") sind KEINE Fragen zum Chatbot: Richte sie an die Gesprächspartner im Chat bzw. die zuletzt antwortenden Parteien — nur diese haben Zugriff auf solche Quellen.
 Nutzerfragen, die nach der passenden Partei für eine bestimmte politische Position, nach einer Wahlempfehlung oder Wertung fragen, sollen an "wahl-chat" gerichtet werden.
 Wenn der Nutzer fragt, wer eine bestimmte Position vertritt oder eine Handlung durchführen will, soll die Frage auch an "wahl-chat" gerichtet werden.
 """

--- a/ai-backend/src/prompts.py
+++ b/ai-backend/src/prompts.py
@@ -206,9 +206,12 @@ SOURCE_FILTER_NOTE_DE = """
 
 # Extra note when the filter includes video recordings: the cited op speeches
 # ARE the videos (the [N] citations deep-link into the recording), so the model
-# must never claim it has no access to video material.
+# must never claim it has no access to video material. The model only sees its
+# RAW [N] markdown — it must be told the UI renders those as video buttons, or
+# it explains its own syntax to users ("klicke auf die eckigen Klammern").
 SOURCE_FILTER_VIDEO_NOTE_DE = """
-- **Videoaufnahmen:** Die bereitgestellten Reden-Ausschnitte stammen ausschließlich aus Reden mit Videoaufzeichnung. Die Quellenangaben [N] verlinken direkt auf die jeweilige Stelle in der Videoaufnahme. Sage NIEMALS, dass du keinen Zugriff auf Videoaufnahmen hast — weise stattdessen darauf hin, dass die zitierten Quellen die Videos direkt öffnen.
+- **Videoaufnahmen:** Die bereitgestellten Reden-Ausschnitte stammen ausschließlich aus Reden mit Videoaufzeichnung. Sage NIEMALS, dass du keinen Zugriff auf Videoaufnahmen hast.
+- Deine Quellenangaben [N] werden den Nutzer:innen NICHT als Zahlen in eckigen Klammern angezeigt, sondern als klickbare Video-Buttons direkt hinter der jeweiligen Aussage. Erkläre daher NICHT, wie man die Videos öffnet (Formulierungen wie „klicke auf die Nummern in den eckigen Klammern" sind falsch). Ein Hinweis auf die Videos ist unnötig; wenn du dennoch einen gibst, sprich von den Video-Buttons hinter den Aussagen.
 """
 
 # Appended (with _federal_origin_disclosure_note) for NON-federal elections:

--- a/ai-backend/src/prompts.py
+++ b/ai-backend/src/prompts.py
@@ -187,8 +187,7 @@ SOURCE_LABEL_SPEECHES_DE = "Reden"
 # =============================================================================
 # User-requested source-type filter (organic "zeig mir nur Videos/Abstimmungen/…")
 # =============================================================================
-# Nominative labels for the filter note's "nur nach: X, Y" list, keyed by the
-# SourceFilterLiteral values the intent classifier emits.
+# Nominative labels, keyed by the classifier's SourceFilterLiteral values.
 SOURCE_FILTER_LABELS_DE = {
     "manifesto": "das Wahlprogramm",
     "votes": "namentliche Abstimmungen",
@@ -196,41 +195,28 @@ SOURCE_FILTER_LABELS_DE = {
     "videos": "Videoaufnahmen von Reden",
 }
 
-# Appended to answer_guidelines when the user explicitly scoped the answer to
-# specific source types. The grounding is already retrieval-filtered; this note
-# makes the model own the scope instead of apologising for "missing" sections,
-# and mandates an honest no-fallback answer when the scoped retrieval is empty.
+# Appended when the user scoped the answer: own the scope (don't apologise for
+# absent sections), honest no-fallback answer when the scoped retrieval is empty.
 SOURCE_FILTER_NOTE_DE = """
 - **Vom Nutzer gewählter Quellenfokus:** Der Nutzer hat ausdrücklich nur nach folgenden Quellenarten gefragt: {requested_sources}. Die bereitgestellten Ausschnitte wurden bewusst auf diese Quellenarten beschränkt. Beantworte die Frage ausschließlich auf dieser Basis; andere Quellenarten fehlen absichtlich — erwähne ihr Fehlen nicht als Mangel.
 - Wenn KEINE passenden Ausschnitte vorliegen, sage klar und ehrlich, dass zu diesem Thema keine Quellen der gewünschten Art vorliegen. Weiche NICHT auf andere Quellenarten aus und erfinde nichts. Biete stattdessen an, die Frage ohne diese Beschränkung zu beantworten.
 """
 
-# Extra note when the filter includes video recordings: the cited op speeches
-# ARE the videos (their citation buttons open the recording), so the model must
-# never claim it has no access to video material. How citations render (buttons,
-# not brackets) is covered generally in the base Zitierstil guidelines.
+# Videos filter: the cited op speeches ARE the videos — never claim no access.
 SOURCE_FILTER_VIDEO_NOTE_DE = """
 - **Videoaufnahmen:** Die bereitgestellten Reden-Ausschnitte stammen ausschließlich aus Reden mit Videoaufzeichnung; ihre Quellen-Buttons öffnen direkt die Videoaufnahme. Sage NIEMALS, dass du keinen Zugriff auf Videoaufnahmen hast.
 """
 
-# Appended (with _federal_origin_disclosure_note) for NON-federal elections:
-# the grounding legitimately mixes levels (Reden are Bundestag-only content,
-# the manifesto is the Land program, votes come from both parliaments), but the
-# ANSWER must not weave the levels into one storyline — customer feedback: a
-# Landtagswahl answer read "Auf Bundesebene lehnt die Partei X ab [Bund].
-# Stattdessen setzt sie auf Y [Land]", presenting a Land position as the
-# direct alternative to a federal one.
+# Non-federal elections: the grounding legitimately mixes Bund and Land sources,
+# but the answer must not weave the levels into one storyline (customer feedback).
 LEVEL_SEPARATION_NOTE_DE = """
 - Deine Quellen stammen teils von der Bundesebene (Reden im Bundestag, Abstimmungen mit dem Label 'Parlament: Bundestag (Bundesebene)') und teils von der Landesebene (das Wahlprogramm zur Landtagswahl, Abstimmungen im Landtag). Mache bei JEDER Aussage erkennbar, von welcher Ebene sie stammt.
 - Gruppiere zusammengehörige Aussagen nach Ebene und leite jede Ebene explizit ein (z.B. „Auf Bundesebene …", „Auf Landesebene …" / „Für das Land …").
 - Verbinde NIEMALS eine Aussage der einen Ebene mit einer Aussage der anderen Ebene, als wären sie Teil desselben Vorhabens. Falsch wäre etwa: „Auf Bundesebene lehnt die Partei E-Fuels ab. Stattdessen setzt sie auf eine Transformationsmilliarde" — wenn das Erste aus dem Bundestag und das Zweite aus dem Landtagswahlprogramm stammt. Formuliere stattdessen einen expliziten Ebenenwechsel.
 """
 
-# Appended to the RAG-query-improvement SYSTEM prompt when a source filter is
-# active. The retrieval is already hard-filtered to the requested source types,
-# so the query must target the TOPIC — a query containing the format words
-# ("Videoaufnahmen", "Abstimmungen") retrieves documents ABOUT videos/votes
-# (e.g. Videokonferenzen in der Justiz) instead of documents about the topic.
+# Query-improvement addition under a filter: query the TOPIC, never the format —
+# format words retrieve documents ABOUT videos/votes instead of about the topic.
 RAG_QUERY_SOURCE_FILTER_NOTE_DE = """
 
 # Quellenfokus des Nutzers

--- a/ai-backend/src/prompts.py
+++ b/ai-backend/src/prompts.py
@@ -537,7 +537,7 @@ Gib die Liste der Quellenarten zurück, auf die der Nutzer die Antwort ausdrück
 ## Wichtige Hinweise zur Einstufung
 - Standard ist die LEERE Liste: Die allermeisten Nachrichten fragen nach einem THEMA, nicht nach einer Quellenart. Gib nur dann Quellenarten an, wenn der Nutzer sie erkennbar verlangt.
 - Nutzer verwenden beliebige eigene Formulierungen — auch Umschreibungen, Umgangssprache, Tippfehler oder englische Begriffe. Entscheide anhand der BEDEUTUNG der Nachricht, welche Quellenart gemeint ist; die Formulierungen in den Hintergrundinformationen sind nur Beispiele, keine vollständige Liste.
-- Fragt der Nutzer nach Videos/Aufnahmen von Reden, gib NUR "videos" an (nicht zusätzlich "speeches"). "speeches" ist für Reden ohne Video-Bezug.
+- "speeches" umfasst alle Reden, mit und ohne Videoaufnahme. Fragt der Nutzer nach Videos/Aufnahmen von Reden, gib NUR "videos" an (nicht zusätzlich "speeches").
 - Ein Thema, das nur zufällig nach einer Quellenart klingt, ist KEINE Beschränkung: "Wie steht ihr zu Videoüberwachung?" oder "Was haltet ihr von Volksabstimmungen?" sind Themenfragen → leere Liste.
 - Kurze Nachfragen, die eine vorherige explizit quellenbeschränkte Frage fortführen, behalten die Beschränkung bei: Auf "Zeig mir Videoaufnahmen zum Thema Lohnniveau" folgt "und zum Thema Infrastruktur?" → ["videos"].
 - Stellt der Nutzer erkennbar eine neue, normale Frage ohne Quellenbezug, endet die Beschränkung → leere Liste.

--- a/ai-backend/src/prompts.py
+++ b/ai-backend/src/prompts.py
@@ -211,6 +211,19 @@ SOURCE_FILTER_VIDEO_NOTE_DE = """
 - **Videoaufnahmen:** Die bereitgestellten Reden-Ausschnitte stammen ausschließlich aus Reden mit Videoaufzeichnung. Die Quellenangaben [N] verlinken direkt auf die jeweilige Stelle in der Videoaufnahme. Sage NIEMALS, dass du keinen Zugriff auf Videoaufnahmen hast — weise stattdessen darauf hin, dass die zitierten Quellen die Videos direkt öffnen.
 """
 
+# Appended (with _federal_origin_disclosure_note) for NON-federal elections:
+# the grounding legitimately mixes levels (Reden are Bundestag-only content,
+# the manifesto is the Land program, votes come from both parliaments), but the
+# ANSWER must not weave the levels into one storyline — customer feedback: a
+# Landtagswahl answer read "Auf Bundesebene lehnt die Partei X ab [Bund].
+# Stattdessen setzt sie auf Y [Land]", presenting a Land position as the
+# direct alternative to a federal one.
+LEVEL_SEPARATION_NOTE_DE = """
+- Deine Quellen stammen teils von der Bundesebene (Reden im Bundestag, Abstimmungen mit dem Label 'Parlament: Bundestag (Bundesebene)') und teils von der Landesebene (das Wahlprogramm zur Landtagswahl, Abstimmungen im Landtag). Mache bei JEDER Aussage erkennbar, von welcher Ebene sie stammt.
+- Gruppiere zusammengehörige Aussagen nach Ebene und leite jede Ebene explizit ein (z.B. „Auf Bundesebene …", „Auf Landesebene …" / „Für das Land …").
+- Verbinde NIEMALS eine Aussage der einen Ebene mit einer Aussage der anderen Ebene, als wären sie Teil desselben Vorhabens. Falsch wäre etwa: „Auf Bundesebene lehnt die Partei E-Fuels ab. Stattdessen setzt sie auf eine Transformationsmilliarde" — wenn das Erste aus dem Bundestag und das Zweite aus dem Landtagswahlprogramm stammt. Formuliere stattdessen einen expliziten Ebenenwechsel.
+"""
+
 # Appended to the RAG-query-improvement SYSTEM prompt when a source filter is
 # active. The retrieval is already hard-filtered to the requested source types,
 # so the query must target the TOPIC — a query containing the format words

--- a/ai-backend/src/prompts.py
+++ b/ai-backend/src/prompts.py
@@ -62,6 +62,7 @@ def get_base_guidelines(
 {style_section}
     - Zitierstil:
         - Gib nach jedem Satz eine Liste der Integer-IDs der Quellen an, die du für die Generierung dieses Satzes verwendet hast. Die Liste muss von eckigen Klammern [] umschlossen sein. Beispiel: [id] für eine Quelle oder [id1, id2, ...] für mehrere Quellen.
+        - Die Quellenangaben werden den Nutzer:innen als klickbare Quellen-Buttons angezeigt (Videoquellen als Video-Button), NICHT als Zahlen in eckigen Klammern. Beschreibe sie daher nie als „Nummern" oder „Klammern" und erkläre nicht, wie man sie anklickt.
         - Falls du für einen Satz keine der Quellen verwendet hast, gib nach diesem Satz keine Quellen an und formatiere den Satz stattdessen _kursiv_.
         - Wenn du für deine Antwort Quellen aus Reden verwendest, formuliere die Aussagen der Redner nicht als Fakt, sondern im Konjunktiv. (Beispiel: <NAME> hebt hervor, dass Klimaschutz wichtig sei.)
         - Quellenpriorität bei Widersprüchen: Bevorzuge Quellen mit höherer Vertrauensstufe (Reihenfolge: authoritative > factual_record > self_reported > promotional). Bei Widersprüchen zwischen Quellen unterschiedlicher Vertrauensstufe weise darauf hin und nutze die vertrauenswürdigere Quelle.
@@ -205,13 +206,11 @@ SOURCE_FILTER_NOTE_DE = """
 """
 
 # Extra note when the filter includes video recordings: the cited op speeches
-# ARE the videos (the [N] citations deep-link into the recording), so the model
-# must never claim it has no access to video material. The model only sees its
-# RAW [N] markdown — it must be told the UI renders those as video buttons, or
-# it explains its own syntax to users ("klicke auf die eckigen Klammern").
+# ARE the videos (their citation buttons open the recording), so the model must
+# never claim it has no access to video material. How citations render (buttons,
+# not brackets) is covered generally in the base Zitierstil guidelines.
 SOURCE_FILTER_VIDEO_NOTE_DE = """
-- **Videoaufnahmen:** Die bereitgestellten Reden-Ausschnitte stammen ausschließlich aus Reden mit Videoaufzeichnung. Sage NIEMALS, dass du keinen Zugriff auf Videoaufnahmen hast.
-- Deine Quellenangaben [N] werden den Nutzer:innen NICHT als Zahlen in eckigen Klammern angezeigt, sondern als klickbare Video-Buttons direkt hinter der jeweiligen Aussage. Erkläre daher NICHT, wie man die Videos öffnet (Formulierungen wie „klicke auf die Nummern in den eckigen Klammern" sind falsch). Ein Hinweis auf die Videos ist unnötig; wenn du dennoch einen gibst, sprich von den Video-Buttons hinter den Aussagen.
+- **Videoaufnahmen:** Die bereitgestellten Reden-Ausschnitte stammen ausschließlich aus Reden mit Videoaufzeichnung; ihre Quellen-Buttons öffnen direkt die Videoaufnahme. Sage NIEMALS, dass du keinen Zugriff auf Videoaufnahmen hast.
 """
 
 # Appended (with _federal_origin_disclosure_note) for NON-federal elections:

--- a/ai-backend/src/prompts.py
+++ b/ai-backend/src/prompts.py
@@ -535,30 +535,33 @@ determine_source_filter_system_prompt_str = """
 # Rolle
 Du analysierst eine Nachricht eines Nutzers an ein Chatsystem im Kontext des bisherigen Chatverlaufs und entscheidest, ob der Nutzer seine Antwort EXPLIZIT auf bestimmte Quellenarten beschränken möchte.
 
-# Verfügbare Quellenarten
-- "manifesto": Wahlprogramm der Partei. Synonyme: Programm, Parteiprogramm, Manifest, Wahlversprechen im Programm.
-- "votes": Namentliche Abstimmungen im Parlament. Synonyme: Abstimmungen, Abstimmungsverhalten, Voten, "wie hat ... abgestimmt".
-- "speeches": Reden im Bundestag. Synonyme: Plenarreden, Redebeiträge, Aussagen/Zitate aus Reden, "was wurde im Parlament gesagt".
-- "videos": Reden, zu denen eine Videoaufnahme existiert. Synonyme: Videos, Videoaufnahmen, Videoaufzeichnungen, Aufzeichnungen, Recordings, Clips, "etwas zum Anschauen".
+# Hintergrundinformationen
+Das Chatsystem beantwortet Fragen auf Basis von vier Quellenarten:
+- "manifesto": Das Wahlprogramm der Partei — was die Partei plant und verspricht (Formulierungen z.B. „Wahlprogramm", „Programm", „was verspricht ihr in eurem Programm").
+- "votes": Namentliche Abstimmungen im Parlament — wie die Partei tatsächlich abgestimmt hat (z.B. „Abstimmungen", „Abstimmungsverhalten", „wie habt ihr ... gestimmt").
+- "speeches": Reden im Bundestag — was Abgeordnete der Partei im Plenum gesagt haben (z.B. „Reden", „Redebeiträge", „was wurde im Parlament gesagt").
+- "videos": Reden, zu denen eine Videoaufnahme existiert — der Nutzer will etwas ansehen/anhören (z.B. „Videos", „Videoaufnahmen", „Aufzeichnungen", „etwas zum Anschauen").
 
 # Aufgabe
 Gib die Liste der Quellenarten zurück, auf die der Nutzer die Antwort ausdrücklich beschränken will. Mehrere Quellenarten sind möglich (z.B. "Abstimmungen und Reden zum Thema Infrastruktur" → ["votes", "speeches"]).
 
-# Wichtige Regeln
+## Wichtige Hinweise zur Einstufung
 - Standard ist die LEERE Liste: Die allermeisten Nachrichten fragen nach einem THEMA, nicht nach einer Quellenart. Gib nur dann Quellenarten an, wenn der Nutzer sie erkennbar verlangt.
+- Nutzer verwenden beliebige eigene Formulierungen — auch Umschreibungen, Umgangssprache, Tippfehler oder englische Begriffe. Entscheide anhand der BEDEUTUNG der Nachricht, welche Quellenart gemeint ist; die Formulierungen in den Hintergrundinformationen sind nur Beispiele, keine vollständige Liste.
 - Fragt der Nutzer nach Videos/Aufnahmen von Reden, gib NUR "videos" an (nicht zusätzlich "speeches"). "speeches" ist für Reden ohne Video-Bezug.
 - Ein Thema, das nur zufällig nach einer Quellenart klingt, ist KEINE Beschränkung: "Wie steht ihr zu Videoüberwachung?" oder "Was haltet ihr von Volksabstimmungen?" sind Themenfragen → leere Liste.
 - Kurze Nachfragen, die eine vorherige explizit quellenbeschränkte Frage fortführen, behalten die Beschränkung bei: Auf "Zeig mir Videoaufnahmen zum Thema Lohnniveau" folgt "und zum Thema Infrastruktur?" → ["videos"].
 - Stellt der Nutzer erkennbar eine neue, normale Frage ohne Quellenbezug, endet die Beschränkung → leere Liste.
 
-# Beispiele
-- "Zeigt mir Videoaufnahmen zum Thema Lohnniveau" → ["videos"]
-- "Wie habt ihr zur Infrastruktur abgestimmt?" → ["votes"]
-- "Was steht in eurem Wahlprogramm zur Bildung?" → ["manifesto"]
-- "Was wurde dazu in Reden im Bundestag gesagt?" → ["speeches"]
-- "Habt ihr Abstimmungen oder Reden zum Mindestlohn?" → ["votes", "speeches"]
-- "Was tut ihr gegen niedrige Löhne?" → []
-- "Wie steht ihr zur Vorratsdatenspeicherung von Videomaterial?" → []
+Beispiele:
+* "Zeigt mir Videoaufnahmen zum Thema Lohnniveau" → ["videos"]
+* "Gibt es einen Clip, wo jemand von euch über Mieten spricht?" → ["videos"] (Umschreibung — der Nutzer will etwas ansehen)
+* "Wie habt ihr zur Infrastruktur abgestimmt?" → ["votes"]
+* "Was steht in eurem Wahlprogramm zur Bildung?" → ["manifesto"]
+* "Was wurde dazu in Reden im Bundestag gesagt?" → ["speeches"]
+* "Habt ihr Abstimmungen oder Reden zum Mindestlohn?" → ["votes", "speeches"]
+* "Was tut ihr gegen niedrige Löhne?" → [] (Themenfrage, keine Quellenart verlangt)
+* "Wie steht ihr zur Vorratsdatenspeicherung von Videomaterial?" → [] ("Video" ist hier das Thema, nicht die gewünschte Quellenart)
 """
 
 determine_source_filter_system_prompt = PromptTemplate.from_template(

--- a/ai-backend/src/prompts.py
+++ b/ai-backend/src/prompts.py
@@ -183,6 +183,47 @@ SOURCE_LABEL_MANIFESTO_DE = "dem Wahlprogramm"
 SOURCE_LABEL_VOTES_DE = "namentlichen Abstimmungen"
 SOURCE_LABEL_SPEECHES_DE = "Reden"
 
+# =============================================================================
+# User-requested source-type filter (organic "zeig mir nur Videos/Abstimmungen/…")
+# =============================================================================
+# Nominative labels for the filter note's "nur nach: X, Y" list, keyed by the
+# SourceFilterLiteral values the intent classifier emits.
+SOURCE_FILTER_LABELS_DE = {
+    "manifesto": "das Wahlprogramm",
+    "votes": "namentliche Abstimmungen",
+    "speeches": "Reden",
+    "videos": "Videoaufnahmen von Reden",
+}
+
+# Appended to answer_guidelines when the user explicitly scoped the answer to
+# specific source types. The grounding is already retrieval-filtered; this note
+# makes the model own the scope instead of apologising for "missing" sections,
+# and mandates an honest no-fallback answer when the scoped retrieval is empty.
+SOURCE_FILTER_NOTE_DE = """
+- **Vom Nutzer gewählter Quellenfokus:** Der Nutzer hat ausdrücklich nur nach folgenden Quellenarten gefragt: {requested_sources}. Die bereitgestellten Ausschnitte wurden bewusst auf diese Quellenarten beschränkt. Beantworte die Frage ausschließlich auf dieser Basis; andere Quellenarten fehlen absichtlich — erwähne ihr Fehlen nicht als Mangel.
+- Wenn KEINE passenden Ausschnitte vorliegen, sage klar und ehrlich, dass zu diesem Thema keine Quellen der gewünschten Art vorliegen. Weiche NICHT auf andere Quellenarten aus und erfinde nichts. Biete stattdessen an, die Frage ohne diese Beschränkung zu beantworten.
+"""
+
+# Extra note when the filter includes video recordings: the cited op speeches
+# ARE the videos (the [N] citations deep-link into the recording), so the model
+# must never claim it has no access to video material.
+SOURCE_FILTER_VIDEO_NOTE_DE = """
+- **Videoaufnahmen:** Die bereitgestellten Reden-Ausschnitte stammen ausschließlich aus Reden mit Videoaufzeichnung. Die Quellenangaben [N] verlinken direkt auf die jeweilige Stelle in der Videoaufnahme. Sage NIEMALS, dass du keinen Zugriff auf Videoaufnahmen hast — weise stattdessen darauf hin, dass die zitierten Quellen die Videos direkt öffnen.
+"""
+
+# Appended to the RAG-query-improvement SYSTEM prompt when a source filter is
+# active. The retrieval is already hard-filtered to the requested source types,
+# so the query must target the TOPIC — a query containing the format words
+# ("Videoaufnahmen", "Abstimmungen") retrieves documents ABOUT videos/votes
+# (e.g. Videokonferenzen in der Justiz) instead of documents about the topic.
+RAG_QUERY_SOURCE_FILTER_NOTE_DE = """
+
+# Quellenfokus des Nutzers
+Der Nutzer möchte Ergebnisse ausschließlich aus folgenden Quellenarten: {requested_sources}. Die Suche ist bereits technisch auf diese Quellenarten gefiltert — deine Query darf das gewünschte Format daher NICHT erwähnen.
+Formuliere die Query ausschließlich nach dem inhaltlichen THEMA der Nutzerfrage. Wörter wie "Videoaufnahme", "Video", "Rede", "Abstimmung" oder "Wahlprogramm" dürfen nicht in der Query stehen, wenn sie nur das gewünschte Format beschreiben — sonst findet die Suche Dokumente ÜBER Videos oder Abstimmungen statt Dokumente zum eigentlichen Thema.
+Beispiel: "Habt ihr Videoaufnahmen zum Thema Lohnniveau?" → Query zu Lohnniveau, Mindestlohn und fairer Bezahlung — NICHT zu Videoaufnahmen.
+"""
+
 
 party_response_system_prompt_template_str = """
 # Rolle
@@ -475,6 +516,52 @@ determine_question_type_user_prompt_str = """
 
 determine_question_type_user_prompt = PromptTemplate.from_template(
     determine_question_type_user_prompt_str
+)
+
+determine_source_filter_system_prompt_str = """
+# Rolle
+Du analysierst eine Nachricht eines Nutzers an ein Chatsystem im Kontext des bisherigen Chatverlaufs und entscheidest, ob der Nutzer seine Antwort EXPLIZIT auf bestimmte Quellenarten beschränken möchte.
+
+# Verfügbare Quellenarten
+- "manifesto": Wahlprogramm der Partei. Synonyme: Programm, Parteiprogramm, Manifest, Wahlversprechen im Programm.
+- "votes": Namentliche Abstimmungen im Parlament. Synonyme: Abstimmungen, Abstimmungsverhalten, Voten, "wie hat ... abgestimmt".
+- "speeches": Reden im Bundestag. Synonyme: Plenarreden, Redebeiträge, Aussagen/Zitate aus Reden, "was wurde im Parlament gesagt".
+- "videos": Reden, zu denen eine Videoaufnahme existiert. Synonyme: Videos, Videoaufnahmen, Videoaufzeichnungen, Aufzeichnungen, Recordings, Clips, "etwas zum Anschauen".
+
+# Aufgabe
+Gib die Liste der Quellenarten zurück, auf die der Nutzer die Antwort ausdrücklich beschränken will. Mehrere Quellenarten sind möglich (z.B. "Abstimmungen und Reden zum Thema Infrastruktur" → ["votes", "speeches"]).
+
+# Wichtige Regeln
+- Standard ist die LEERE Liste: Die allermeisten Nachrichten fragen nach einem THEMA, nicht nach einer Quellenart. Gib nur dann Quellenarten an, wenn der Nutzer sie erkennbar verlangt.
+- Fragt der Nutzer nach Videos/Aufnahmen von Reden, gib NUR "videos" an (nicht zusätzlich "speeches"). "speeches" ist für Reden ohne Video-Bezug.
+- Ein Thema, das nur zufällig nach einer Quellenart klingt, ist KEINE Beschränkung: "Wie steht ihr zu Videoüberwachung?" oder "Was haltet ihr von Volksabstimmungen?" sind Themenfragen → leere Liste.
+- Kurze Nachfragen, die eine vorherige explizit quellenbeschränkte Frage fortführen, behalten die Beschränkung bei: Auf "Zeig mir Videoaufnahmen zum Thema Lohnniveau" folgt "und zum Thema Infrastruktur?" → ["videos"].
+- Stellt der Nutzer erkennbar eine neue, normale Frage ohne Quellenbezug, endet die Beschränkung → leere Liste.
+
+# Beispiele
+- "Zeigt mir Videoaufnahmen zum Thema Lohnniveau" → ["videos"]
+- "Wie habt ihr zur Infrastruktur abgestimmt?" → ["votes"]
+- "Was steht in eurem Wahlprogramm zur Bildung?" → ["manifesto"]
+- "Was wurde dazu in Reden im Bundestag gesagt?" → ["speeches"]
+- "Habt ihr Abstimmungen oder Reden zum Mindestlohn?" → ["votes", "speeches"]
+- "Was tut ihr gegen niedrige Löhne?" → []
+- "Wie steht ihr zur Vorratsdatenspeicherung von Videomaterial?" → []
+"""
+
+determine_source_filter_system_prompt = PromptTemplate.from_template(
+    determine_source_filter_system_prompt_str
+)
+
+determine_source_filter_user_prompt_str = """
+## Bisheriger Chatverlauf
+{previous_chat_history}
+
+## Nutzerfrage
+{user_message}
+"""
+
+determine_source_filter_user_prompt = PromptTemplate.from_template(
+    determine_source_filter_user_prompt_str
 )
 
 generate_chat_summary_system_prompt_str = """

--- a/ai-backend/tests/test_chatbot_async.py
+++ b/ai-backend/tests/test_chatbot_async.py
@@ -120,6 +120,10 @@ def test_federal_origin_disclosure_note_only_for_non_federal() -> None:
             f"{lvl}: note must reference Bundestag, got {note!r}"
         )
         assert "Landtag" in note, f"{lvl}: note must reference Landtag, got {note!r}"
+        # Level-separation guidance: never weave a Bund statement and a Land
+        # statement into one storyline (customer feedback on a BW answer).
+        assert "Ebene" in note, f"{lvl}: note must carry the level-separation rule"
+        assert "NIEMALS" in note, f"{lvl}: note must forbid cross-level storyline joins"
 
 
 def test_both_response_paths_apply_federal_disclosure(monkeypatch) -> None:

--- a/ai-backend/tests/test_retrieve.py
+++ b/ai-backend/tests/test_retrieve.py
@@ -185,6 +185,62 @@ def test_source_type_filter(temp_qdrant_collection) -> None:  # type: ignore[typ
     )
 
 
+def test_source_provenance_filter(temp_qdrant_collection) -> None:  # type: ignore[type-arg]
+    """retrieve(source_type='parliamentary_speech', source='op') returns only
+    op (video-bearing) speeches — the user-facing "nur Videoaufnahmen" scope.
+    Omitting `source` keeps returning both provenances (default unchanged)."""
+    from qdrant_client.models import PointStruct
+
+    from src.ingestion.retrieve import retrieve
+
+    client, collection_name = temp_qdrant_collection
+
+    points = []
+    for i, source in enumerate(["op", "op", "dip", "dip", "dip"]):
+        payload = _make_payload("parliamentary_speech")
+        payload["source"] = source
+        # Distinct speech_keys so dedup_prefer_op never collapses anything.
+        payload["speech_key"] = f"de-20-1-speaker{i}-topic{i}"
+        points.append(
+            PointStruct(
+                id=str(uuid.uuid4()),
+                vector={"dense": _zero_vector()},
+                payload=payload,
+            )
+        )
+    client.upsert(collection_name=collection_name, points=points, wait=True)
+
+    import src.ingestion.retrieve as _retrieve_mod
+
+    original_collection = _retrieve_mod.COLLECTION_NAME
+    _retrieve_mod.COLLECTION_NAME = collection_name  # type: ignore[assignment]
+    try:
+        op_only = retrieve(
+            query="lohnniveau",
+            source_type="parliamentary_speech",
+            source="op",
+            limit=10,
+            _client=client,
+            _embed_fn=_fake_embed,
+        )
+        unfiltered = retrieve(
+            query="lohnniveau",
+            source_type="parliamentary_speech",
+            limit=10,
+            _client=client,
+            _embed_fn=_fake_embed,
+        )
+    finally:
+        _retrieve_mod.COLLECTION_NAME = original_collection  # type: ignore[assignment]
+
+    assert len(op_only) == 2, f"expected exactly the 2 op speeches, got {len(op_only)}"
+    assert all(p.get("source") == "op" for p in op_only)
+
+    assert {p.get("source") for p in unfiltered} == {"op", "dip"}, (
+        "omitting `source` must keep returning both provenances"
+    )
+
+
 # ---------------------------------------------------------------------------
 # test_query_vector_skips_embed
 # ---------------------------------------------------------------------------

--- a/ai-backend/tests/test_source_filter.py
+++ b/ai-backend/tests/test_source_filter.py
@@ -250,11 +250,22 @@ def test_source_filter_note_composition() -> None:
 
     videos = _source_filter_note(["videos"])
     assert "Videoaufnahmen von Reden" in videos
-    # The video-specific instruction must be present: never claim no video
-    # access, and citations render as video BUTTONS — the model must not
-    # describe its raw [N] bracket syntax to users.
-    assert "Video-Buttons" in videos
-    assert "eckigen Klammern" in videos
+    # Video-specific instruction: never claim no video access; the citation
+    # buttons open the recording.
+    assert "NIEMALS" in videos
+    assert "öffnen direkt die Videoaufnahme" in videos
+
+
+def test_base_guidelines_describe_citation_rendering() -> None:
+    """The shared Zitierstil block must tell the model its [N] citations render
+    as clickable buttons — the model only sees its raw markdown and otherwise
+    explains its own bracket syntax to users ('klicke auf die eckigen
+    Klammern')."""
+    from src.prompts import get_chat_answer_guidelines
+
+    guidelines = get_chat_answer_guidelines("SPD")
+    assert "klickbare Quellen-Buttons" in guidelines
+    assert "Video-Button" in guidelines
 
 
 def test_source_filter_labels_are_canonically_ordered() -> None:

--- a/ai-backend/tests/test_source_filter.py
+++ b/ai-backend/tests/test_source_filter.py
@@ -1,0 +1,455 @@
+# SPDX-FileCopyrightText: 2026 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""
+User-requested source-type filter ("zeig mir nur Videos/Abstimmungen zu …").
+
+Tests defined here:
+  - _retrieve_party_buckets gating: only requested source legs run, requested
+    legs get the raised _FILTERED_* budgets, "videos" adds the source=="op"
+    provenance filter to the speech leg (unless "speeches" is also requested).
+  - The default (no filter) path is byte-for-byte unchanged (all legs, original
+    limits, no provenance filter).
+  - A total failure of all REQUESTED sources raises RetrievalUnavailableError
+    (the pre-filter literal 3 would let a votes-only outage stream ungrounded).
+  - detect_source_filter is fail-open and returns canonical-order values.
+  - _source_filter_note composition (empty / labels / video instruction).
+  - generate_improvement_rag_query appends the topic-not-format note.
+  - sources[] entries carry source_type.
+  - the adaptive speech trim is skipped under a filter.
+
+Behavioural tests — collaborators are monkeypatched; no LLM, no network, no
+live Qdrant.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+import src.chat_service as cs
+import src.chatbot_async as ca
+from src.chat_service import RetrievalUnavailableError, fetch_party_response_stream
+from src.chatbot_async import (
+    _source_filter_note,
+    detect_source_filter,
+    generate_improvement_rag_query,
+    source_filter_labels_de,
+)
+from src.models.chat import GroupChatSession, Message
+from src.models.context import ContextParty
+from src.models.general import LLMSize
+from src.models.structured_outputs import SourceFilterClassifier
+from datetime import datetime, timezone
+
+
+_TW = (
+    datetime(2021, 1, 1, tzinfo=timezone.utc),
+    datetime(2026, 1, 1, tzinfo=timezone.utc),
+)
+
+
+def _make_party(pid: str = "spd") -> ContextParty:
+    return ContextParty(
+        party_id=pid,
+        name=pid.upper(),
+        long_name=f"{pid.upper()} lang",
+        website_url="https://example.com",
+    )
+
+
+def _make_session() -> GroupChatSession:
+    return GroupChatSession(
+        session_id="s1",
+        context_id="c1",
+        chat_history=[Message(id="m1", role="user", content="Frage?")],
+        chat_response_llm_size=LLMSize.LARGE,
+    )
+
+
+class _FakeEmbed:
+    async def aembed_query(self, _query: str) -> list[float]:
+        return [0.0, 0.1, 0.2]
+
+
+def _drive_buckets(term_window, source_filter) -> None:
+    asyncio.run(
+        cs._retrieve_party_buckets(
+            party=_make_party(),
+            improved_rag_query="q",
+            rag_query_vector=[0.0],
+            region_path=["DE"],
+            legislature_period_id=None,
+            election_level="federal",
+            term_window=term_window,
+            manifesto_term_start=None,
+            source_filter=source_filter,
+        )
+    )
+
+
+def _recorder(store: dict, result):
+    def _rec(_query, **kwargs):
+        store[kwargs.get("source_type")] = kwargs
+        return result
+
+    return _rec
+
+
+# ---------------------------------------------------------------------------
+# Retrieval gating
+# ---------------------------------------------------------------------------
+
+
+def test_bucket_gating_votes_only(monkeypatch) -> None:
+    """source_filter=["votes"] runs ONLY the vote leg (two-pass AND single-pass)
+    with the raised filtered budget."""
+    two_pass_calls: dict = {}
+    monkeypatch.setattr(
+        cs,
+        "retrieve_two_pass",
+        _recorder(two_pass_calls, {"current": [], "historic": []}),
+    )
+    _drive_buckets(_TW, ["votes"])
+    assert set(two_pass_calls) == {"vote_record"}
+    assert two_pass_calls["vote_record"]["current_limit"] == cs._FILTERED_VOTE_LIMIT
+
+    single_calls: dict = {}
+    monkeypatch.setattr(cs, "retrieve", _recorder(single_calls, []))
+    _drive_buckets(None, ["votes"])
+    assert set(single_calls) == {"vote_record"}
+    assert single_calls["vote_record"]["limit"] == cs._FILTERED_VOTE_LIMIT
+
+
+def test_bucket_gating_videos_only(monkeypatch) -> None:
+    """source_filter=["videos"] runs ONLY the speech leg, with the Qdrant-level
+    source=="op" provenance filter and the raised speech budget."""
+    two_pass_calls: dict = {}
+    monkeypatch.setattr(
+        cs,
+        "retrieve_two_pass",
+        _recorder(two_pass_calls, {"current": [], "historic": []}),
+    )
+    _drive_buckets(_TW, ["videos"])
+    assert set(two_pass_calls) == {"parliamentary_speech"}
+    speech_kw = two_pass_calls["parliamentary_speech"]
+    assert speech_kw["source"] == "op"
+    assert speech_kw["current_limit"] == cs._FILTERED_SPEECH_LIMIT
+
+    single_calls: dict = {}
+    monkeypatch.setattr(cs, "retrieve", _recorder(single_calls, []))
+    _drive_buckets(None, ["videos"])
+    assert set(single_calls) == {"parliamentary_speech"}
+    assert single_calls["parliamentary_speech"]["source"] == "op"
+
+
+def test_bucket_gating_videos_plus_speeches_keeps_dip(monkeypatch) -> None:
+    """ "speeches" alongside "videos" keeps the UNfiltered speech leg — the user
+    asked for speeches in general, op results already rank first via dedup."""
+    two_pass_calls: dict = {}
+    monkeypatch.setattr(
+        cs,
+        "retrieve_two_pass",
+        _recorder(two_pass_calls, {"current": [], "historic": []}),
+    )
+    _drive_buckets(_TW, ["speeches", "videos"])
+    assert set(two_pass_calls) == {"parliamentary_speech"}
+    assert two_pass_calls["parliamentary_speech"]["source"] is None
+
+
+def test_bucket_default_all_sources_unchanged(monkeypatch) -> None:
+    """No filter → all three legs with the original budgets and no provenance
+    filter — the pre-feature behaviour, byte-for-byte."""
+    two_pass_calls: dict = {}
+    monkeypatch.setattr(
+        cs,
+        "retrieve_two_pass",
+        _recorder(two_pass_calls, {"current": [], "historic": []}),
+    )
+    _drive_buckets(_TW, None)
+    assert set(two_pass_calls) == {
+        "vote_record",
+        "party_manifesto",
+        "parliamentary_speech",
+    }
+    assert two_pass_calls["vote_record"]["current_limit"] == cs._CURRENT_VOTE_LIMIT
+    assert (
+        two_pass_calls["party_manifesto"]["current_limit"]
+        == cs._CURRENT_MANIFESTO_LIMIT
+    )
+    speech_kw = two_pass_calls["parliamentary_speech"]
+    assert speech_kw["current_limit"] == cs._CURRENT_SPEECH_FALLBACK
+    assert speech_kw["source"] is None
+
+
+def test_requested_source_failure_fails_turn(monkeypatch) -> None:
+    """When EVERY requested source fails, the turn must fail — with a votes-only
+    filter a single vote-leg outage is a total outage (the pre-filter literal 3
+    would stream an ungrounded 'successful' answer instead)."""
+
+    def _boom(_query, **_kwargs):
+        raise RuntimeError("qdrant down")
+
+    monkeypatch.setattr(cs, "retrieve_two_pass", _boom)
+    with pytest.raises(RetrievalUnavailableError):
+        _drive_buckets(_TW, ["votes"])
+
+
+def test_one_of_two_requested_sources_may_fail(monkeypatch) -> None:
+    """With two requested sources, one failing leg degrades to empty buckets
+    (per-source degradation) instead of failing the turn."""
+
+    def _vote_fails(_query, **kwargs):
+        if kwargs.get("source_type") == "vote_record":
+            raise RuntimeError("vote leg down")
+        return {"current": [], "historic": []}
+
+    monkeypatch.setattr(cs, "retrieve_two_pass", _vote_fails)
+    _drive_buckets(_TW, ["votes", "speeches"])  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Intent detection
+# ---------------------------------------------------------------------------
+
+
+def test_detect_source_filter_canonical_order_and_dedup(monkeypatch) -> None:
+    async def _mock_structured(_llms, _messages, _model):
+        return SourceFilterClassifier(
+            requested_source_types=["videos", "votes", "votes"]
+        )
+
+    monkeypatch.setattr(ca, "get_structured_output_from_llms", _mock_structured)
+    result = asyncio.run(detect_source_filter("msg", "history"))
+    assert result == ["votes", "videos"]
+
+
+def test_detect_source_filter_fail_open(monkeypatch) -> None:
+    """A classifier error degrades to [] (all sources) — never a blocked turn."""
+
+    async def _mock_structured(_llms, _messages, _model):
+        raise RuntimeError("LLM unavailable")
+
+    monkeypatch.setattr(ca, "get_structured_output_from_llms", _mock_structured)
+    assert asyncio.run(detect_source_filter("msg", "history")) == []
+
+
+# ---------------------------------------------------------------------------
+# Prompt composition
+# ---------------------------------------------------------------------------
+
+
+def test_source_filter_note_composition() -> None:
+    assert _source_filter_note(None) == ""
+    assert _source_filter_note([]) == ""
+
+    votes_speeches = _source_filter_note(["votes", "speeches"])
+    assert "namentliche Abstimmungen und Reden" in votes_speeches
+    assert "Videoaufnahmen" not in votes_speeches
+
+    videos = _source_filter_note(["videos"])
+    assert "Videoaufnahmen von Reden" in videos
+    # The video-specific instruction (citations ARE the videos) must be present.
+    assert "verlinken direkt" in videos
+
+
+def test_source_filter_labels_are_canonically_ordered() -> None:
+    assert (
+        source_filter_labels_de(["videos", "manifesto"])
+        == "das Wahlprogramm und Videoaufnahmen von Reden"
+    )
+
+
+def test_improvement_query_gets_topic_not_format_note(monkeypatch) -> None:
+    """With a filter active, the query-improvement system prompt instructs the
+    model to query the TOPIC and never the media format; without a filter the
+    prompt is unchanged."""
+    captured: dict = {}
+
+    class _Resp:
+        content = "improved query"
+
+    async def _mock_answer(_llms, messages):
+        captured["system"] = messages[0].content
+        return _Resp()
+
+    monkeypatch.setattr(ca, "get_answer_from_llms", _mock_answer)
+
+    asyncio.run(
+        generate_improvement_rag_query(
+            _make_party(),
+            "conv",
+            "Habt ihr Videos zum Lohnniveau?",
+            source_filter=["videos"],
+        )
+    )
+    assert "Quellenfokus des Nutzers" in captured["system"]
+    assert "Videoaufnahmen von Reden" in captured["system"]
+
+    asyncio.run(generate_improvement_rag_query(_make_party(), "conv", "Frage?"))
+    assert "Quellenfokus des Nutzers" not in captured["system"]
+
+
+# ---------------------------------------------------------------------------
+# sources[] source_type marker + adaptive trim under filter
+# ---------------------------------------------------------------------------
+
+
+def _wire_stream_mocks(monkeypatch, capture: dict) -> None:
+    async def _mock_rag_query(*_a, **_k) -> str:
+        return "improved q"
+
+    async def _mock_llm(_party, _conv, _question, combined_docs, **kwargs):
+        capture["combined_docs"] = combined_docs
+        capture["llm_kwargs"] = kwargs
+
+        async def _gen():
+            return
+            yield  # pragma: no cover
+
+        return _gen()
+
+    monkeypatch.setattr(cs, "generate_improvement_rag_query", _mock_rag_query)
+    monkeypatch.setattr(cs, "embed", _FakeEmbed())
+    monkeypatch.setattr(cs, "generate_streaming_chatbot_response", _mock_llm)
+
+
+def _drive_single_party(
+    term_window, capture, monkeypatch, **stream_kwargs
+) -> list[str]:
+    _wire_stream_mocks(monkeypatch, capture)
+
+    async def _run() -> list[str]:
+        events: list[str] = []
+        async for ev in fetch_party_response_stream(
+            _make_party(),
+            "conv",
+            "q?",
+            _make_session(),
+            all_available_parties=[],
+            use_premium_llms=False,
+            is_proposed_question=False,
+            is_cacheable_chat=False,
+            region_path=["DE"],
+            term_window=term_window,
+            **stream_kwargs,
+        ):
+            events.append(ev)
+        return events
+
+    return asyncio.run(_run())
+
+
+def _sources_from_events(events: list[str]) -> list[dict]:
+    for ev in events:
+        if '"sources_ready"' in ev:
+            return json.loads(ev)["data"]["sources"]
+    return []
+
+
+def _manifesto_payload(title: str) -> dict:
+    return {
+        "citation_title": title,
+        "citation_url": "https://example.com/m.pdf",
+        "publish_date": "2025-01-01",
+        "text": "manifesto text",
+        "meta": {"page_start": 3},
+    }
+
+
+def _vote_payload(title: str) -> dict:
+    return {
+        "citation_title": title,
+        "citation_url": "https://example.com/v",
+        "publish_date": "2025-02-01",
+        "region": "DE",
+        "text": "vote text",
+        "meta": {
+            "motion_outcome": "angenommen",
+            "vote_results": [
+                {
+                    "party_id": "spd",
+                    "stance": "yes",
+                    "yes": 100,
+                    "no": 0,
+                    "abstain": 0,
+                    "no_show": 0,
+                }
+            ],
+        },
+    }
+
+
+def _speech_payload(title: str) -> dict:
+    return {
+        "citation_title": title,
+        "citation_url": "https://example.com/s.pdf",
+        "publish_date": "2025-03-01",
+        "source": "dip",
+        "text": "speech text",
+        "meta": {},
+    }
+
+
+def test_sources_carry_source_type(monkeypatch) -> None:
+    """Every emitted sources[] entry names its corpus source category so the
+    client can label/group by kind instead of sniffing URLs."""
+
+    def _retrieve(_query, **kwargs):
+        st = kwargs.get("source_type")
+        if st == "party_manifesto":
+            return [_manifesto_payload("Programm")]
+        if st == "vote_record":
+            return [_vote_payload("Abstimmung")]
+        return [_speech_payload("Rede")]
+
+    monkeypatch.setattr(cs, "retrieve", _retrieve)
+    capture: dict = {}
+    sources = _sources_from_events(_drive_single_party(None, capture, monkeypatch))
+
+    by_name = {s["source"]: s for s in sources}
+    assert by_name["Programm"]["source_type"] == "party_manifesto"
+    assert by_name["Abstimmung"]["source_type"] == "vote_record"
+    assert by_name["Rede"]["source_type"] == "parliamentary_speech"
+
+
+def test_speech_trim_skipped_under_filter(monkeypatch) -> None:
+    """With official data present the speech bucket is normally trimmed to
+    _CURRENT_SPEECH_LIMIT; under a user filter the requested speeches keep their
+    raised budget."""
+    n_speeches = cs._CURRENT_SPEECH_LIMIT + 2
+
+    def _retrieve(_query, **kwargs):
+        st = kwargs.get("source_type")
+        if st == "party_manifesto":
+            return [_manifesto_payload("Programm")]
+        if st == "vote_record":
+            return [_vote_payload("Abstimmung")]
+        return [_speech_payload(f"Rede {i}") for i in range(n_speeches)]
+
+    def _speech_docs(docs) -> list:
+        return [
+            d for d in docs if d.metadata.get("source_type") == "parliamentary_speech"
+        ]
+
+    monkeypatch.setattr(cs, "retrieve", _retrieve)
+
+    capture: dict = {}
+    _drive_single_party(None, capture, monkeypatch)
+    assert len(_speech_docs(capture["combined_docs"])) == cs._CURRENT_SPEECH_LIMIT
+
+    capture_filtered: dict = {}
+    _drive_single_party(
+        None,
+        capture_filtered,
+        monkeypatch,
+        source_filter=["manifesto", "votes", "speeches"],
+    )
+    assert len(_speech_docs(capture_filtered["combined_docs"])) == n_speeches
+    # The filter must also reach answer generation for the prompt note.
+    assert capture_filtered["llm_kwargs"]["source_filter"] == [
+        "manifesto",
+        "votes",
+        "speeches",
+    ]

--- a/ai-backend/tests/test_source_filter.py
+++ b/ai-backend/tests/test_source_filter.py
@@ -25,6 +25,7 @@ live Qdrant.
 
 import asyncio
 import json
+from datetime import datetime, timezone
 
 import pytest
 
@@ -41,8 +42,6 @@ from src.models.chat import GroupChatSession, Message
 from src.models.context import ContextParty
 from src.models.general import LLMSize
 from src.models.structured_outputs import SourceFilterClassifier
-from datetime import datetime, timezone
-
 
 _TW = (
     datetime(2021, 1, 1, tzinfo=timezone.utc),

--- a/ai-backend/tests/test_source_filter.py
+++ b/ai-backend/tests/test_source_filter.py
@@ -250,8 +250,11 @@ def test_source_filter_note_composition() -> None:
 
     videos = _source_filter_note(["videos"])
     assert "Videoaufnahmen von Reden" in videos
-    # The video-specific instruction (citations ARE the videos) must be present.
-    assert "verlinken direkt" in videos
+    # The video-specific instruction must be present: never claim no video
+    # access, and citations render as video BUTTONS — the model must not
+    # describe its raw [N] bracket syntax to users.
+    assert "Video-Buttons" in videos
+    assert "eckigen Klammern" in videos
 
 
 def test_source_filter_labels_are_canonically_ordered() -> None:

--- a/web/components/chat/chat-markdown.tsx
+++ b/web/components/chat/chat-markdown.tsx
@@ -71,8 +71,7 @@ function ChatMarkdown({ message }: Props) {
     return `${number + 1}`;
   };
 
-  // Derived from getSourceMediaLinks (the same helper a click uses to decide
-  // how to open), so the video pill can never disagree with what a click does.
+  // Same helper the click handler uses, so the pill never disagrees with a click.
   const getReferenceIsVideo = (number: number) => {
     const source = message.sources?.[number];
     if (!source) {

--- a/web/components/chat/chat-markdown.tsx
+++ b/web/components/chat/chat-markdown.tsx
@@ -3,6 +3,7 @@
 import { Markdown } from '@/components/markdown';
 import { useMediaViewer } from '@/components/providers/media-viewer-provider';
 import type { Source } from '@/lib/stores/chat-store.types';
+import { getSourceMediaLinks } from '@/lib/utils';
 
 type Props = {
   message: {
@@ -70,11 +71,22 @@ function ChatMarkdown({ message }: Props) {
     return `${number + 1}`;
   };
 
+  // Derived from getSourceMediaLinks (the same helper a click uses to decide
+  // how to open), so the video pill can never disagree with what a click does.
+  const getReferenceIsVideo = (number: number) => {
+    const source = message.sources?.[number];
+    if (!source) {
+      return false;
+    }
+    return getSourceMediaLinks(source).some((link) => link.kind === 'video');
+  };
+
   return (
     <Markdown
       onReferenceClick={onReferenceClick}
       getReferenceTooltip={getReferenceTooltip}
       getReferenceName={getReferenceName}
+      getReferenceIsVideo={getReferenceIsVideo}
     >
       {message.content ?? ''}
     </Markdown>

--- a/web/components/chat/chat-message-reference.tsx
+++ b/web/components/chat/chat-message-reference.tsx
@@ -27,7 +27,10 @@ function ChatMessageReference({
   return (
     <span key={index} className="inline-flex flex-row flex-wrap gap-1">
       {numbers.map((number) => {
-        const refNumber = Number.parseInt(number);
+        const refNumber = Number.parseInt(number, 10);
+        if (Number.isNaN(refNumber)) {
+          return null;
+        }
 
         const name = getReferenceName?.(refNumber) ?? `Ref. ${number}`;
         const tooltip = getReferenceTooltip?.(refNumber) ?? name;
@@ -45,7 +48,7 @@ function ChatMessageReference({
                   isVideo &&
                     'gap-1 bg-primary/10 font-medium text-primary hover:bg-primary/20 dark:bg-primary/20 dark:hover:bg-primary/30',
                 )}
-                onClick={() => onReferenceClick(Number.parseInt(number))}
+                onClick={() => onReferenceClick(refNumber)}
               >
                 {isVideo ? (
                   <>

--- a/web/components/chat/chat-message-reference.tsx
+++ b/web/components/chat/chat-message-reference.tsx
@@ -4,6 +4,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
+import { ClapperboardIcon } from 'lucide-react';
 
 type Props = {
   numbers: string[];
@@ -11,6 +12,9 @@ type Props = {
   onReferenceClick: (number: number) => void;
   getReferenceTooltip?: (number: number) => string | null;
   getReferenceName?: (number: number) => string | null;
+  // True when the reference opens as a video (op speech recording) — rendered
+  // as a prominent call-to-action pill instead of a bare number.
+  getReferenceIsVideo?: (number: number) => boolean;
 };
 
 function ChatMessageReference({
@@ -19,6 +23,7 @@ function ChatMessageReference({
   onReferenceClick,
   getReferenceTooltip,
   getReferenceName,
+  getReferenceIsVideo,
 }: Props) {
   return (
     <span key={index} className="inline-flex flex-row flex-wrap gap-1">
@@ -27,6 +32,7 @@ function ChatMessageReference({
 
         const name = getReferenceName?.(refNumber) ?? `Ref. ${number}`;
         const tooltip = getReferenceTooltip?.(refNumber) ?? name;
+        const isVideo = getReferenceIsVideo?.(refNumber) ?? false;
 
         return (
           <Tooltip key={number}>
@@ -37,10 +43,19 @@ function ChatMessageReference({
                 className={cn(
                   'inline-flex cursor-pointer items-center justify-center rounded-full bg-muted px-2 py-1 text-xs transition-colors hover:bg-muted/80',
                   'group-data-[has-message-background=true]:bg-zinc-200 dark:group-data-[has-message-background=true]:bg-zinc-800',
+                  isVideo &&
+                    'gap-1 bg-primary/10 font-medium text-primary hover:bg-primary/20 dark:bg-primary/20 dark:hover:bg-primary/30',
                 )}
                 onClick={() => onReferenceClick(Number.parseInt(number))}
               >
-                {name}
+                {isVideo ? (
+                  <>
+                    <ClapperboardIcon className="size-3.5 shrink-0" />
+                    <span>Video {name}</span>
+                  </>
+                ) : (
+                  name
+                )}
               </span>
             </TooltipTrigger>
             <TooltipContent className="max-w-96 text-ellipsis whitespace-nowrap">

--- a/web/components/chat/chat-message-reference.tsx
+++ b/web/components/chat/chat-message-reference.tsx
@@ -12,8 +12,7 @@ type Props = {
   onReferenceClick: (number: number) => void;
   getReferenceTooltip?: (number: number) => string | null;
   getReferenceName?: (number: number) => string | null;
-  // True when the reference opens as a video (op speech recording) — rendered
-  // as a prominent call-to-action pill instead of a bare number.
+  // Video references render as a call-to-action pill instead of a bare number.
   getReferenceIsVideo?: (number: number) => boolean;
 };
 

--- a/web/components/markdown.tsx
+++ b/web/components/markdown.tsx
@@ -15,6 +15,7 @@ type Props = {
   onReferenceClick: (number: number) => void;
   getReferenceName?: (number: number) => string | null;
   getReferenceTooltip?: (number: number) => string | null;
+  getReferenceIsVideo?: (number: number) => boolean;
 };
 
 const NonMemoizedMarkdown = ({
@@ -22,6 +23,7 @@ const NonMemoizedMarkdown = ({
   onReferenceClick,
   getReferenceTooltip,
   getReferenceName,
+  getReferenceIsVideo,
 }: Props) => {
   // react-markdown v9 passes a 'node' prop to components which is not a valid DOM attribute
   // and causes TypeScript errors when spreading props to elements like Link or pre.
@@ -54,6 +56,7 @@ const NonMemoizedMarkdown = ({
                 onReferenceClick={onReferenceClick}
                 getReferenceTooltip={getReferenceTooltip}
                 getReferenceName={getReferenceName}
+                getReferenceIsVideo={getReferenceIsVideo}
               />
             );
           }

--- a/web/lib/stores/chat-store.types.ts
+++ b/web/lib/stores/chat-store.types.ts
@@ -17,9 +17,8 @@ export type Source = {
   source_document: string;
   document_publish_date: string;
   party_id?: string;
-  // Corpus source category ('party_manifesto' | 'vote_record' |
-  // 'parliamentary_speech'); absent on messages persisted before it shipped.
-  source_type?: string;
+  // Corpus source category; absent on messages persisted before it shipped.
+  source_type?: 'party_manifesto' | 'vote_record' | 'parliamentary_speech';
   // Dual-format speech links (backend merges op video + DIP transcript into ONE
   // source): when both are present the citation renders two quick-links — the
   // video deep-link and the PDF transcript — for the same source. `url` stays the

--- a/web/lib/stores/chat-store.types.ts
+++ b/web/lib/stores/chat-store.types.ts
@@ -17,6 +17,10 @@ export type Source = {
   source_document: string;
   document_publish_date: string;
   party_id?: string;
+  // Corpus source category ('party_manifesto' | 'vote_record' |
+  // 'parliamentary_speech') — lets the UI label/group sources by kind instead
+  // of sniffing URLs. Optional: absent on messages persisted before it shipped.
+  source_type?: string;
   // Dual-format speech links (backend merges op video + DIP transcript into ONE
   // source): when both are present the citation renders two quick-links — the
   // video deep-link and the PDF transcript — for the same source. `url` stays the

--- a/web/lib/stores/chat-store.types.ts
+++ b/web/lib/stores/chat-store.types.ts
@@ -18,8 +18,7 @@ export type Source = {
   document_publish_date: string;
   party_id?: string;
   // Corpus source category ('party_manifesto' | 'vote_record' |
-  // 'parliamentary_speech') — lets the UI label/group sources by kind instead
-  // of sniffing URLs. Optional: absent on messages persisted before it shipped.
+  // 'parliamentary_speech'); absent on messages persisted before it shipped.
   source_type?: string;
   // Dual-format speech links (backend merges op video + DIP transcript into ONE
   // source): when both are present the citation renders two quick-links — the


### PR DESCRIPTION
## Summary

Source filtering feature: users can ask for specific source kinds directly (e.g. "Zeigt mir Videoaufnahmen zum Thema Lohnniveau", "Abstimmungen zur Infrastruktur").

A new LLM preprocessing step (concurrent with party targeting) detects the requested source kinds (`manifesto` / `votes` / `speeches` / `videos`, **default: all**; fail-open). Retrieval then only queries those legs, with raised top-k budgets at the unchanged score threshold; `videos` filters the speech leg to `source=="op"` in Qdrant. Filtered turns bypass the cross-user cache. Works in single-party and comparison chats; follow-ups keep the filter.

Also in this PR:

- **Video pills**: citations that open a recording render as a clapperboard "Video N" button instead of a bare number (chat + share pages).
- **Bund/Land separation** (prompt-only): Landtagswahl answers must signpost level switches, never "lehnt X ab [Bund]. Stattdessen Y [Land]" as one storyline.

## Trying it

`make dev`, Bundestagswahl chat: "Zeigt mir Videoaufnahmen zum Thema Lohnniveau" → video-only answer with pills; "Wie steht ihr zu Videoüberwachung?" → normal answer (negative control). Backend log shows each verdict: `User source filter active … ['videos']`.
