### PR TITLE
129 improve seo

### DIFF
--- a/web/app/(custom-header)/login/page.tsx
+++ b/web/app/(custom-header)/login/page.tsx
@@ -1,4 +1,10 @@
 import LoginForm from '@/components/auth/login-form';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Login',
+  robots: 'noindex, nofollow',
+};
 
 function LoginPage() {
   return <LoginForm onSuccess={() => {}} />;

--- a/web/app/(with-header)/about-us/page.tsx
+++ b/web/app/(with-header)/about-us/page.tsx
@@ -9,7 +9,6 @@ export const metadata: Metadata = {
   title: 'Über uns',
   description:
     'Das Team hinter wahl.chat – wer wir sind und warum wir Politik interaktiv zugänglich machen.',
-  robots: 'noindex',
 };
 
 function AboutUs() {

--- a/web/app/(with-header)/how-to/page.tsx
+++ b/web/app/(with-header)/how-to/page.tsx
@@ -5,7 +5,6 @@ export const metadata: Metadata = {
   title: 'So funktioniert wahl.chat',
   description:
     'Erfahre, wie du wahl.chat nutzen kannst – Parteien vergleichen, Fragen stellen und quellengestützte Antworten erhalten.',
-  robots: 'noindex',
 };
 
 function HowToPage() {

--- a/web/app/(with-header)/topics/page.tsx
+++ b/web/app/(with-header)/topics/page.tsx
@@ -14,7 +14,6 @@ export const metadata: Metadata = {
   title: 'Beliebte Themen',
   description:
     'Entdecke beliebte politische Themen und Fragen – vergleiche die Positionen der Parteien bei wahl.chat.',
-  robots: 'noindex',
 };
 
 async function TopicsPage() {

--- a/web/app/(with-header)/topics/page.tsx
+++ b/web/app/(with-header)/topics/page.tsx
@@ -14,6 +14,9 @@ export const metadata: Metadata = {
   title: 'Beliebte Themen',
   description:
     'Entdecke beliebte politische Themen und Fragen – vergleiche die Positionen der Parteien bei wahl.chat.',
+  // Context-less and built around federal parties, so it is not tied to a
+  // current election and should not surface for election queries.
+  robots: 'noindex',
 };
 
 async function TopicsPage() {

--- a/web/app/[contextId]/(home)/share/page.tsx
+++ b/web/app/[contextId]/(home)/share/page.tsx
@@ -11,6 +11,7 @@ import {
 import { InternalReferrers } from '@/lib/internal-referrers';
 import { cn, generateOgImageUrl } from '@/lib/utils';
 import { ArrowLeftIcon } from 'lucide-react';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
 
@@ -24,13 +25,19 @@ type Props = {
   }>;
 };
 
-export async function generateMetadata({ searchParams }: Props) {
+export async function generateMetadata({
+  searchParams,
+}: Props): Promise<Metadata> {
+  // Shared chats are user-generated with an unbounded URL space, so every return
+  // path here must opt out of indexing.
+  const noIndex: Metadata = { robots: 'noindex, nofollow' };
+
   const { snapshot_id } = await searchParams;
 
   const snapshot = await getSnapshot(snapshot_id);
 
   if (snapshot.party_ids.length > 1) {
-    return {};
+    return noIndex;
   }
 
   const partyId = snapshot.party_ids[0];
@@ -38,10 +45,11 @@ export async function generateMetadata({ searchParams }: Props) {
   const image = await generateOgImageUrl(partyId);
 
   if (!image) {
-    return {};
+    return noIndex;
   }
 
   return {
+    ...noIndex,
     openGraph: {
       images: [image],
     },

--- a/web/app/[contextId]/(home)/sources/page.tsx
+++ b/web/app/[contextId]/(home)/sources/page.tsx
@@ -37,10 +37,7 @@ export async function generateMetadata({
     return { title: 'Quellen' };
   }
 
-  return {
-    ...buildContextMetadata(context, 'Quellen'),
-    robots: 'noindex',
-  };
+  return buildContextMetadata(context, 'Quellen');
 }
 
 async function SourcesPage({ params }: Props) {

--- a/web/app/[contextId]/layout.tsx
+++ b/web/app/[contextId]/layout.tsx
@@ -28,10 +28,11 @@ export async function generateMetadata({
   const context = await getContext(contextId);
 
   if (!context) {
-    return {};
+    // The page body redirects to the default context, so this URL must not be indexed.
+    return { robots: 'noindex, nofollow' };
   }
 
-  return buildContextMetadata(context, undefined, true);
+  return buildContextMetadata(context);
 }
 
 async function ContextLayout({ children, params }: Props) {

--- a/web/app/[contextId]/session/layout.tsx
+++ b/web/app/[contextId]/session/layout.tsx
@@ -4,6 +4,13 @@ import ChatSidebar from '@/components/chat/sidebar/chat-sidebar';
 import { ChatStoreProvider } from '@/components/providers/chat-store-provider';
 import SseChatProvider from '@/components/providers/sse-chat-provider';
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
+import type { Metadata } from 'next';
+
+// Covers both /[contextId]/session and /[contextId]/session/[chatSessionId]: chat
+// sessions are user-generated and must never be indexed.
+export const metadata: Metadata = {
+  robots: 'noindex, nofollow',
+};
 
 type Props = {
   children: React.ReactNode;

--- a/web/app/agent/layout.tsx
+++ b/web/app/agent/layout.tsx
@@ -5,9 +5,10 @@ import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Wahl Agent | wahl.chat',
+  title: 'Wahl Agent',
   description:
     'Dein persönlicher Begleiter zur politischen Meinungsbildung. Diskutiere politische Themen mit dem Wahl Agent.',
+  robots: 'noindex, nofollow',
 };
 
 interface Props {

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -9,12 +9,26 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   if (contexts.length === 0) {
     // Intentional fallback: if no contexts are available, the sitemap only includes static pages.
     console.warn(
-      'sitemap(): getContexts() returned no contexts; generating sitemap with base URL only.',
+      'sitemap(): getContexts() returned no contexts; generating sitemap with static pages only.',
     );
   }
 
+  // Only indexable pages belong here. /topics is deliberately excluded: it is
+  // context-less and not tied to a current election.
   const staticPages: MetadataRoute.Sitemap = [
     { url: baseUrl, lastModified: now, changeFrequency: 'daily', priority: 1 },
+    {
+      url: `${baseUrl}/how-to`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.6,
+    },
+    {
+      url: `${baseUrl}/about-us`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
   ];
 
   const contextPages: MetadataRoute.Sitemap = [];

--- a/web/lib/constants.ts
+++ b/web/lib/constants.ts
@@ -4,26 +4,19 @@ export const GROUP_PARTY_ID = 'group';
 export const TENANT_ID_HEADER = 'x-tenant-id';
 export const CONTEXT_ID_HEADER = 'x-context-id';
 
+// The next upcoming election. Kept static for now; deriving it from the context
+// dates is tracked separately.
 export const DEFAULT_CONTEXT_ID =
   process.env.NEXT_PUBLIC_DEFAULT_CONTEXT_ID ??
-  'landtagswahl-baden-wuerttemberg-2026';
+  'landtagswahl-sachsen-anhalt-2026';
 
-// Region to context ID mapping for geo-IP detection
+// Region to context ID mapping for geo-IP detection. Only regions with a context
+// that actually exists belong here — an unmapped region falls through to
+// DEFAULT_CONTEXT_ID in a single redirect, whereas mapping it to a missing
+// context costs an extra hop via /[contextId]'s redirect.
 export const REGION_TO_CONTEXT: Record<string, string> = {
   BW: 'landtagswahl-baden-wuerttemberg-2026', // Baden-Württemberg
   BY: 'kommunalwahl-muenchen-2026', // Bayern
-  BE: 'be2026', // Berlin
-  BB: 'bb2029', // Brandenburg
-  HB: 'hb2027', // Bremen
-  HH: 'hh2029', // Hamburg
-  HE: 'he2028', // Hessen
-  MV: 'mv2026', // Mecklenburg-Vorpommern
-  NI: 'ni2027', // Niedersachsen
-  NW: 'nw2027', // Nordrhein-Westfalen
   RP: 'landtagswahl-rheinland-pfalz-2026', // Rheinland-Pfalz
-  SL: 'sl2027', // Saarland
-  SN: 'sn2029', // Sachsen
-  ST: 'st2026', // Sachsen-Anhalt
-  SH: 'sh2027', // Schleswig-Holstein
-  TH: 'th2029', // Thüringen
+  ST: 'landtagswahl-sachsen-anhalt-2026', // Sachsen-Anhalt
 };

--- a/web/lib/seo.ts
+++ b/web/lib/seo.ts
@@ -1,9 +1,13 @@
 import type { Context } from '@/lib/firebase/firebase.types';
+import { formatGermanDate } from '@/lib/utils';
 import type { Metadata } from 'next';
 
 const BASE_URL = 'https://wahl.chat';
 
-const IS_PRODUCTION = process.env.SITE_URL === 'https://wahl.chat';
+// VERCEL_ENV is injected by Vercel and is 'production' only on production
+// deployments, so previews and local dev stay noindex without depending on a
+// manually configured variable.
+const IS_PRODUCTION = process.env.VERCEL_ENV === 'production';
 
 export const productionRobots = IS_PRODUCTION
   ? 'index, follow'
@@ -18,10 +22,13 @@ export function buildContextMetadata(
     ? `${pageSuffix} – ${context.name}`
     : `${context.name} – Parteipositionen im Chat vergleichen`;
 
-  const description =
-    context.date !== null && context.date.length > 0
-      ? `Vergleiche die Positionen der Parteien zur ${context.name} (${context.location_name}). Stelle Fragen zu politischen Themen und erhalte quellengestützte Antworten.`
-      : `Vergleiche die Positionen der Parteien in ${context.location_name}. Stelle Fragen zu politischen Themen und erhalte quellengestützte Antworten.`;
+  // context.date is a Date at runtime (see getContext in firebase-server.ts),
+  // so it must not be treated as a string here.
+  const electionDate = formatGermanDate(context.date);
+
+  const description = electionDate
+    ? `Vergleiche die Positionen der Parteien zur ${context.name} am ${electionDate}. Stelle Fragen und erhalte quellengestützte Antworten.`
+    : `Vergleiche die Positionen der Parteien in ${context.location_name}. Stelle Fragen zu politischen Themen und erhalte quellengestützte Antworten.`;
 
   const url = `${BASE_URL}/${context.context_id}`;
 
@@ -45,14 +52,15 @@ export function buildContextMetadata(
 }
 
 export function buildContextJsonLd(context: Context) {
+  const electionDate = formatGermanDate(context.date);
+
   return {
     '@context': 'https://schema.org',
     '@type': 'WebPage',
     name: `${context.name} – wahl.chat`,
-    description:
-      context.date !== null && context.date.length > 0
-        ? `Parteipositionen für ${context.name} in ${context.location_name} vergleichen.`
-        : `Parteipositionen in ${context.location_name} vergleichen.`,
+    description: electionDate
+      ? `Parteipositionen für ${context.name} in ${context.location_name} am ${electionDate} vergleichen.`
+      : `Parteipositionen in ${context.location_name} vergleichen.`,
     url: `${BASE_URL}/${context.context_id}`,
     isPartOf: {
       '@type': 'WebSite',

--- a/web/next-sitemap.config.js
+++ b/web/next-sitemap.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  siteUrl: process.env.NEXT_PUBLIC_SITE_URL || 'https://wahl.chat',
-  generateRobotsTxt: true,
-  sitemapSize: 7000,
-};

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -27,8 +27,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    "next.config.mjs",
-    "next-sitemap.config.js"
+    "next.config.mjs"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## What

wahl.chat was fully deindexed — every product page emitted `<meta name="robots" content="noindex">`. GSC shows 1 indexed page vs 200 not indexed. This makes the site indexable and closes the holes that noindex was accidentally covering.

## Changes

**Made indexable:** context pages (`[contextId]/layout.tsx` hardcoded `noIndex=true` — one argument deindexed the whole product surface), plus `about-us`, `how-to` and `[contextId]/sources`.

**Blocked properly:** `/agent` (the Prolific study instrument) and `/login` were *already indexable in production*. `session/[chatSessionId]` and `share` had no `noindex` of their own and would have been published the moment the inherited one was removed — so every user chat session and shared conversation. All four now explicit.

**Hardened:** robots now gates on `VERCEL_ENV === 'production'` instead of an exact `SITE_URL` string match, so previews stay noindexed deterministically. (`SITE_URL` is still used by `lib/utils.ts` — don't remove it from Vercel.)

**Fixed a dead branch:** `context.date` is a `Date` at runtime but typed `string`, so `context.date.length > 0` was always falsy and no context page ever got its election-specific meta description.

**Default context** → next upcoming election (Sachsen-Anhalt; BW concluded 08.03.2026). `REGION_TO_CONTEXT` had 13 of 16 entries pointing at contexts that don't exist — `ST` repointed, the other 12 removed, so `/` resolves in one hop instead of two.

**Sitemap:** added `how-to` + `about-us` (they had nothing pointing at them). `topics` stays noindexed and out of the sitemap — it's context-less and built on federal parties, so it's Bundestagswahl-2025 content. `donate` stays noindexed too.

**Deleted** dead `next-sitemap.config.js` (not a dependency, no `postbuild`; its `generateRobotsTxt` would have shadowed `app/robots.ts`).

## Verified

`typecheck`, `lint`, `build` clean. Robots tags checked on a local production build both ways: with `VERCEL_ENV=production` the content pages return `index, follow` and every sensitive route `noindex`; without it, everything `noindex, nofollow`.

## ⚠️ Deploy ordering

`landtagswahl-sachsen-anhalt-2026` isn't in prod Firestore yet. `[contextId]/layout.tsx` calls `notFound()` when the missing context *is* the default — so if this ships first, the homepage returns a hard 404. **Firestore update must land before or with this.** Gate on `curl -s -o /dev/null -w "%{http_code}" https://wahl.chat/landtagswahl-sachsen-anhalt-2026` → 200.

Also: `NEXT_PUBLIC_DEFAULT_CONTEXT_ID` is set in Vercel to `landtagswahl-rheinland-pfalz-2026` and overrides the code default — the default-context change does nothing until it's repointed or unset.
