### PR TITLE
feat(sources): seed ST 2026 source documents for the sources page

### DIFF
--- a/firebase/firestore_data/dev/sources_landtagswahl-sachsen-anhalt-2026.json
+++ b/firebase/firestore_data/dev/sources_landtagswahl-sachsen-anhalt-2026.json
@@ -1,0 +1,201 @@
+{
+  "spd": {
+    "01-wahlprogramm-spd-sachsen-anhalt-2026-2026-06-01": {
+      "name": "Wahlprogramm Landtagswahl 2026",
+      "publish_date": "2026-06-01",
+      "storage_url": "https://storage.googleapis.com/wahl-chat-dev.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/wahlprogramme/spd/Wahlprogramm-SPD-Sachsen-Anhalt-2026_2026-06-01.pdf"
+    },
+    "02-landtag-votes": {
+      "name": "Abstimmungen im Landtag von Sachsen-Anhalt (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/sachsen-anhalt"
+    },
+    "03-bundestag-votes": {
+      "name": "Abstimmungen im Bundestag (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/bundestag/abstimmungen"
+    },
+    "04-bundestag-speech-videos": {
+      "name": "Reden im Bundestag – Videoaufzeichnungen (openparliament.tv)",
+      "storage_url": "https://de.openparliament.tv"
+    },
+    "05-bundestag-speech-protocols": {
+      "name": "Reden im Bundestag – Plenarprotokolle (dip.bundestag.de)",
+      "storage_url": "https://dip.bundestag.de"
+    }
+  },
+  "cdu": {
+    "01-regierungsprogramm-entwurf-cdu-sachsen-anhalt-2026-2026-03-24": {
+      "name": "Regierungsprogramm Landtagswahl 2026 (Entwurf)",
+      "publish_date": "2026-03-24",
+      "storage_url": "https://storage.googleapis.com/wahl-chat-dev.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/wahlprogramme/cdu/Regierungsprogramm-Entwurf-CDU-Sachsen-Anhalt-2026_2026-03-24.pdf"
+    },
+    "02-landtag-votes": {
+      "name": "Abstimmungen im Landtag von Sachsen-Anhalt (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/sachsen-anhalt"
+    },
+    "03-bundestag-votes": {
+      "name": "Abstimmungen im Bundestag (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/bundestag/abstimmungen"
+    },
+    "04-bundestag-speech-videos": {
+      "name": "Reden im Bundestag – Videoaufzeichnungen (openparliament.tv)",
+      "storage_url": "https://de.openparliament.tv"
+    },
+    "05-bundestag-speech-protocols": {
+      "name": "Reden im Bundestag – Plenarprotokolle (dip.bundestag.de)",
+      "storage_url": "https://dip.bundestag.de"
+    }
+  },
+  "afd": {
+    "01-regierungsprogramm-entwurf-afd-sachsen-anhalt-2026-2026-03-05": {
+      "name": "Regierungsprogramm Landtagswahl 2026 (Entwurf)",
+      "publish_date": "2026-03-05",
+      "storage_url": "https://storage.googleapis.com/wahl-chat-dev.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/wahlprogramme/afd/Regierungsprogramm-Entwurf-AfD-Sachsen-Anhalt-2026_2026-03-05.pdf"
+    },
+    "02-landtag-votes": {
+      "name": "Abstimmungen im Landtag von Sachsen-Anhalt (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/sachsen-anhalt"
+    },
+    "03-bundestag-votes": {
+      "name": "Abstimmungen im Bundestag (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/bundestag/abstimmungen"
+    },
+    "04-bundestag-speech-videos": {
+      "name": "Reden im Bundestag – Videoaufzeichnungen (openparliament.tv)",
+      "storage_url": "https://de.openparliament.tv"
+    },
+    "05-bundestag-speech-protocols": {
+      "name": "Reden im Bundestag – Plenarprotokolle (dip.bundestag.de)",
+      "storage_url": "https://dip.bundestag.de"
+    }
+  },
+  "gruene": {
+    "01-wahlprogramm-gruene-sachsen-anhalt-2026-2026-05-21": {
+      "name": "Wahlprogramm Landtagswahl 2026",
+      "publish_date": "2026-05-21",
+      "storage_url": "https://storage.googleapis.com/wahl-chat-dev.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/wahlprogramme/gruene/Wahlprogramm-Gruene-Sachsen-Anhalt-2026_2026-05-21.pdf"
+    },
+    "02-landtag-votes": {
+      "name": "Abstimmungen im Landtag von Sachsen-Anhalt (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/sachsen-anhalt"
+    },
+    "03-bundestag-votes": {
+      "name": "Abstimmungen im Bundestag (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/bundestag/abstimmungen"
+    },
+    "04-bundestag-speech-videos": {
+      "name": "Reden im Bundestag – Videoaufzeichnungen (openparliament.tv)",
+      "storage_url": "https://de.openparliament.tv"
+    },
+    "05-bundestag-speech-protocols": {
+      "name": "Reden im Bundestag – Plenarprotokolle (dip.bundestag.de)",
+      "storage_url": "https://dip.bundestag.de"
+    }
+  },
+  "linke": {
+    "01-wahlprogramm-linke-sachsen-anhalt-2026-2026-03-19": {
+      "name": "Wahlprogramm Landtagswahl 2026",
+      "publish_date": "2026-03-19",
+      "storage_url": "https://storage.googleapis.com/wahl-chat-dev.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/wahlprogramme/linke/Wahlprogramm-Linke-Sachsen-Anhalt-2026_2026-03-19.pdf"
+    },
+    "02-landtag-votes": {
+      "name": "Abstimmungen im Landtag von Sachsen-Anhalt (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/sachsen-anhalt"
+    },
+    "03-bundestag-votes": {
+      "name": "Abstimmungen im Bundestag (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/bundestag/abstimmungen"
+    },
+    "04-bundestag-speech-videos": {
+      "name": "Reden im Bundestag – Videoaufzeichnungen (openparliament.tv)",
+      "storage_url": "https://de.openparliament.tv"
+    },
+    "05-bundestag-speech-protocols": {
+      "name": "Reden im Bundestag – Plenarprotokolle (dip.bundestag.de)",
+      "storage_url": "https://dip.bundestag.de"
+    }
+  },
+  "fdp": {
+    "01-wahlprogramm-fdp-sachsen-anhalt-2026-2026-06-05": {
+      "name": "Wahlprogramm Landtagswahl 2026",
+      "publish_date": "2026-06-05",
+      "storage_url": "https://storage.googleapis.com/wahl-chat-dev.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/wahlprogramme/fdp/Wahlprogramm-FDP-Sachsen-Anhalt-2026_2026-06-05.pdf"
+    },
+    "02-landtag-votes": {
+      "name": "Abstimmungen im Landtag von Sachsen-Anhalt (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/sachsen-anhalt"
+    },
+    "03-bundestag-votes": {
+      "name": "Abstimmungen im Bundestag (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/bundestag/abstimmungen"
+    },
+    "04-bundestag-speech-videos": {
+      "name": "Reden im Bundestag – Videoaufzeichnungen (openparliament.tv)",
+      "storage_url": "https://de.openparliament.tv"
+    },
+    "05-bundestag-speech-protocols": {
+      "name": "Reden im Bundestag – Plenarprotokolle (dip.bundestag.de)",
+      "storage_url": "https://dip.bundestag.de"
+    }
+  },
+  "bsw": {
+    "01-wahlprogramm-bsw-sachsen-anhalt-2026-2026-03-07": {
+      "name": "Wahlprogramm Landtagswahl 2026",
+      "publish_date": "2026-03-07",
+      "storage_url": "https://storage.googleapis.com/wahl-chat-dev.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/wahlprogramme/bsw/Wahlprogramm-BSW-Sachsen-Anhalt-2026_2026-03-07.pdf"
+    },
+    "02-bundestag-votes": {
+      "name": "Abstimmungen im Bundestag (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/bundestag/abstimmungen"
+    },
+    "03-bundestag-speech-videos": {
+      "name": "Reden im Bundestag – Videoaufzeichnungen (openparliament.tv)",
+      "storage_url": "https://de.openparliament.tv"
+    },
+    "04-bundestag-speech-protocols": {
+      "name": "Reden im Bundestag – Plenarprotokolle (dip.bundestag.de)",
+      "storage_url": "https://dip.bundestag.de"
+    }
+  },
+  "fw": {
+    "01-wahlprogramm-freie-waehler-sachsen-anhalt-2026-2026-07-14": {
+      "name": "Wahlprogramm Landtagswahl 2026",
+      "publish_date": "2026-07-14",
+      "storage_url": "https://storage.googleapis.com/wahl-chat-dev.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/wahlprogramme/fw/Wahlprogramm-Freie-Waehler-Sachsen-Anhalt-2026_2026-07-14.pdf"
+    }
+  },
+  "basis": {
+    "01-wahlprogramm-diebasis-sachsen-anhalt-2026-2026-07-08": {
+      "name": "Wahlprogramm Landtagswahl 2026",
+      "publish_date": "2026-07-08",
+      "storage_url": "https://storage.googleapis.com/wahl-chat-dev.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/wahlprogramme/basis/Wahlprogramm-dieBasis-Sachsen-Anhalt-2026_2026-07-08.pdf"
+    }
+  },
+  "volt": {
+    "01-wahlprogramm-volt-sachsen-anhalt-2026-2026-09-06": {
+      "name": "Wahlprogramm Landtagswahl 2026",
+      "publish_date": "2026-09-06",
+      "storage_url": "https://storage.googleapis.com/wahl-chat-dev.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/wahlprogramme/volt/Wahlprogramm-Volt-Sachsen-Anhalt-2026_2026-09-06.pdf"
+    }
+  },
+  "tierschutzpartei": {
+    "01-grundsatzprogramm-tierschutzpartei-2026-02-07": {
+      "name": "Grundsatzprogramm",
+      "publish_date": "2026-02-07",
+      "storage_url": "https://storage.googleapis.com/wahl-chat-dev.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/parteidokumente/tierschutzpartei/Grundsatzprogramm-Tierschutzpartei_2026-02-07.pdf"
+    }
+  },
+  "pdf": {
+    "01-grundsatzprogramm-pdf-2026-03-21": {
+      "name": "Grundsatzprogramm",
+      "publish_date": "2026-03-21",
+      "storage_url": "https://storage.googleapis.com/wahl-chat-dev.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/parteidokumente/pdf/Grundsatzprogramm-PdF_2026-03-21.pdf"
+    }
+  },
+  "gartenpartei": {
+    "01-satzung-gartenpartei-2019-11-30": {
+      "name": "Satzung",
+      "publish_date": "2019-11-30",
+      "storage_url": "https://storage.googleapis.com/wahl-chat-dev.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/parteidokumente/gartenpartei/Satzung-Gartenpartei_2019-11-30.pdf"
+    }
+  }
+}

--- a/firebase/firestore_data/prod/sources_landtagswahl-sachsen-anhalt-2026.json
+++ b/firebase/firestore_data/prod/sources_landtagswahl-sachsen-anhalt-2026.json
@@ -1,0 +1,201 @@
+{
+  "spd": {
+    "01-wahlprogramm-spd-sachsen-anhalt-2026-2026-06-01": {
+      "name": "Wahlprogramm Landtagswahl 2026",
+      "publish_date": "2026-06-01",
+      "storage_url": "https://storage.googleapis.com/wahl-chat.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/wahlprogramme/spd/Wahlprogramm-SPD-Sachsen-Anhalt-2026_2026-06-01.pdf"
+    },
+    "02-landtag-votes": {
+      "name": "Abstimmungen im Landtag von Sachsen-Anhalt (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/sachsen-anhalt"
+    },
+    "03-bundestag-votes": {
+      "name": "Abstimmungen im Bundestag (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/bundestag/abstimmungen"
+    },
+    "04-bundestag-speech-videos": {
+      "name": "Reden im Bundestag – Videoaufzeichnungen (openparliament.tv)",
+      "storage_url": "https://de.openparliament.tv"
+    },
+    "05-bundestag-speech-protocols": {
+      "name": "Reden im Bundestag – Plenarprotokolle (dip.bundestag.de)",
+      "storage_url": "https://dip.bundestag.de"
+    }
+  },
+  "cdu": {
+    "01-regierungsprogramm-entwurf-cdu-sachsen-anhalt-2026-2026-03-24": {
+      "name": "Regierungsprogramm Landtagswahl 2026 (Entwurf)",
+      "publish_date": "2026-03-24",
+      "storage_url": "https://storage.googleapis.com/wahl-chat.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/wahlprogramme/cdu/Regierungsprogramm-Entwurf-CDU-Sachsen-Anhalt-2026_2026-03-24.pdf"
+    },
+    "02-landtag-votes": {
+      "name": "Abstimmungen im Landtag von Sachsen-Anhalt (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/sachsen-anhalt"
+    },
+    "03-bundestag-votes": {
+      "name": "Abstimmungen im Bundestag (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/bundestag/abstimmungen"
+    },
+    "04-bundestag-speech-videos": {
+      "name": "Reden im Bundestag – Videoaufzeichnungen (openparliament.tv)",
+      "storage_url": "https://de.openparliament.tv"
+    },
+    "05-bundestag-speech-protocols": {
+      "name": "Reden im Bundestag – Plenarprotokolle (dip.bundestag.de)",
+      "storage_url": "https://dip.bundestag.de"
+    }
+  },
+  "afd": {
+    "01-regierungsprogramm-entwurf-afd-sachsen-anhalt-2026-2026-03-05": {
+      "name": "Regierungsprogramm Landtagswahl 2026 (Entwurf)",
+      "publish_date": "2026-03-05",
+      "storage_url": "https://storage.googleapis.com/wahl-chat.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/wahlprogramme/afd/Regierungsprogramm-Entwurf-AfD-Sachsen-Anhalt-2026_2026-03-05.pdf"
+    },
+    "02-landtag-votes": {
+      "name": "Abstimmungen im Landtag von Sachsen-Anhalt (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/sachsen-anhalt"
+    },
+    "03-bundestag-votes": {
+      "name": "Abstimmungen im Bundestag (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/bundestag/abstimmungen"
+    },
+    "04-bundestag-speech-videos": {
+      "name": "Reden im Bundestag – Videoaufzeichnungen (openparliament.tv)",
+      "storage_url": "https://de.openparliament.tv"
+    },
+    "05-bundestag-speech-protocols": {
+      "name": "Reden im Bundestag – Plenarprotokolle (dip.bundestag.de)",
+      "storage_url": "https://dip.bundestag.de"
+    }
+  },
+  "gruene": {
+    "01-wahlprogramm-gruene-sachsen-anhalt-2026-2026-05-21": {
+      "name": "Wahlprogramm Landtagswahl 2026",
+      "publish_date": "2026-05-21",
+      "storage_url": "https://storage.googleapis.com/wahl-chat.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/wahlprogramme/gruene/Wahlprogramm-Gruene-Sachsen-Anhalt-2026_2026-05-21.pdf"
+    },
+    "02-landtag-votes": {
+      "name": "Abstimmungen im Landtag von Sachsen-Anhalt (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/sachsen-anhalt"
+    },
+    "03-bundestag-votes": {
+      "name": "Abstimmungen im Bundestag (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/bundestag/abstimmungen"
+    },
+    "04-bundestag-speech-videos": {
+      "name": "Reden im Bundestag – Videoaufzeichnungen (openparliament.tv)",
+      "storage_url": "https://de.openparliament.tv"
+    },
+    "05-bundestag-speech-protocols": {
+      "name": "Reden im Bundestag – Plenarprotokolle (dip.bundestag.de)",
+      "storage_url": "https://dip.bundestag.de"
+    }
+  },
+  "linke": {
+    "01-wahlprogramm-linke-sachsen-anhalt-2026-2026-03-19": {
+      "name": "Wahlprogramm Landtagswahl 2026",
+      "publish_date": "2026-03-19",
+      "storage_url": "https://storage.googleapis.com/wahl-chat.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/wahlprogramme/linke/Wahlprogramm-Linke-Sachsen-Anhalt-2026_2026-03-19.pdf"
+    },
+    "02-landtag-votes": {
+      "name": "Abstimmungen im Landtag von Sachsen-Anhalt (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/sachsen-anhalt"
+    },
+    "03-bundestag-votes": {
+      "name": "Abstimmungen im Bundestag (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/bundestag/abstimmungen"
+    },
+    "04-bundestag-speech-videos": {
+      "name": "Reden im Bundestag – Videoaufzeichnungen (openparliament.tv)",
+      "storage_url": "https://de.openparliament.tv"
+    },
+    "05-bundestag-speech-protocols": {
+      "name": "Reden im Bundestag – Plenarprotokolle (dip.bundestag.de)",
+      "storage_url": "https://dip.bundestag.de"
+    }
+  },
+  "fdp": {
+    "01-wahlprogramm-fdp-sachsen-anhalt-2026-2026-06-05": {
+      "name": "Wahlprogramm Landtagswahl 2026",
+      "publish_date": "2026-06-05",
+      "storage_url": "https://storage.googleapis.com/wahl-chat.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/wahlprogramme/fdp/Wahlprogramm-FDP-Sachsen-Anhalt-2026_2026-06-05.pdf"
+    },
+    "02-landtag-votes": {
+      "name": "Abstimmungen im Landtag von Sachsen-Anhalt (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/sachsen-anhalt"
+    },
+    "03-bundestag-votes": {
+      "name": "Abstimmungen im Bundestag (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/bundestag/abstimmungen"
+    },
+    "04-bundestag-speech-videos": {
+      "name": "Reden im Bundestag – Videoaufzeichnungen (openparliament.tv)",
+      "storage_url": "https://de.openparliament.tv"
+    },
+    "05-bundestag-speech-protocols": {
+      "name": "Reden im Bundestag – Plenarprotokolle (dip.bundestag.de)",
+      "storage_url": "https://dip.bundestag.de"
+    }
+  },
+  "bsw": {
+    "01-wahlprogramm-bsw-sachsen-anhalt-2026-2026-03-07": {
+      "name": "Wahlprogramm Landtagswahl 2026",
+      "publish_date": "2026-03-07",
+      "storage_url": "https://storage.googleapis.com/wahl-chat.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/wahlprogramme/bsw/Wahlprogramm-BSW-Sachsen-Anhalt-2026_2026-03-07.pdf"
+    },
+    "02-bundestag-votes": {
+      "name": "Abstimmungen im Bundestag (abgeordnetenwatch.de)",
+      "storage_url": "https://www.abgeordnetenwatch.de/bundestag/abstimmungen"
+    },
+    "03-bundestag-speech-videos": {
+      "name": "Reden im Bundestag – Videoaufzeichnungen (openparliament.tv)",
+      "storage_url": "https://de.openparliament.tv"
+    },
+    "04-bundestag-speech-protocols": {
+      "name": "Reden im Bundestag – Plenarprotokolle (dip.bundestag.de)",
+      "storage_url": "https://dip.bundestag.de"
+    }
+  },
+  "fw": {
+    "01-wahlprogramm-freie-waehler-sachsen-anhalt-2026-2026-07-14": {
+      "name": "Wahlprogramm Landtagswahl 2026",
+      "publish_date": "2026-07-14",
+      "storage_url": "https://storage.googleapis.com/wahl-chat.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/wahlprogramme/fw/Wahlprogramm-Freie-Waehler-Sachsen-Anhalt-2026_2026-07-14.pdf"
+    }
+  },
+  "basis": {
+    "01-wahlprogramm-diebasis-sachsen-anhalt-2026-2026-07-08": {
+      "name": "Wahlprogramm Landtagswahl 2026",
+      "publish_date": "2026-07-08",
+      "storage_url": "https://storage.googleapis.com/wahl-chat.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/wahlprogramme/basis/Wahlprogramm-dieBasis-Sachsen-Anhalt-2026_2026-07-08.pdf"
+    }
+  },
+  "volt": {
+    "01-wahlprogramm-volt-sachsen-anhalt-2026-2026-09-06": {
+      "name": "Wahlprogramm Landtagswahl 2026",
+      "publish_date": "2026-09-06",
+      "storage_url": "https://storage.googleapis.com/wahl-chat.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/wahlprogramme/volt/Wahlprogramm-Volt-Sachsen-Anhalt-2026_2026-09-06.pdf"
+    }
+  },
+  "tierschutzpartei": {
+    "01-grundsatzprogramm-tierschutzpartei-2026-02-07": {
+      "name": "Grundsatzprogramm",
+      "publish_date": "2026-02-07",
+      "storage_url": "https://storage.googleapis.com/wahl-chat.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/parteidokumente/tierschutzpartei/Grundsatzprogramm-Tierschutzpartei_2026-02-07.pdf"
+    }
+  },
+  "pdf": {
+    "01-grundsatzprogramm-pdf-2026-03-21": {
+      "name": "Grundsatzprogramm",
+      "publish_date": "2026-03-21",
+      "storage_url": "https://storage.googleapis.com/wahl-chat.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/parteidokumente/pdf/Grundsatzprogramm-PdF_2026-03-21.pdf"
+    }
+  },
+  "gartenpartei": {
+    "01-satzung-gartenpartei-2019-11-30": {
+      "name": "Satzung",
+      "publish_date": "2019-11-30",
+      "storage_url": "https://storage.googleapis.com/wahl-chat.firebasestorage.app/public/landtagswahl-sachsen-anhalt-2026/parteidokumente/gartenpartei/Satzung-Gartenpartei_2019-11-30.pdf"
+    }
+  }
+}

--- a/firebase/scripts/seed_firestore.py
+++ b/firebase/scripts/seed_firestore.py
@@ -14,6 +14,8 @@ This script:
    into contexts/{context_id}/parties sub-collection
 3. Imports proposed questions from firestore_data/{env}/proposed_questions_{context_id}.json
    into contexts/{context_id}/proposed_questions sub-collection
+4. Imports source documents from firestore_data/{env}/sources_{context_id}.json
+   into sources/{context_id}/parties/{party_id}/source_documents
 
 File naming convention:
 - contexts.json: Contains all context documents
@@ -22,11 +24,15 @@ File naming convention:
 - proposed_questions_{context_id}.json: Contains proposed questions for a specific context
   Example: proposed_questions_kommunalwahl-muenchen-2026.json
            -> contexts/kommunalwahl-muenchen-2026/proposed_questions/
+- sources_{context_id}.json: Contains the source documents shown on the sources page
+  Example: sources_landtagswahl-sachsen-anhalt-2026.json
+           -> sources/landtagswahl-sachsen-anhalt-2026/parties/{party_id}/source_documents/
 """
 
 import json
 import os
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 import firebase_admin
@@ -291,6 +297,56 @@ def seed_proposed_questions(db):
             print(f"    - {context_id}/{path}: {error}")
 
 
+def seed_sources(db):
+    """Seed source documents for each context's sources page.
+
+    File structure: {party_id: {document_id: {name, storage_url, publish_date?}}}.
+    Documents land at sources/{context_id}/parties/{party_id}/source_documents/{document_id},
+    the path the web sources page reads. The storage-upload trigger writes the same shape
+    (PartySource), but documents uploaded under the five-segment layout bypass it, so
+    elections ingested via the ai-backend uploader are seeded from these files instead.
+    publish_date is optional because external entries (abgeordnetenwatch.de etc.) have none.
+    """
+    sources_files = list(DATA_DIR.glob("sources_*.json"))
+
+    if not sources_files:
+        print("\n⚠️  No sources files found")
+        return
+
+    print(f"\n📁 Found {len(sources_files)} sources files")
+    print("-" * 60)
+
+    total_documents = 0
+    for sources_file in sorted(sources_files):
+        context_id = sources_file.stem.replace("sources_", "")
+
+        with open(sources_file) as f:
+            parties = json.load(f)
+
+        print(f"\n  📂 {context_id} ({len(parties)} parties)")
+
+        for party_id, documents in parties.items():
+            for document_id, document in documents.items():
+                data = dict(document)
+                if "publish_date" in data:
+                    data["publish_date"] = datetime.strptime(
+                        data["publish_date"], "%Y-%m-%d"
+                    ).replace(tzinfo=timezone.utc)
+                (
+                    db.collection("sources")
+                    .document(context_id)
+                    .collection("parties")
+                    .document(party_id)
+                    .collection("source_documents")
+                    .document(document_id)
+                    .set(data)
+                )
+                total_documents += 1
+            print(f"    ✅ {party_id} ({len(documents)} documents)")
+
+    print(f"\nTotal source documents seeded: {total_documents}")
+
+
 def main():
     print("=" * 60)
     print("Firestore Seed Script")
@@ -312,6 +368,9 @@ def main():
 
     # Seed proposed questions for each context
     seed_proposed_questions(db)
+
+    # Seed source documents for each context's sources page
+    seed_sources(db)
 
     print("\n" + "=" * 60)
     print("✅ Seeding complete!")


### PR DESCRIPTION
The ST 2026 documents were uploaded under the five-segment storage layout that bypasses the `on_party_document_upload` trigger, so the sources page for Landtagswahl Sachsen-Anhalt stayed empty. This adds a `seed_sources()` step to `seed_firestore.py` plus `sources_landtagswahl-sachsen-anhalt-2026.json` fixtures (dev/prod bucket URLs) that fill `sources/{ctx}/parties/{party}/source_documents`. Party PDFs get clean names and real publish dates; generic external entries are only added for parties whose data is actually queryable in this context. Verified against the emulator (40 docs); prod PDFs still need to be uploaded/made public before the prod seed.

| Party | Sources |
|---|---|
| SPD, CDU, AfD, Grüne, Linke, FDP | Wahl-/Regierungsprogramm · Abstimmungen Landtag ST (AW) · Abstimmungen Bundestag (AW) · Reden Bundestag: Videoaufzeichnungen (openparliament.tv) + Plenarprotokolle (DIP) |
| BSW | Wahlprogramm · Abstimmungen Bundestag (AW) · Reden Bundestag (openparliament.tv + DIP) |
| FW, dieBasis, Volt | Wahlprogramm |
| Tierschutzpartei, PdF | Grundsatzprogramm |
| Gartenpartei | Satzung |