### PR TITLE
fix(seo): stop the embed domain duplicating the site, add h1 and canonicals

### DIFF
--- a/web/app/(with-header)/about-us/page.tsx
+++ b/web/app/(with-header)/about-us/page.tsx
@@ -9,6 +9,9 @@ export const metadata: Metadata = {
   title: 'Über uns',
   description:
     'Das Team hinter wahl.chat – wer wir sind und warum wir Politik interaktiv zugänglich machen.',
+  alternates: {
+    canonical: '/about-us',
+  },
 };
 
 function AboutUs() {

--- a/web/app/(with-header)/how-to/page.tsx
+++ b/web/app/(with-header)/how-to/page.tsx
@@ -5,6 +5,9 @@ export const metadata: Metadata = {
   title: 'So funktioniert wahl.chat',
   description:
     'Erfahre, wie du wahl.chat nutzen kannst – Parteien vergleichen, Fragen stellen und quellengestützte Antworten erhalten.',
+  alternates: {
+    canonical: '/how-to',
+  },
 };
 
 function HowToPage() {

--- a/web/app/[contextId]/(home)/page.tsx
+++ b/web/app/[contextId]/(home)/page.tsx
@@ -1,4 +1,5 @@
 import ContactCard from '@/components/home/contact-card';
+import ContextIntro from '@/components/home/context-intro';
 import ElectionPartySelector from '@/components/home/election-party-selector';
 import GitHubCard from '@/components/home/github-card';
 import HomeInput from '@/components/home/home-input';
@@ -8,12 +9,18 @@ import OpenCallCard, {
   getAvailableOpenCallUrl,
 } from '@/components/home/open-call-card';
 import SupportUsCard from '@/components/home/support-us-card';
+import AiDisclaimer from '@/components/legal/ai-disclaimer';
+import JsonLd from '@/components/seo/json-ld';
 import {
+  getContext,
   getHomeInputProposedQuestions,
+  getPartiesForContext,
   getSystemStatus,
   getUser,
 } from '@/lib/firebase/firebase-server';
+import { buildContextCanonical, buildContextJsonLd } from '@/lib/seo';
 import { IS_EMBEDDED } from '@/lib/utils';
+import type { Metadata } from 'next';
 
 type Props = {
   params: Promise<{
@@ -21,19 +28,33 @@ type Props = {
   }>;
 };
 
+// Only the canonical lives here — title, description, robots and Open Graph all
+// come from app/[contextId]/layout.tsx. See buildContextCanonical for why the
+// canonical must not be set at layout level.
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { contextId } = await params;
+  return buildContextCanonical(contextId);
+}
+
 export default async function ContextHome({ params }: Props) {
   const { contextId } = await params;
 
-  const [wahlChatQuestions, systemStatus, user, openCallUrl] =
+  // getContext and getPartiesForContext are cached and already resolved by the
+  // layout in this render, so these are reads from the same cache entry.
+  const [wahlChatQuestions, systemStatus, user, openCallUrl, context, parties] =
     await Promise.all([
       getHomeInputProposedQuestions(),
       getSystemStatus(),
       getUser(),
       getAvailableOpenCallUrl(),
+      getContext(contextId),
+      getPartiesForContext(contextId),
     ]);
 
   return (
     <>
+      {context && <JsonLd data={buildContextJsonLd(context)} />}
+
       <div className="mt-4 w-full">
         <ElectionPartySelector contextId={contextId} />
       </div>
@@ -45,6 +66,7 @@ export default async function ContextHome({ params }: Props) {
         hasValidServerUser={!user?.isAnonymous}
         contextId={contextId}
       />
+      <AiDisclaimer className="hidden md:block" />
 
       {!IS_EMBEDDED && <KnownFrom />}
 
@@ -69,6 +91,11 @@ export default async function ContextHome({ params }: Props) {
         hasValidServerUser={!user?.isAnonymous}
         contextId={contextId}
       />
+      <AiDisclaimer className="md:hidden" />
+
+      {context && !IS_EMBEDDED && (
+        <ContextIntro context={context} parties={parties} />
+      )}
     </>
   );
 }

--- a/web/app/[contextId]/(home)/sources/page.tsx
+++ b/web/app/[contextId]/(home)/sources/page.tsx
@@ -1,4 +1,5 @@
 import Logo from '@/components/chat/logo';
+import JsonLd from '@/components/seo/json-ld';
 import { SourcesContextBadge } from '@/components/sources/sources-context-badge';
 import {
   Accordion,
@@ -13,7 +14,11 @@ import {
   getSourceDocumentsForContext,
 } from '@/lib/firebase/firebase-server';
 import type { SourceDocument } from '@/lib/firebase/firebase.types';
-import { buildContextMetadata } from '@/lib/seo';
+import {
+  buildContextCanonical,
+  buildContextJsonLd,
+  buildContextMetadata,
+} from '@/lib/seo';
 import { buildPartyImageUrl } from '@/lib/utils';
 import type { Metadata } from 'next';
 import Image from 'next/image';
@@ -37,7 +42,13 @@ export async function generateMetadata({
     return { title: 'Quellen' };
   }
 
-  return buildContextMetadata(context, 'Quellen');
+  return {
+    ...buildContextMetadata(context, {
+      pageSuffix: 'Quellen',
+      path: 'sources',
+    }),
+    ...buildContextCanonical(contextId, 'sources'),
+  };
 }
 
 async function SourcesPage({ params }: Props) {
@@ -60,6 +71,8 @@ async function SourcesPage({ params }: Props) {
 
   return (
     <article>
+      {context && <JsonLd data={buildContextJsonLd(context, 'sources')} />}
+
       <div className="mt-4 flex flex-col items-start justify-between gap-2 sm:flex-row sm:items-center">
         <h1 className="text-xl font-bold md:text-2xl">
           <span className="underline">wahl.chat&apos;s</span> Quellen

--- a/web/app/[contextId]/layout.tsx
+++ b/web/app/[contextId]/layout.tsx
@@ -5,7 +5,7 @@ import {
   getContexts,
   getPartiesForContext,
 } from '@/lib/firebase/firebase-server';
-import { buildContextJsonLd, buildContextMetadata } from '@/lib/seo';
+import { buildContextMetadata } from '@/lib/seo';
 import { shuffleArray } from '@/lib/utils';
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
@@ -58,22 +58,17 @@ async function ContextLayout({ children, params }: Props) {
   // meaning all users see the same party order during that period.
   const shuffledParties = shuffleArray(parties);
 
-  const jsonLd = buildContextJsonLd(context);
-
+  // The WebPage node is emitted per page, not here: it carries a URL and an @id,
+  // and every route under this layout (/session, /swiper, /share, /sources) would
+  // otherwise declare the same node while living at a different URL.
   return (
-    <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-      />
-      <ContextProvider
-        context={context}
-        contexts={contexts}
-        parties={shuffledParties}
-      >
-        {children}
-      </ContextProvider>
-    </>
+    <ContextProvider
+      context={context}
+      contexts={contexts}
+      parties={shuffledParties}
+    >
+      {children}
+    </ContextProvider>
   );
 }
 

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -10,9 +10,15 @@ import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import TenantProvider from '@/components/providers/tenant-provider';
 import { TENANT_ID_HEADER } from '@/lib/constants';
+import { socialMediaConfig } from '@/lib/contact-config';
 import { getTenant } from '@/lib/firebase/firebase-admin';
 import { getUser } from '@/lib/firebase/firebase-server';
-import { productionRobots } from '@/lib/seo';
+import {
+  BASE_URL,
+  ORGANIZATION_ID,
+  WEBSITE_ID,
+  productionRobots,
+} from '@/lib/seo';
 import { IS_EMBEDDED } from '@/lib/utils';
 import { LazyMotion, domAnimation } from 'motion/react';
 import { headers } from 'next/headers';
@@ -135,16 +141,29 @@ export default async function RootLayout({
               '@graph': [
                 {
                   '@type': 'Organization',
+                  '@id': ORGANIZATION_ID,
                   name: 'wahl.chat',
-                  url: 'https://wahl.chat',
+                  url: BASE_URL,
+                  logo: `${BASE_URL}/images/logo.webp`,
+                  email: socialMediaConfig.email.replace('mailto:', ''),
                   description:
                     'Politische Informationsplattform – Parteipositionen interaktiv vergleichen.',
+                  // sameAs is how a search engine resolves the brand to a single
+                  // entity, which is what decides exact-brand queries.
+                  sameAs: [
+                    socialMediaConfig.instagram,
+                    socialMediaConfig.linkedin,
+                    socialMediaConfig.x,
+                    'https://github.com/wahl-chat',
+                  ],
                 },
                 {
                   '@type': 'WebSite',
+                  '@id': WEBSITE_ID,
                   name: 'wahl.chat',
-                  url: 'https://wahl.chat',
+                  url: BASE_URL,
                   inLanguage: 'de',
+                  publisher: { '@id': ORGANIZATION_ID },
                   description:
                     'Verstehe die Positionen der Parteien zu Bundestags-, Landtags- und Kommunalwahlen.',
                 },

--- a/web/app/robots.ts
+++ b/web/app/robots.ts
@@ -1,11 +1,24 @@
+import { BASE_URL, IS_INDEXABLE } from '@/lib/seo';
 import type { MetadataRoute } from 'next';
 
 export default function robots(): MetadataRoute.Robots {
+  // Previews and the embed deployment must not be crawled at all, and must not
+  // advertise the production sitemap. Keep this in step with the meta robots
+  // tag (lib/seo.ts) so robots.txt and the pages never disagree.
+  if (!IS_INDEXABLE) {
+    return {
+      rules: {
+        userAgent: '*',
+        disallow: '/',
+      },
+    };
+  }
+
   return {
     rules: {
       userAgent: '*',
       allow: '/',
     },
-    sitemap: 'https://wahl.chat/sitemap.xml',
+    sitemap: `${BASE_URL}/sitemap.xml`,
   };
 }

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -1,8 +1,9 @@
+import { isUpcomingElection } from '@/lib/elections';
 import { getContexts } from '@/lib/firebase/firebase-server';
+import { BASE_URL } from '@/lib/seo';
 import type { MetadataRoute } from 'next';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = 'https://wahl.chat';
   const now = new Date().toISOString();
 
   const contexts = (await getContexts()) ?? [];
@@ -14,17 +15,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   }
 
   // Only indexable pages belong here. /topics is deliberately excluded: it is
-  // context-less and not tied to a current election.
+  // context-less and not tied to a current election. The swiper, session, share
+  // and agent routes are noindex by design and must never be listed.
   const staticPages: MetadataRoute.Sitemap = [
-    { url: baseUrl, lastModified: now, changeFrequency: 'daily', priority: 1 },
+    { url: BASE_URL, lastModified: now, changeFrequency: 'daily', priority: 1 },
     {
-      url: `${baseUrl}/how-to`,
+      url: `${BASE_URL}/how-to`,
       lastModified: now,
       changeFrequency: 'monthly',
       priority: 0.6,
     },
     {
-      url: `${baseUrl}/about-us`,
+      url: `${BASE_URL}/about-us`,
       lastModified: now,
       changeFrequency: 'monthly',
       priority: 0.5,
@@ -36,21 +38,25 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   for (const context of contexts) {
     const id = context.context_id;
 
+    // A concluded election is an archive: still worth indexing, but claiming it
+    // changes daily at near-top priority just burns crawl budget.
+    const isUpcoming = isUpcomingElection(context);
+    const changeFrequency = isUpcoming ? 'daily' : 'yearly';
+    const priority = isUpcoming ? 0.9 : 0.4;
+
     contextPages.push({
-      url: `${baseUrl}/${id}`,
+      url: `${BASE_URL}/${id}`,
       lastModified: now,
-      changeFrequency: 'daily',
-      priority: 0.9,
+      changeFrequency,
+      priority,
     });
 
-    if (context.supports_swiper) {
-      contextPages.push({
-        url: `${baseUrl}/${id}/swiper`,
-        lastModified: now,
-        changeFrequency: 'weekly',
-        priority: 0.7,
-      });
-    }
+    contextPages.push({
+      url: `${BASE_URL}/${id}/sources`,
+      lastModified: now,
+      changeFrequency: isUpcoming ? 'weekly' : 'yearly',
+      priority: isUpcoming ? 0.7 : 0.3,
+    });
   }
 
   return [...staticPages, ...contextPages];

--- a/web/components/home/context-intro.tsx
+++ b/web/components/home/context-intro.tsx
@@ -1,0 +1,93 @@
+import type { Context } from '@/lib/firebase/firebase.types';
+import type { PartyDetails } from '@/lib/party-details';
+import { formatGermanDate } from '@/lib/utils';
+import Link from 'next/link';
+
+type Props = {
+  context: Context;
+  parties?: PartyDetails[];
+};
+
+function formatPartyList(parties: PartyDetails[]): string {
+  const names = parties.map((party) => party.name);
+
+  if (names.length <= 1) return names.join('');
+
+  return `${names.slice(0, -1).join(', ')} und ${names[names.length - 1]}`;
+}
+
+/**
+ * Crawlable prose about the election, rendered below the interactive surface.
+ *
+ * Placement is deliberate: search engines read the whole document regardless of
+ * visual order, so the selector and chat input keep the top of the page while
+ * the page still carries enough text to be understood as being about this
+ * election.
+ */
+function ContextIntro({ context, parties }: Props) {
+  const electionDate = formatGermanDate(context.date);
+  const partyList = parties?.length ? formatPartyList(parties) : undefined;
+
+  return (
+    <section className="mt-8 space-y-4 text-sm text-muted-foreground">
+      <h2 className="text-xl font-bold text-foreground md:text-2xl">
+        {context.name} – Parteipositionen im Chat vergleichen
+      </h2>
+
+      <p>
+        {electionDate
+          ? `Am ${electionDate} wird in ${context.location_name} gewählt. `
+          : `In ${context.location_name} stehen politische Entscheidungen an. `}
+        Auf wahl.chat kannst du den Parteien deine eigenen Fragen stellen – zu
+        Mieten, Bildung, Klima, Wirtschaft oder jedem anderen Thema, das dich
+        beschäftigt. Statt dich durch hunderte Seiten Wahlprogramm zu arbeiten,
+        bekommst du eine Antwort auf genau die Frage, die du gestellt hast.
+      </p>
+
+      {partyList && (
+        <p>
+          Für die {context.name} kannst du mit {partyList} chatten. Du kannst
+          auch mehrere Parteien gleichzeitig auswählen und ihre Positionen zum
+          selben Thema direkt nebeneinander vergleichen.
+        </p>
+      )}
+
+      <p>
+        Jede Antwort ist mit Quellen belegt: wahl.chat zitiert die Stellen aus
+        den Wahl- und Parteiprogrammen, auf denen die Antwort beruht, und du
+        kannst sie mit einem Klick im Original nachlesen. Welche Dokumente
+        dahinterstehen, findest du auf der{' '}
+        <Link
+          href={`/${context.context_id}/sources`}
+          className="font-medium underline"
+        >
+          Quellenseite
+        </Link>
+        .
+      </p>
+
+      <p>
+        Anders als beim Wahl-O-Mat beantwortest du keine vorgegebenen Thesen. Du
+        bestimmst selbst, worüber gesprochen wird, und kannst nachfragen, wenn
+        dir eine Antwort zu vage ist. Wie das genau funktioniert, erklärt die{' '}
+        <Link href="/how-to" className="font-medium underline">
+          Anleitung
+        </Link>
+        .
+      </p>
+
+      <p>
+        Die Antworten werden von einer künstlichen Intelligenz erzeugt und sind
+        keine offiziellen Aussagen der Parteien. Deine Nachrichten werden
+        gespeichert, um die Antworten zu erzeugen und dir deinen Chatverlauf
+        anzuzeigen – Details dazu stehen in der{' '}
+        <Link href="/datenschutz" className="font-medium underline">
+          Datenschutzerklärung
+        </Link>
+        .
+      </p>
+    </section>
+  );
+}
+
+export default ContextIntro;

--- a/web/components/home/election-party-selector.tsx
+++ b/web/components/home/election-party-selector.tsx
@@ -14,7 +14,7 @@ type Props = {
 };
 
 export function ElectionPartySelector({ contextId }: Props) {
-  const { partyCount, parties } = useElectionContext();
+  const { context, partyCount, parties } = useElectionContext();
 
   const [isLoading, setIsLoading] = useState(true);
 
@@ -43,7 +43,9 @@ export function ElectionPartySelector({ contextId }: Props) {
         className="flex flex-col gap-3"
         aria-labelledby="party-selection"
       >
-        <h2
+        {/* The page's only h1. Kept at the visual size of the old h2 — the tag
+            and the text are what carry the signal, not the type scale. */}
+        <h1
           id="party-selection"
           className="flex items-center justify-center gap-2 text-center text-base font-semibold text-foreground"
         >
@@ -51,8 +53,8 @@ export function ElectionPartySelector({ contextId }: Props) {
             className="size-7 shrink-0"
             aria-hidden="true"
           />
-          Wähle eine Partei, um den Chat mit ihr zu starten
-        </h2>
+          {context.name} – wähle eine Partei für den Chat
+        </h1>
 
         {!parties || isLoading ? (
           <LoadingPartyCards

--- a/web/components/home/election-select.tsx
+++ b/web/components/home/election-select.tsx
@@ -14,6 +14,7 @@ import {
   SelectSeparator,
   SelectTrigger,
 } from '@/components/ui/select';
+import { splitElectionsByDate } from '@/lib/elections';
 import type { Context } from '@/lib/firebase/firebase.types';
 import { formatGermanDate } from '@/lib/utils';
 import { CalendarIcon, CheckIcon, MapPinIcon } from 'lucide-react';
@@ -95,29 +96,8 @@ export function ElectionSelect() {
     }
   };
 
-  // Separate contexts into upcoming and past elections
-  // Add a 5-day buffer before moving elections to past
-  const now = new Date();
-  const bufferDays = 5;
-  const cutoffDate = new Date(now.getTime() - bufferDays * 24 * 60 * 60 * 1000);
-
-  const upcomingElections = contexts
-    .filter((ctx) => {
-      if (!ctx.date) return true; // No date = show in upcoming
-      return new Date(ctx.date) >= cutoffDate;
-    })
-    .sort((a, b) => {
-      // Sort by date ascending (closest elections first)
-      if (!a.date && !b.date) return 0;
-      if (!a.date) return 1; // No date goes to end
-      if (!b.date) return -1;
-      return new Date(a.date).getTime() - new Date(b.date).getTime();
-    });
-
-  const pastElections = contexts.filter((ctx) => {
-    if (!ctx.date) return false;
-    return new Date(ctx.date) < cutoffDate;
-  });
+  const { upcoming: upcomingElections, past: pastElections } =
+    splitElectionsByDate(contexts);
 
   // Don't show selector if there's only one context
   if (contexts.length <= 1) {

--- a/web/components/legal/ai-disclaimer.tsx
+++ b/web/components/legal/ai-disclaimer.tsx
@@ -5,12 +5,15 @@ import {
   ResponsiveDialogTitle,
   ResponsiveDialogTrigger,
 } from '@/components/chat/responsive-drawer-dialog';
+import { cn } from '@/lib/utils';
 import {
   AlertCircleIcon,
   AlertTriangleIcon,
   CpuIcon,
+  DatabaseIcon,
   GitBranch,
 } from 'lucide-react';
+import Link from 'next/link';
 
 function AiDisclaimerContent() {
   return (
@@ -62,6 +65,20 @@ function AiDisclaimerContent() {
             gelegentlich auftreten.
           </span>
         </li>
+        <li>
+          <DatabaseIcon className="mr-2 size-6 shrink-0" />
+          <span className="inline-block">
+            <span className="font-semibold">
+              Deine Nachrichten werden gespeichert
+            </span>
+            , um die Antworten zu erzeugen und dir deinen Chatverlauf
+            anzuzeigen. Mehr dazu in der{' '}
+            <Link href="/datenschutz" className="font-semibold underline">
+              Datenschutzerklärung
+            </Link>
+            .
+          </span>
+        </li>
       </ul>
 
       <p>
@@ -76,11 +93,22 @@ function AiDisclaimerContent() {
   );
 }
 
-function AiDisclaimer() {
+type Props = {
+  className?: string;
+};
+
+function AiDisclaimer({ className }: Props) {
   return (
     <ResponsiveDialog>
-      <p className="my-2 text-center text-xs text-muted-foreground">
-        wahl.chat kann Fehler machen.{' '}
+      {/* The storage fact is stated in the always-visible line, not only behind
+          the dialog: it has to be readable before the first message is sent. */}
+      <p
+        className={cn(
+          'my-2 text-center text-xs text-muted-foreground',
+          className,
+        )}
+      >
+        wahl.chat kann Fehler machen und speichert deine Nachrichten.{' '}
         <ResponsiveDialogTrigger className="font-semibold underline">
           Erfahre hier mehr.
         </ResponsiveDialogTrigger>

--- a/web/components/seo/json-ld.tsx
+++ b/web/components/seo/json-ld.tsx
@@ -1,0 +1,21 @@
+type Props = {
+  data: unknown;
+};
+
+/**
+ * Renders a schema.org node as an inline JSON-LD script.
+ *
+ * Belongs on the page that the node describes, not in a shared layout — nodes
+ * carry a url and an @id, so emitting one from a layout would make every route
+ * beneath it claim the same identity.
+ */
+function JsonLd({ data }: Props) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}
+
+export default JsonLd;

--- a/web/components/wahl-swiper/wahl-swiper-chat-wrapper.tsx
+++ b/web/components/wahl-swiper/wahl-swiper-chat-wrapper.tsx
@@ -7,6 +7,7 @@ import {
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from '@/components/chat/responsive-drawer-dialog';
+import AiDisclaimer from '@/components/legal/ai-disclaimer';
 import { useWahlSwiperStore } from '@/components/providers/wahl-swiper-store-provider';
 import { Separator } from '@/components/ui/separator';
 import VisuallyHidden from '@/components/visually-hidden';
@@ -71,6 +72,10 @@ function WahlSwiperChatWrapper() {
           handleToggleExpand={handleToggleExpand}
           handleNewMessage={() => setChatIsExpanded(true)}
         />
+        {/* Sits on the sticky input rather than the one inside the dialog: this
+            is the input a first message is sent from, and the dialog input is
+            only reachable once this notice has already been on screen. */}
+        <AiDisclaimer />
       </div>
 
       <ResponsiveDialogContent className="flex h-[95dvh] w-full flex-col md:max-w-xl">

--- a/web/lib/elections.ts
+++ b/web/lib/elections.ts
@@ -1,0 +1,84 @@
+import type { Context } from '@/lib/firebase/firebase.types';
+
+// An election stays "upcoming" for a few days past its date: results are the
+// most-searched thing immediately after polls close, so demoting the context on
+// election night would be wrong.
+const PAST_ELECTION_BUFFER_DAYS = 5;
+
+// Context.date is declared `string | null` but firebase-server.ts maps it
+// through firestoreTimestampToDate(), so it is a Date at runtime. Accept both
+// rather than trusting either — this is the one place that does real date
+// arithmetic on it.
+type ContextDate = Context['date'] | Date | undefined;
+
+function toDate(date: ContextDate): Date | undefined {
+  if (!date) return undefined;
+
+  const parsed = date instanceof Date ? date : new Date(date);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+function bufferCutoff(now: Date): Date {
+  return new Date(
+    now.getTime() - PAST_ELECTION_BUFFER_DAYS * 24 * 60 * 60 * 1000,
+  );
+}
+
+/**
+ * A context counts as upcoming while its election is still ahead (plus the
+ * buffer). Contexts without a date are always upcoming — they are standing
+ * topics rather than a dated election.
+ */
+export function isUpcomingElection(
+  context: Context,
+  now = new Date(),
+): boolean {
+  const date = toDate(context.date);
+  if (!date) return true;
+
+  return date >= bufferCutoff(now);
+}
+
+function compareByDateAscending(a: Context, b: Context): number {
+  const dateA = toDate(a.date);
+  const dateB = toDate(b.date);
+
+  // Undated contexts sort last — a concrete election date is the stronger signal.
+  if (!dateA && !dateB) return 0;
+  if (!dateA) return 1;
+  if (!dateB) return -1;
+
+  return dateA.getTime() - dateB.getTime();
+}
+
+/**
+ * Splits contexts into upcoming (nearest election first) and past.
+ */
+export function splitElectionsByDate(
+  contexts: Context[],
+  now = new Date(),
+): { upcoming: Context[]; past: Context[] } {
+  const upcoming: Context[] = [];
+  const past: Context[] = [];
+
+  for (const context of contexts) {
+    if (isUpcomingElection(context, now)) {
+      upcoming.push(context);
+    } else {
+      past.push(context);
+    }
+  }
+
+  return { upcoming: upcoming.sort(compareByDateAscending), past };
+}
+
+/**
+ * The election to present by default. Undefined when every context is in the
+ * past, which callers must handle — it is the steady state between elections.
+ */
+export function getNextUpcomingElection(
+  contexts: Context[],
+  now = new Date(),
+): Context | undefined {
+  return splitElectionsByDate(contexts, now).upcoming[0];
+}

--- a/web/lib/seo.ts
+++ b/web/lib/seo.ts
@@ -1,22 +1,61 @@
 import type { Context } from '@/lib/firebase/firebase.types';
-import { formatGermanDate } from '@/lib/utils';
+import { IS_EMBEDDED, formatGermanDate } from '@/lib/utils';
 import type { Metadata } from 'next';
 
-const BASE_URL = 'https://wahl.chat';
+export const BASE_URL = 'https://wahl.chat';
 
 // VERCEL_ENV is injected by Vercel and is 'production' only on production
 // deployments, so previews and local dev stay noindex without depending on a
 // manually configured variable.
-const IS_PRODUCTION = process.env.VERCEL_ENV === 'production';
+//
+// The embed deployment (embed.wahl.chat) serves the same routes from the same
+// codebase, so without the IS_EMBEDDED check it is a full duplicate of the site
+// competing with wahl.chat for every URL.
+export const IS_INDEXABLE =
+  process.env.VERCEL_ENV === 'production' && !IS_EMBEDDED;
 
-export const productionRobots = IS_PRODUCTION
+export const productionRobots = IS_INDEXABLE
   ? 'index, follow'
   : 'noindex, nofollow';
 
+// Stable node identifiers so every page references one Organization and one
+// WebSite entity instead of re-declaring detached copies of them.
+export const ORGANIZATION_ID = `${BASE_URL}/#organization`;
+export const WEBSITE_ID = `${BASE_URL}/#website`;
+
+type ContextMetadataOptions = {
+  /** Appended before the context name in the title, e.g. 'Quellen'. */
+  pageSuffix?: string;
+  /** Sub-path under the context, e.g. 'sources'. */
+  path?: string;
+};
+
+function buildContextUrlPath(context: Context, path?: string): string {
+  return `/${context.context_id}${path ? `/${path}` : ''}`;
+}
+
+/**
+ * Canonical for an indexable context page.
+ *
+ * Deliberately not part of buildContextMetadata: that helper is called from
+ * app/[contextId]/layout.tsx, and Next merges metadata field-by-field down the
+ * tree, so a canonical set there would be inherited by the noindex /session,
+ * /swiper and /share routes. Emit it from the page instead.
+ */
+export function buildContextCanonical(
+  contextId: string,
+  path?: string,
+): Metadata {
+  return {
+    alternates: {
+      canonical: `/${contextId}${path ? `/${path}` : ''}`,
+    },
+  };
+}
+
 export function buildContextMetadata(
   context: Context,
-  pageSuffix?: string,
-  noIndex?: boolean,
+  { pageSuffix, path }: ContextMetadataOptions = {},
 ): Metadata {
   const title = pageSuffix
     ? `${pageSuffix} – ${context.name}`
@@ -30,7 +69,7 @@ export function buildContextMetadata(
     ? `Vergleiche die Positionen der Parteien zur ${context.name} am ${electionDate}. Stelle Fragen und erhalte quellengestützte Antworten.`
     : `Vergleiche die Positionen der Parteien in ${context.location_name}. Stelle Fragen zu politischen Themen und erhalte quellengestützte Antworten.`;
 
-  const url = `${BASE_URL}/${context.context_id}`;
+  const urlPath = buildContextUrlPath(context, path);
 
   return {
     title,
@@ -39,33 +78,28 @@ export function buildContextMetadata(
     openGraph: {
       title,
       description,
-      url,
+      url: `${BASE_URL}${urlPath}`,
     },
     twitter: {
       title,
       description,
     },
-    ...(noIndex && {
-      robots: 'noindex',
-    }),
   };
 }
 
-export function buildContextJsonLd(context: Context) {
+export function buildContextJsonLd(context: Context, path?: string) {
   const electionDate = formatGermanDate(context.date);
+  const url = `${BASE_URL}${buildContextUrlPath(context, path)}`;
 
   return {
     '@context': 'https://schema.org',
     '@type': 'WebPage',
+    '@id': `${url}#webpage`,
     name: `${context.name} – wahl.chat`,
     description: electionDate
       ? `Parteipositionen für ${context.name} in ${context.location_name} am ${electionDate} vergleichen.`
       : `Parteipositionen in ${context.location_name} vergleichen.`,
-    url: `${BASE_URL}/${context.context_id}`,
-    isPartOf: {
-      '@type': 'WebSite',
-      name: 'wahl.chat',
-      url: BASE_URL,
-    },
+    url,
+    isPartOf: { '@id': WEBSITE_ID },
   };
 }


### PR DESCRIPTION
`embed.wahl.chat` runs the same code on the same routes and became indexable along with the rest of the site — a full duplicate of every URL, no canonical, already in Google's index next to `wahl.chat`. Meta robots and `robots.txt` now gate on `IS_EMBEDDED` as well as `VERCEL_ENV`, which also stops preview deploys advertising the production sitemap.

Also:

- context pages get an `<h1>` (they had none — the outline started at `<h2>`, 173 words total) plus ~180 words of crawlable prose below the interactive surface
- self-canonicals, emitted per page rather than from `app/[contextId]/layout.tsx`: metadata merges downward, so a layout canonical would land on the noindex `/session`, `/swiper` and `/share`. Same reason the `WebPage` JSON-LD node moved out of the layout — it carries an `@id`
- sitemap drops `/{ctx}/swiper` (the swiper layout marks it noindex), adds `/{ctx}/sources`, and stops scoring concluded elections `daily` / `0.9`
- `Organization` and `WebSite` get stable `@id`s plus `sameAs`, `logo`, `email`
- the AI disclaimer now states that messages are stored, in the always-visible line, and renders next to the home-page and swiper inputs — previously a first message could be sent having never seen it

Verified: `/agent`, `/topics`, `/{ctx}/swiper` and `/{ctx}/session` stay noindex with zero canonicals.
