### PR TITLE
fix(cache): scope party answer cache by election context

### DIFF
--- a/ai-backend/src/chat_service.py
+++ b/ai-backend/src/chat_service.py
@@ -815,7 +815,9 @@ async def fetch_party_response_stream(
             )
             existing_cached_answers: List[
                 CachedResponse
-            ] = await aget_cached_answers_for_party(party.party_id, cache_key)
+            ] = await aget_cached_answers_for_party(
+                group_chat_session.context_id, party.party_id, cache_key
+            )
             cached_answer_limit = 1
             possible_answers: list = (
                 existing_cached_answers + [None]
@@ -1201,7 +1203,7 @@ async def fetch_party_response_stream(
                 ),
             )
             await awrite_cached_answer_for_party(
-                party.party_id, cache_key, cached_answer
+                group_chat_session.context_id, party.party_id, cache_key, cached_answer
             )
 
     except openai.BadRequestError as e:

--- a/ai-backend/src/firebase_service.py
+++ b/ai-backend/src/firebase_service.py
@@ -129,11 +129,20 @@ def _sanitize_cache_key(cache_key: str) -> str:
     return cache_key
 
 
+def _cache_party_doc_id(context_id: str, party_id: str) -> str:
+    """Party IDs are shared across elections (the same ``cdu`` runs federally
+    and in Sachsen-Anhalt), but cached answers are grounded in one election's
+    corpus and prompt — so the cache is scoped per (election, party).
+    """
+    return f"{context_id}__{party_id}"
+
+
 async def aget_cached_answers_for_party(
-    party_id: str, cache_key: str
+    context_id: str, party_id: str, cache_key: str
 ) -> list[CachedResponse]:
     cached_answers = async_db.collection(
-        f"cached_answers/{party_id}/{_sanitize_cache_key(cache_key)}"
+        f"cached_answers/{_cache_party_doc_id(context_id, party_id)}"
+        f"/{_sanitize_cache_key(cache_key)}"
     ).stream()
     return [
         CachedResponse(**cached_answer.to_dict())
@@ -142,10 +151,11 @@ async def aget_cached_answers_for_party(
 
 
 async def awrite_cached_answer_for_party(
-    party_id: str, cache_key: str, cached_answer: CachedResponse
+    context_id: str, party_id: str, cache_key: str, cached_answer: CachedResponse
 ) -> None:
     cached_answer_ref = async_db.collection(
-        f"cached_answers/{party_id}/{_sanitize_cache_key(cache_key)}"
+        f"cached_answers/{_cache_party_doc_id(context_id, party_id)}"
+        f"/{_sanitize_cache_key(cache_key)}"
     ).document()
     await cached_answer_ref.set(cached_answer.model_dump())
 

--- a/ai-backend/tests/conftest.py
+++ b/ai-backend/tests/conftest.py
@@ -189,7 +189,9 @@ async def _fake_aget_proposed_questions(party_id: str) -> list[str]:
     return []
 
 
-async def _fake_aget_cached_answers(party_id: str, cache_key: str) -> list[Any]:
+async def _fake_aget_cached_answers(
+    context_id: str, party_id: str, cache_key: str
+) -> list[Any]:
     return []
 
 

--- a/ai-backend/tests/test_chat_sse.py
+++ b/ai-backend/tests/test_chat_sse.py
@@ -244,8 +244,10 @@ async def test_first_turn_proposed_question_is_cached(patch_chat_io, app, monkey
 
     assert payloads[-1] == "[DONE]"
     write_mock.assert_awaited_once()
-    # (party_id, cache_key, cached_answer) — the key is the question text.
-    _party_id, cache_key, _cached = write_mock.await_args.args
+    # (context_id, party_id, cache_key, cached_answer) — the key is the
+    # question text, scoped to the session's election.
+    context_id, _party_id, cache_key, _cached = write_mock.await_args.args
+    assert context_id == _CHAT_REQUEST_BODY["context_id"]
     assert cache_key == _PROPOSED_QUESTION
 
 

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -34,11 +34,9 @@ service cloud.firestore {
     	allow read;
     }
 
-    match /cached_answers/{party_id}/{hash}/{cached_answer_id} {
-    	allow read;
-    }
-
-    match /cached_answers/{context_id}/{party_id}/{hash}/{cached_answer_id} {
+    // Doc id is "{context_id}__{party_id}": cached answers are scoped per
+    // election because party ids repeat across elections.
+    match /cached_answers/{context_party_id}/{hash}/{cached_answer_id} {
     	allow read;
     }
 


### PR DESCRIPTION
## Problem
Cached party answers were keyed only by party + question (`cached_answers/{party_id}/{cache_key}`). Party ids repeat across elections, so clicking the proposed question "Was kann ich fragen?" in the Sachsen-Anhalt chat replayed the cached Bundestagswahl-2025 answer. The multi-turn history-hash keys collided the same way.

## Fix
- Cache docs now live under `cached_answers/{context_id}__{party_id}/{cache_key}` — both Firestore helpers take a required `context_id`, passed from `GroupChatSession.context_id`.
- Removed a dead 5-segment `firestore.rules` match (odd segment count never matches a document); the new composite doc id is covered by the existing rule.

## Notes
- Legacy un-scoped cache docs are deliberately **not** migrated: the collision means they mix contexts and can't be attributed. They're orphaned; each election's cache refills lazily. Optional follow-up: one-off deletion of the old docs.
- Tests: full backend suite + SSE smoke green; the cache-write test now asserts the context id.