### PR TITLE
feat(pdf): in-page PDF viewer with cited-page jump and quote highlighting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,11 @@ dev:
 dev-web:
 	cd web && bun run dev
 
+# BACKEND_HOST=0.0.0.0 exposes the backend on the LAN for phone testing.
+BACKEND_HOST ?= 127.0.0.1
+
 dev-backend:
-	cd ai-backend && uv run python -m src.app
+	cd ai-backend && uv run python -m src.app --host $(BACKEND_HOST)
 
 # --- Linting ---
 

--- a/ai-backend/src/chat_service.py
+++ b/ai-backend/src/chat_service.py
@@ -184,6 +184,25 @@ def _pdf_page_from_url(url: Optional[str]) -> Optional[int]:
     return int(match.group(1)) if match else None
 
 
+_SNIPPET_MAX_CHARS = 600
+
+
+def _source_snippet(text: Optional[str]) -> Optional[str]:
+    """Leading excerpt of the cited chunk, for the PDF viewer's text highlight.
+
+    Whitespace-normalized and cut at a word boundary; the frontend anchors a
+    fuzzy match on the cited page with it and degrades to page-only when the
+    match fails, so this is best-effort by design. None when there is no text.
+    """
+    if not text:
+        return None
+    normalized = " ".join(text.split())
+    if len(normalized) <= _SNIPPET_MAX_CHARS:
+        return normalized
+    cut = normalized.rfind(" ", 0, _SNIPPET_MAX_CHARS)
+    return normalized[: cut if cut > 0 else _SNIPPET_MAX_CHARS]
+
+
 def _mk_manifesto_docs(payloads: list[dict]) -> list[Document]:
     return [
         Document(
@@ -253,6 +272,11 @@ def _append_document_source(
         entry["source_type"] = md.get("source_type")
     if party_id is not None:
         entry["party_id"] = party_id
+    # Highlight anchor for PDF-backed sources only; votes cite web pages.
+    if md.get("source_type") in ("party_manifesto", "parliamentary_speech"):
+        snippet = _source_snippet(source_doc.page_content)
+        if snippet:
+            entry["snippet"] = snippet
 
     payload = md.get("_source_payload")
     if isinstance(payload, dict):
@@ -921,18 +945,18 @@ async def fetch_party_response_stream(
             def _append_manifesto_sources(payloads: list[dict]) -> None:
                 for manifesto_payload in payloads:
                     meta = _meta_dict(manifesto_payload)
-                    sources.append(
-                        {
-                            "source": manifesto_payload.get("citation_title"),
-                            "page": meta.get("page_start"),
-                            "document_publish_date": manifesto_payload.get(
-                                "publish_date"
-                            ),
-                            "url": manifesto_payload.get("citation_url"),
-                            "source_document": manifesto_payload.get("citation_title"),
-                            "source_type": "party_manifesto",
-                        }
-                    )
+                    manifesto_entry = {
+                        "source": manifesto_payload.get("citation_title"),
+                        "page": meta.get("page_start"),
+                        "document_publish_date": manifesto_payload.get("publish_date"),
+                        "url": manifesto_payload.get("citation_url"),
+                        "source_document": manifesto_payload.get("citation_title"),
+                        "source_type": "party_manifesto",
+                    }
+                    snippet = _source_snippet(manifesto_payload.get("text"))
+                    if snippet:
+                        manifesto_entry["snippet"] = snippet
+                    sources.append(manifesto_entry)
 
             def _append_speech_sources(payloads: list[dict]) -> None:
                 for speech_payload in payloads:
@@ -977,6 +1001,9 @@ async def fetch_party_response_stream(
                         pdf_page = _pdf_page_from_url(primary_url)
                         if pdf_page is not None:
                             source_entry["page"] = pdf_page
+                    snippet = _source_snippet(speech_payload.get("text"))
+                    if snippet:
+                        source_entry["snippet"] = snippet
                     source_entry.update(_speech_attribution(speech_payload))
                     # Record op speeches with a timed sentence_map so their video
                     # deep-link can be refined post-generation from the cited claim.

--- a/ai-backend/tests/test_chat_service.py
+++ b/ai-backend/tests/test_chat_service.py
@@ -150,6 +150,77 @@ def test_speech_sources_emit_dual_links(monkeypatch) -> None:
     assert "video_url" not in dip_src, "a dip speech has no video deep-link"
 
 
+def test_source_snippet_normalizes_and_truncates() -> None:
+    """_source_snippet is the PDF viewer's highlight anchor: whitespace collapses,
+    long text cuts at a word boundary under the cap, empty text yields None."""
+    from src.chat_service import _SNIPPET_MAX_CHARS, _source_snippet
+
+    assert _source_snippet(None) is None
+    assert _source_snippet("") is None
+    assert _source_snippet("Ein  Satz\n\tmit   Umbrüchen") == "Ein Satz mit Umbrüchen"
+
+    long_text = "Wort " * 300
+    snippet = _source_snippet(long_text)
+    assert snippet is not None
+    assert len(snippet) <= _SNIPPET_MAX_CHARS
+    assert not snippet.endswith(" ") and snippet.endswith("Wort")
+
+
+def test_pdf_sources_carry_snippet_votes_do_not(monkeypatch) -> None:
+    """Manifesto and speech sources carry a `snippet` (chunk-text excerpt) for the
+    PDF viewer's highlight; vote sources cite web pages and must not get one."""
+    manifesto_payload = {
+        "citation_title": "Wahlprogramm",
+        "citation_url": "https://storage.example/wahlprogramm.pdf",
+        "publish_date": "2026-06-01",
+        "text": "Wir  fordern\neine bessere Zukunft.",
+        "meta": {"page_start": 8},
+    }
+    vote_payload = {
+        "citation_title": "Abstimmung: Testgesetz",
+        "citation_url": "https://example.com/vote/1",
+        "publish_date": "2024-01-15",
+        "text": "vote text must not leak into a snippet",
+        "meta": {
+            "vote_results": [{"party_id": "spd", "stance": "yes", "yes": 1, "no": 0}]
+        },
+    }
+    speech_payload = {
+        "citation_title": "Rede C",
+        "citation_url": "https://dserver.example/btp/20/2000103.pdf",
+        "publish_date": "2024-01-16",
+        "source": "dip",
+        "text": "Sehr geehrte Damen und Herren, wir beraten heute.",
+        "meta": {},
+    }
+
+    def _retrieve(_query, **kwargs):
+        st = kwargs.get("source_type")
+        if st == "party_manifesto":
+            return [manifesto_payload]
+        if st == "vote_record":
+            return [vote_payload]
+        if st == "parliamentary_speech":
+            return [speech_payload]
+        return []
+
+    _wire_common_mocks(monkeypatch, {})
+    monkeypatch.setattr(cs, "retrieve", _retrieve)
+
+    sources = _sources_from_events(_drive_single_party(None))
+
+    manifesto_src = next(s for s in sources if s["source"] == "Wahlprogramm")
+    assert manifesto_src.get("snippet") == "Wir fordern eine bessere Zukunft."
+
+    speech_src = next(s for s in sources if s["source"] == "Rede C")
+    assert speech_src.get("snippet") == (
+        "Sehr geehrte Damen und Herren, wir beraten heute."
+    )
+
+    vote_src = next(s for s in sources if s["source"] == "Abstimmung: Testgesetz")
+    assert "snippet" not in vote_src
+
+
 # ---------------------------------------------------------------------------
 # election_level scoping (vote_record only) is proven behaviourally by
 # test_historic_period_id_current_only + test_single_pass_fallback_when_no_window.

--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -22,9 +22,11 @@
   },
   "emulators": {
     "firestore": {
+      "host": "0.0.0.0",
       "port": 8081
     },
     "auth": {
+      "host": "0.0.0.0",
       "port": 9099
     },
     "ui": {

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -8,6 +8,11 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 import { Analytics } from '@vercel/analytics/react';
 import type { Metadata, Viewport } from 'next';
 import './globals.css';
+// pdf.js text-layer positioning for the citation PDF viewer. Imported here, NOT
+// in the dynamically imported viewer chunk: CSS imported only from a
+// next/dynamic(ssr:false) chunk is dropped in some dev/HMR paths, and without
+// it the text layer flows below the canvas instead of overlaying it.
+import 'react-pdf/dist/esm/Page/TextLayer.css';
 import TenantProvider from '@/components/providers/tenant-provider';
 import { TENANT_ID_HEADER } from '@/lib/constants';
 import { getTenant } from '@/lib/firebase/firebase-admin';

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -45,7 +45,7 @@
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-markdown": "^9.1.0",
-        "react-pdf": "^10.4.1",
+        "react-pdf": "^9",
         "react-remove-scroll": "^2.7.2",
         "react-share": "^5.3.0",
         "react-textarea-autosize": "^8.5.9",
@@ -332,30 +332,6 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
-
-    "@napi-rs/canvas": ["@napi-rs/canvas@0.1.100", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "0.1.100", "@napi-rs/canvas-darwin-arm64": "0.1.100", "@napi-rs/canvas-darwin-x64": "0.1.100", "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100", "@napi-rs/canvas-linux-arm64-gnu": "0.1.100", "@napi-rs/canvas-linux-arm64-musl": "0.1.100", "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100", "@napi-rs/canvas-linux-x64-gnu": "0.1.100", "@napi-rs/canvas-linux-x64-musl": "0.1.100", "@napi-rs/canvas-win32-arm64-msvc": "0.1.100", "@napi-rs/canvas-win32-x64-msvc": "0.1.100" } }, "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA=="],
-
-    "@napi-rs/canvas-android-arm64": ["@napi-rs/canvas-android-arm64@0.1.100", "", { "os": "android", "cpu": "arm64" }, "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ=="],
-
-    "@napi-rs/canvas-darwin-arm64": ["@napi-rs/canvas-darwin-arm64@0.1.100", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A=="],
-
-    "@napi-rs/canvas-darwin-x64": ["@napi-rs/canvas-darwin-x64@0.1.100", "", { "os": "darwin", "cpu": "x64" }, "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw=="],
-
-    "@napi-rs/canvas-linux-arm-gnueabihf": ["@napi-rs/canvas-linux-arm-gnueabihf@0.1.100", "", { "os": "linux", "cpu": "arm" }, "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA=="],
-
-    "@napi-rs/canvas-linux-arm64-gnu": ["@napi-rs/canvas-linux-arm64-gnu@0.1.100", "", { "os": "linux", "cpu": "arm64" }, "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw=="],
-
-    "@napi-rs/canvas-linux-arm64-musl": ["@napi-rs/canvas-linux-arm64-musl@0.1.100", "", { "os": "linux", "cpu": "arm64" }, "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ=="],
-
-    "@napi-rs/canvas-linux-riscv64-gnu": ["@napi-rs/canvas-linux-riscv64-gnu@0.1.100", "", { "os": "linux", "cpu": "none" }, "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw=="],
-
-    "@napi-rs/canvas-linux-x64-gnu": ["@napi-rs/canvas-linux-x64-gnu@0.1.100", "", { "os": "linux", "cpu": "x64" }, "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg=="],
-
-    "@napi-rs/canvas-linux-x64-musl": ["@napi-rs/canvas-linux-x64-musl@0.1.100", "", { "os": "linux", "cpu": "x64" }, "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA=="],
-
-    "@napi-rs/canvas-win32-arm64-msvc": ["@napi-rs/canvas-win32-arm64-msvc@0.1.100", "", { "os": "win32", "cpu": "arm64" }, "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw=="],
-
-    "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@0.1.100", "", { "os": "win32", "cpu": "x64" }, "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
@@ -773,11 +749,15 @@
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
+    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
+
     "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.28.4", "", { "dependencies": { "baseline-browser-mapping": "^2.10.38", "caniuse-lite": "^1.0.30001799", "electron-to-chromium": "^1.5.376", "node-releases": "^2.0.48", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw=="],
+
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
@@ -795,6 +775,8 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001800", "", {}, "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA=="],
 
+    "canvas": ["canvas@3.2.3", "", { "dependencies": { "node-addon-api": "^7.0.0", "prebuild-install": "^7.1.3" } }, "sha512-PzE5nJZPz72YUAfo8oTp0u3fqqY7IzlTubneAihqDYAUcBk7ryeCmBbdJBEdaH0bptSOe2VT2Zwcb3UaFyaSWw=="],
+
     "canvg": ["canvg@3.0.11", "", { "dependencies": { "@babel/runtime": "^7.12.5", "@types/raf": "^3.4.0", "core-js": "^3.8.3", "raf": "^3.4.1", "regenerator-runtime": "^0.13.7", "rgbcolor": "^1.0.1", "stackblur-canvas": "^2.0.0", "svg-pathdata": "^6.0.3" } }, "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
@@ -810,6 +792,8 @@
     "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
 
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
+    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "chrome-trace-event": ["chrome-trace-event@1.0.4", "", {}, "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ=="],
 
@@ -888,6 +872,10 @@
     "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
+    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
+
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
@@ -1015,6 +1003,8 @@
 
     "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
 
+    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
     "exsolve": ["exsolve@1.1.0", "", {}, "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
@@ -1071,6 +1061,8 @@
 
     "framer-motion": ["framer-motion@12.42.2", "", { "dependencies": { "motion-dom": "^12.42.2", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw=="],
 
+    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
+
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -1102,6 +1094,8 @@
     "get-symbol-description": ["get-symbol-description@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6" } }, "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg=="],
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
+
+    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
     "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
@@ -1163,6 +1157,8 @@
 
     "idb": ["idb@7.1.1", "", {}, "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="],
 
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
@@ -1174,6 +1170,8 @@
     "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
@@ -1365,9 +1363,9 @@
 
     "lucide-react": ["lucide-react@0.460.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc" } }, "sha512-BVtq/DykVeIvRTJvRAgCsOwaGL8Un3Bxh8MbDxMhEWlZay3T4IpEKDEpwt5KZ0KJMHzgm6jrltxlT5eXOWXDHg=="],
 
-    "make-cancellable-promise": ["make-cancellable-promise@2.0.0", "", {}, "sha512-3SEQqTpV9oqVsIWqAcmDuaNeo7yBO3tqPtqGRcKkEo0lrzD3wqbKG9mkxO65KoOgXqj+zH2phJ2LiAsdzlogSw=="],
+    "make-cancellable-promise": ["make-cancellable-promise@1.3.2", "", {}, "sha512-GCXh3bq/WuMbS+Ky4JBPW1hYTOU+znU+Q5m9Pu+pI8EoUqIHk9+tviOKC6/qhHh8C4/As3tzJ69IF32kdz85ww=="],
 
-    "make-event-props": ["make-event-props@2.0.0", "", {}, "sha512-G/hncXrl4Qt7mauJEXSg3AcdYzmpkIITTNl5I+rH9sog5Yw0kK6vseJjCaPfOXqOqQuPUP89Rkhfz5kPS8ijtw=="],
+    "make-event-props": ["make-event-props@1.6.2", "", {}, "sha512-iDwf7mA03WPiR8QxvcVHmVWEPfMY1RZXerDVNCRYW7dUr2ppH3J58Rwb39/WG39yTZdRSxr3x+2v22tvI0VEvA=="],
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
@@ -1405,7 +1403,7 @@
 
     "memoize-one": ["memoize-one@5.2.1", "", {}, "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="],
 
-    "merge-refs": ["merge-refs@2.0.0", "", { "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-3+B21mYK2IqUWnd2EivABLT7ueDhb0b8/dGK8LoFQPrU61YITeCMn14F7y7qZafWNZhUEKb24cJdiT5Wxs3prg=="],
+    "merge-refs": ["merge-refs@1.3.0", "", { "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-nqXPXbso+1dcKDpPCXvwZyJILz+vSLqGGOnDrYHQYE+B8n9JTCekVLC65AfCpR4ggVyA/45Y0iR9LDyS2iI+zA=="],
 
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
@@ -1477,11 +1475,15 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
+    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
+
     "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "minimizer-webpack-plugin": ["minimizer-webpack-plugin@5.6.1", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "jest-worker": "^27.4.5", "schema-utils": "^4.3.0", "terser": "^5.31.1" }, "peerDependencies": { "@minify-html/node": "*", "@swc/core": "*", "@swc/css": "*", "@swc/html": "*", "clean-css": "*", "cssnano": "*", "csso": "*", "esbuild": "*", "html-minifier-terser": "*", "lightningcss": "*", "postcss": "*", "uglify-js": "*", "webpack": "^5.1.0" }, "optionalPeers": ["@minify-html/node", "@swc/core", "@swc/css", "@swc/html", "clean-css", "cssnano", "csso", "esbuild", "html-minifier-terser", "lightningcss", "postcss", "uglify-js"] }, "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw=="],
+
+    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
     "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
 
@@ -1499,6 +1501,8 @@
 
     "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
+    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
+
     "napi-postinstall": ["napi-postinstall@0.3.4", "", { "bin": { "napi-postinstall": "lib/cli.js" } }, "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
@@ -1508,6 +1512,10 @@
     "next": ["next@15.5.21", "", { "dependencies": { "@next/env": "15.5.21", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.21", "@next/swc-darwin-x64": "15.5.21", "@next/swc-linux-arm64-gnu": "15.5.21", "@next/swc-linux-arm64-musl": "15.5.21", "@next/swc-linux-x64-gnu": "15.5.21", "@next/swc-linux-x64-musl": "15.5.21", "@next/swc-win32-arm64-msvc": "15.5.21", "@next/swc-win32-x64-msvc": "15.5.21", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-/TsdBtkWLhkl+NVL3Uqws2UphNd6IPzOtzSk1fHaf+0P7GQKLZDUytyhns/Ykbzdy9+YRjwG7ONvrHaaTDdFqQ=="],
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
+
+    "node-abi": ["node-abi@3.94.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g=="],
+
+    "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
@@ -1569,9 +1577,11 @@
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
+    "path2d": ["path2d@0.2.2", "", {}, "sha512-+vnG6S4dYcYxZd+CZxzXCNKdELYZSKfohrk98yajCo1PtRoDgCTrrwOvK1GT0UoAdVszagDVllQc0U1vaX4NUQ=="],
+
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
-    "pdfjs-dist": ["pdfjs-dist@5.4.296", "", { "optionalDependencies": { "@napi-rs/canvas": "^0.1.80" } }, "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q=="],
+    "pdfjs-dist": ["pdfjs-dist@4.8.69", "", { "optionalDependencies": { "canvas": "^3.0.0-rc2", "path2d": "^0.2.1" } }, "sha512-IHZsA4T7YElCKNNXtiLgqScw4zPd3pG9do8UrznC757gMd7UPeHSL2qwNNMJo4r79fl8oj1Xx+1nh2YkzdMpLQ=="],
 
     "performance-now": ["performance-now@2.1.0", "", {}, "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="],
 
@@ -1601,6 +1611,8 @@
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
+    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
+
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
@@ -1610,6 +1622,8 @@
     "proto3-json-serializer": ["proto3-json-serializer@2.0.2", "", { "dependencies": { "protobufjs": "^7.2.5" } }, "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ=="],
 
     "protobufjs": ["protobufjs@7.6.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
+
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
@@ -1623,6 +1637,8 @@
 
     "raw-loader": ["raw-loader@4.0.2", "", { "dependencies": { "loader-utils": "^2.0.0", "schema-utils": "^3.0.0" }, "peerDependencies": { "webpack": "^4.0.0 || ^5.0.0" } }, "sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA=="],
 
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
+
     "react": ["react@19.0.0", "", {}, "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ=="],
 
     "react-dom": ["react-dom@19.0.0", "", { "dependencies": { "scheduler": "^0.25.0" }, "peerDependencies": { "react": "^19.0.0" } }, "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ=="],
@@ -1631,7 +1647,7 @@
 
     "react-markdown": ["react-markdown@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw=="],
 
-    "react-pdf": ["react-pdf@10.4.1", "", { "dependencies": { "clsx": "^2.0.0", "dequal": "^2.0.3", "make-cancellable-promise": "^2.0.0", "make-event-props": "^2.0.0", "merge-refs": "^2.0.0", "pdfjs-dist": "5.4.296", "tiny-invariant": "^1.0.0", "warning": "^4.0.0" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-kS/35staVCBqS29verTQJQZXw7RfsRCPO3fdJoW1KXylcv7A9dw6DZ3vJXC2w+bIBgLw5FN4pOFvKSQtkQhPfA=="],
+    "react-pdf": ["react-pdf@9.2.1", "", { "dependencies": { "clsx": "^2.0.0", "dequal": "^2.0.3", "make-cancellable-promise": "^1.3.1", "make-event-props": "^1.6.0", "merge-refs": "^1.3.0", "pdfjs-dist": "4.8.69", "tiny-invariant": "^1.0.0", "warning": "^4.0.0" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-AJt0lAIkItWEZRA5d/mO+Om4nPCuTiQ0saA+qItO967DTjmGjnhmF+Bi2tL286mOTfBlF5CyLzJ35KTMaDoH+A=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
@@ -1737,6 +1753,10 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
+    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
+
+    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
+
     "sirv": ["sirv@2.0.4", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ=="],
 
     "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
@@ -1821,6 +1841,10 @@
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
+    "tar-fs": ["tar-fs@2.1.5", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw=="],
+
+    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
+
     "teeny-request": ["teeny-request@9.0.0", "", { "dependencies": { "http-proxy-agent": "^5.0.0", "https-proxy-agent": "^5.0.0", "node-fetch": "^2.6.9", "stream-events": "^1.0.5", "uuid": "^9.0.0" } }, "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g=="],
 
     "terser": ["terser@5.48.0", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.15.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": { "terser": "bin/terser" } }, "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q=="],
@@ -1858,6 +1882,8 @@
     "tsconfig-paths": ["tsconfig-paths@3.15.0", "", { "dependencies": { "@types/json5": "^0.0.29", "json5": "^1.0.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
@@ -2073,11 +2099,15 @@
 
     "mlly/pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
+    "node-abi/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "postcss-nested/postcss-selector-parser": ["postcss-selector-parser@6.1.4", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -45,6 +45,7 @@
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-markdown": "^9.1.0",
+        "react-pdf": "^10.4.1",
         "react-remove-scroll": "^2.7.2",
         "react-share": "^5.3.0",
         "react-textarea-autosize": "^8.5.9",
@@ -331,6 +332,30 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
+
+    "@napi-rs/canvas": ["@napi-rs/canvas@0.1.100", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "0.1.100", "@napi-rs/canvas-darwin-arm64": "0.1.100", "@napi-rs/canvas-darwin-x64": "0.1.100", "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100", "@napi-rs/canvas-linux-arm64-gnu": "0.1.100", "@napi-rs/canvas-linux-arm64-musl": "0.1.100", "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100", "@napi-rs/canvas-linux-x64-gnu": "0.1.100", "@napi-rs/canvas-linux-x64-musl": "0.1.100", "@napi-rs/canvas-win32-arm64-msvc": "0.1.100", "@napi-rs/canvas-win32-x64-msvc": "0.1.100" } }, "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA=="],
+
+    "@napi-rs/canvas-android-arm64": ["@napi-rs/canvas-android-arm64@0.1.100", "", { "os": "android", "cpu": "arm64" }, "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ=="],
+
+    "@napi-rs/canvas-darwin-arm64": ["@napi-rs/canvas-darwin-arm64@0.1.100", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A=="],
+
+    "@napi-rs/canvas-darwin-x64": ["@napi-rs/canvas-darwin-x64@0.1.100", "", { "os": "darwin", "cpu": "x64" }, "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw=="],
+
+    "@napi-rs/canvas-linux-arm-gnueabihf": ["@napi-rs/canvas-linux-arm-gnueabihf@0.1.100", "", { "os": "linux", "cpu": "arm" }, "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA=="],
+
+    "@napi-rs/canvas-linux-arm64-gnu": ["@napi-rs/canvas-linux-arm64-gnu@0.1.100", "", { "os": "linux", "cpu": "arm64" }, "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw=="],
+
+    "@napi-rs/canvas-linux-arm64-musl": ["@napi-rs/canvas-linux-arm64-musl@0.1.100", "", { "os": "linux", "cpu": "arm64" }, "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ=="],
+
+    "@napi-rs/canvas-linux-riscv64-gnu": ["@napi-rs/canvas-linux-riscv64-gnu@0.1.100", "", { "os": "linux", "cpu": "none" }, "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw=="],
+
+    "@napi-rs/canvas-linux-x64-gnu": ["@napi-rs/canvas-linux-x64-gnu@0.1.100", "", { "os": "linux", "cpu": "x64" }, "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg=="],
+
+    "@napi-rs/canvas-linux-x64-musl": ["@napi-rs/canvas-linux-x64-musl@0.1.100", "", { "os": "linux", "cpu": "x64" }, "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA=="],
+
+    "@napi-rs/canvas-win32-arm64-msvc": ["@napi-rs/canvas-win32-arm64-msvc@0.1.100", "", { "os": "win32", "cpu": "arm64" }, "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw=="],
+
+    "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@0.1.100", "", { "os": "win32", "cpu": "x64" }, "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
@@ -1340,6 +1365,10 @@
 
     "lucide-react": ["lucide-react@0.460.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc" } }, "sha512-BVtq/DykVeIvRTJvRAgCsOwaGL8Un3Bxh8MbDxMhEWlZay3T4IpEKDEpwt5KZ0KJMHzgm6jrltxlT5eXOWXDHg=="],
 
+    "make-cancellable-promise": ["make-cancellable-promise@2.0.0", "", {}, "sha512-3SEQqTpV9oqVsIWqAcmDuaNeo7yBO3tqPtqGRcKkEo0lrzD3wqbKG9mkxO65KoOgXqj+zH2phJ2LiAsdzlogSw=="],
+
+    "make-event-props": ["make-event-props@2.0.0", "", {}, "sha512-G/hncXrl4Qt7mauJEXSg3AcdYzmpkIITTNl5I+rH9sog5Yw0kK6vseJjCaPfOXqOqQuPUP89Rkhfz5kPS8ijtw=="],
+
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
@@ -1375,6 +1404,8 @@
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
     "memoize-one": ["memoize-one@5.2.1", "", {}, "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="],
+
+    "merge-refs": ["merge-refs@2.0.0", "", { "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-3+B21mYK2IqUWnd2EivABLT7ueDhb0b8/dGK8LoFQPrU61YITeCMn14F7y7qZafWNZhUEKb24cJdiT5Wxs3prg=="],
 
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
@@ -1540,6 +1571,8 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "pdfjs-dist": ["pdfjs-dist@5.4.296", "", { "optionalDependencies": { "@napi-rs/canvas": "^0.1.80" } }, "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q=="],
+
     "performance-now": ["performance-now@2.1.0", "", {}, "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
@@ -1597,6 +1630,8 @@
     "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "react-markdown": ["react-markdown@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw=="],
+
+    "react-pdf": ["react-pdf@10.4.1", "", { "dependencies": { "clsx": "^2.0.0", "dequal": "^2.0.3", "make-cancellable-promise": "^2.0.0", "make-event-props": "^2.0.0", "merge-refs": "^2.0.0", "pdfjs-dist": "5.4.296", "tiny-invariant": "^1.0.0", "warning": "^4.0.0" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-kS/35staVCBqS29verTQJQZXw7RfsRCPO3fdJoW1KXylcv7A9dw6DZ3vJXC2w+bIBgLw5FN4pOFvKSQtkQhPfA=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
@@ -1889,6 +1924,8 @@
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "victory-vendor": ["victory-vendor@36.9.2", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ=="],
+
+    "warning": ["warning@4.0.3", "", { "dependencies": { "loose-envify": "^1.0.0" } }, "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w=="],
 
     "watchpack": ["watchpack@2.5.2", "", { "dependencies": { "graceful-fs": "^4.1.2" } }, "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg=="],
 

--- a/web/components/chat/pdf-viewer.tsx
+++ b/web/components/chat/pdf-viewer.tsx
@@ -191,6 +191,21 @@ function PdfViewer({
     setCurrentPage(page);
   }, [slotHeight, numPages]);
 
+  // Missing highlights are silent for users by design, but the two causes need
+  // to stay distinguishable for developers (a source without a snippet vs. a
+  // snippet the page no longer matches, e.g. after a corpus re-chunk). Logged
+  // once per viewer instance — the text layer re-renders on zoom/resize.
+  const highlightStateLogged = useRef(false);
+  const debugHighlightState = useCallback(
+    (message: string, detail?: Record<string, unknown>) => {
+      if (!highlightStateLogged.current) {
+        highlightStateLogged.current = true;
+        console.debug(`[PdfViewer] ${message}`, detail ?? '');
+      }
+    },
+    [],
+  );
+
   // TextItem vs TextMarkedContent: only real text items carry `str`; marked-
   // content entries still occupy indices, so keep positions aligned with ''.
   // transform[5] is the item's y in PDF text space — the matcher uses it to
@@ -198,6 +213,9 @@ function PdfViewer({
   const onTextSuccess = useCallback(
     (textContent: { items: unknown[] }) => {
       if (!snippet) {
+        debugHighlightState(
+          'source carries no snippet — nothing to highlight (message may predate snippet support)',
+        );
         return;
       }
       const highlightInput = textContent.items.map((item) => {
@@ -213,9 +231,16 @@ function PdfViewer({
           y: Number.isFinite(y) ? y : null,
         };
       });
-      setHighlightItems(matchSnippetItems(highlightInput, snippet));
+      const nextHighlightItems = matchSnippetItems(highlightInput, snippet);
+      if (nextHighlightItems.size === 0) {
+        debugHighlightState(
+          'snippet matched nothing on the cited page — document and corpus may be out of sync',
+          { citedPage, snippetStart: snippet.slice(0, 80) },
+        );
+      }
+      setHighlightItems(nextHighlightItems);
     },
-    [snippet],
+    [snippet, citedPage, debugHighlightState],
   );
 
   const textRenderer = useCallback(

--- a/web/components/chat/pdf-viewer.tsx
+++ b/web/components/chat/pdf-viewer.tsx
@@ -191,10 +191,7 @@ function PdfViewer({
     setCurrentPage(page);
   }, [slotHeight, numPages]);
 
-  // Missing highlights are silent for users by design, but the two causes need
-  // to stay distinguishable for developers (a source without a snippet vs. a
-  // snippet the page no longer matches, e.g. after a corpus re-chunk). Logged
-  // once per viewer instance — the text layer re-renders on zoom/resize.
+  // Why-no-highlight debug, once per instance (text layer re-renders on zoom/resize).
   const highlightStateLogged = useRef(false);
   const debugHighlightState = useCallback(
     (message: string, detail?: Record<string, unknown>) => {

--- a/web/components/chat/pdf-viewer.tsx
+++ b/web/components/chat/pdf-viewer.tsx
@@ -13,8 +13,9 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Document, Page, pdfjs } from 'react-pdf';
 import 'react-pdf/dist/Page/TextLayer.css';
 
+// Legacy worker to match the legacy main build aliased in next.config.ts.
 pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-  'pdfjs-dist/build/pdf.worker.min.mjs',
+  'pdfjs-dist/legacy/build/pdf.worker.min.mjs',
   import.meta.url,
 ).toString();
 

--- a/web/components/chat/pdf-viewer.tsx
+++ b/web/components/chat/pdf-viewer.tsx
@@ -11,11 +11,10 @@ import {
 } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Document, Page, pdfjs } from 'react-pdf';
-import 'react-pdf/dist/Page/TextLayer.css';
+import 'react-pdf/dist/esm/Page/TextLayer.css';
 
-// Legacy worker to match the legacy main build aliased in next.config.ts.
 pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-  'pdfjs-dist/legacy/build/pdf.worker.min.mjs',
+  'pdfjs-dist/build/pdf.worker.min.mjs',
   import.meta.url,
 ).toString();
 

--- a/web/components/chat/pdf-viewer.tsx
+++ b/web/components/chat/pdf-viewer.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { escapeHtml, matchSnippetItems } from '@/lib/pdf-highlight';
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  Loader2Icon,
+  ZoomInIcon,
+  ZoomOutIcon,
+} from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Document, Page, pdfjs } from 'react-pdf';
+import 'react-pdf/dist/Page/TextLayer.css';
+
+pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+  'pdfjs-dist/build/pdf.worker.min.mjs',
+  import.meta.url,
+).toString();
+
+const ZOOM_STEPS = [0.6, 0.8, 1, 1.25, 1.5, 2, 3];
+
+/**
+ * Highlight style is inlined (not a class) because customTextRenderer output is
+ * raw HTML outside Tailwind's reach. `color: transparent` is load-bearing: the
+ * text layer's glyphs must stay invisible so only the canvas text shows through.
+ */
+const MARK_HTML_OPEN =
+  '<mark style="background:rgba(250,204,21,.45);color:transparent;border-radius:2px;padding:0">';
+
+type PdfViewerProps = {
+  /** Resolved fetchable URL (direct GCS or same-origin proxy). */
+  fileUrl: string;
+  /** 1-based page to open at. */
+  initialPage?: number;
+  /** Cited text to highlight (best effort — no match, no highlight). */
+  snippet?: string;
+  title: string;
+  /** First successful document load — parent can drop its loading overlay. */
+  onReady: () => void;
+  /** Unrecoverable load failure — parent shows its new-tab fallback. */
+  onFail: () => void;
+};
+
+/**
+ * In-page PDF viewer rendered with pdf.js instead of the browser's native
+ * viewer, so cited-page jumps (and text highlighting) behave identically across
+ * browsers and devices — mobile browsers ignore `#page=N` open parameters and
+ * iOS renders PDF iframes unreliably, which is exactly what this replaces.
+ * Single-page view with page/zoom controls; the cited snippet is re-matched on
+ * whatever page is shown, so it also survives manual navigation.
+ */
+function PdfViewer({
+  fileUrl,
+  initialPage,
+  snippet,
+  title,
+  onReady,
+  onFail,
+}: PdfViewerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [numPages, setNumPages] = useState<number | null>(null);
+  const [pageNumber, setPageNumber] = useState(
+    initialPage && initialPage > 0 ? initialPage : 1,
+  );
+  const [zoomIndex, setZoomIndex] = useState(2); // 1 = fit width
+  const [containerWidth, setContainerWidth] = useState<number | null>(null);
+  const [highlightItems, setHighlightItems] = useState<Set<number>>(
+    () => new Set(),
+  );
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width;
+      if (width) {
+        setContainerWidth(width);
+      }
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
+  const onDocumentLoad = useCallback(
+    ({ numPages: total }: { numPages: number }) => {
+      setNumPages(total);
+      setPageNumber((current) => Math.min(current, total));
+      onReady();
+    },
+    [onReady],
+  );
+
+  // TextItem vs TextMarkedContent: only real text items carry `str`; marked-
+  // content entries still occupy indices, so keep positions aligned with ''.
+  const onTextSuccess = useCallback(
+    (textContent: { items: unknown[] }) => {
+      if (!snippet) {
+        return;
+      }
+      const strings = textContent.items.map((item) =>
+        typeof item === 'object' && item !== null && 'str' in item
+          ? String((item as { str: unknown }).str)
+          : '',
+      );
+      setHighlightItems(matchSnippetItems(strings, snippet));
+    },
+    [snippet],
+  );
+
+  const textRenderer = useCallback(
+    ({ str, itemIndex }: { str: string; itemIndex: number }) =>
+      highlightItems.has(itemIndex)
+        ? `${MARK_HTML_OPEN}${escapeHtml(str)}</mark>`
+        : escapeHtml(str),
+    [highlightItems],
+  );
+
+  // Bring the highlight into view once the text layer of the cited page is up.
+  const onTextLayerRendered = useCallback(() => {
+    const scroller = scrollRef.current;
+    const mark = scroller?.querySelector('mark');
+    if (scroller && mark) {
+      const markTop = mark.getBoundingClientRect().top;
+      const scrollerTop = scroller.getBoundingClientRect().top;
+      scroller.scrollTop +=
+        markTop - scrollerTop - scroller.clientHeight * 0.35;
+    }
+  }, []);
+
+  const goTo = (page: number) => {
+    setHighlightItems(new Set());
+    setPageNumber(page);
+  };
+
+  const zoom = ZOOM_STEPS[zoomIndex];
+  const pageWidth = containerWidth ? containerWidth * zoom : undefined;
+
+  return (
+    <div ref={containerRef} className="flex size-full min-h-0 flex-col">
+      <div className="flex items-center justify-center gap-1 border-b bg-background p-1.5">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2"
+          disabled={pageNumber <= 1}
+          onClick={() => goTo(pageNumber - 1)}
+          aria-label="Vorherige Seite"
+        >
+          <ChevronLeftIcon className="size-4" />
+        </Button>
+        <span className="min-w-20 text-center text-xs tabular-nums text-muted-foreground">
+          Seite {pageNumber}
+          {numPages ? ` / ${numPages}` : ''}
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2"
+          disabled={numPages !== null && pageNumber >= numPages}
+          onClick={() => goTo(pageNumber + 1)}
+          aria-label="Nächste Seite"
+        >
+          <ChevronRightIcon className="size-4" />
+        </Button>
+        <div className="mx-1 h-4 w-px bg-border" />
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2"
+          disabled={zoomIndex <= 0}
+          onClick={() => setZoomIndex(zoomIndex - 1)}
+          aria-label="Verkleinern"
+        >
+          <ZoomOutIcon className="size-4" />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2"
+          disabled={zoomIndex >= ZOOM_STEPS.length - 1}
+          onClick={() => setZoomIndex(zoomIndex + 1)}
+          aria-label="Vergrößern"
+        >
+          <ZoomInIcon className="size-4" />
+        </Button>
+      </div>
+      <div ref={scrollRef} className="min-h-0 grow overflow-auto">
+        <Document
+          file={fileUrl}
+          onLoadSuccess={onDocumentLoad}
+          onLoadError={onFail}
+          // The parent's loading overlay covers document fetch; a second
+          // spinner here would stack under it.
+          loading={null}
+          error={null}
+          externalLinkTarget="_blank"
+        >
+          <Page
+            pageNumber={pageNumber}
+            width={pageWidth}
+            customTextRenderer={textRenderer}
+            onGetTextSuccess={onTextSuccess}
+            onRenderTextLayerSuccess={onTextLayerRendered}
+            renderAnnotationLayer={false}
+            loading={
+              <div className="flex h-40 items-center justify-center text-muted-foreground">
+                <Loader2Icon className="size-6 animate-spin" />
+              </div>
+            }
+            aria-label={title}
+          />
+        </Document>
+      </div>
+    </div>
+  );
+}
+
+export default PdfViewer;

--- a/web/components/chat/pdf-viewer.tsx
+++ b/web/components/chat/pdf-viewer.tsx
@@ -9,9 +9,14 @@ import {
   ZoomInIcon,
   ZoomOutIcon,
 } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import { Document, Page, pdfjs } from 'react-pdf';
-import 'react-pdf/dist/esm/Page/TextLayer.css';
 
 pdfjs.GlobalWorkerOptions.workerSrc = new URL(
   'pdfjs-dist/build/pdf.worker.min.mjs',
@@ -188,17 +193,27 @@ function PdfViewer({
 
   // TextItem vs TextMarkedContent: only real text items carry `str`; marked-
   // content entries still occupy indices, so keep positions aligned with ''.
+  // transform[5] is the item's y in PDF text space — the matcher uses it to
+  // keep visually distant matches (running footers) out of the passage cluster.
   const onTextSuccess = useCallback(
     (textContent: { items: unknown[] }) => {
       if (!snippet) {
         return;
       }
-      const strings = textContent.items.map((item) =>
-        typeof item === 'object' && item !== null && 'str' in item
-          ? String((item as { str: unknown }).str)
-          : '',
-      );
-      setHighlightItems(matchSnippetItems(strings, snippet));
+      const highlightInput = textContent.items.map((item) => {
+        if (typeof item !== 'object' || item === null || !('str' in item)) {
+          return { str: '', y: null };
+        }
+        const textItem = item as { str: unknown; transform?: unknown };
+        const y = Array.isArray(textItem.transform)
+          ? Number(textItem.transform[5])
+          : null;
+        return {
+          str: String(textItem.str),
+          y: Number.isFinite(y) ? y : null,
+        };
+      });
+      setHighlightItems(matchSnippetItems(highlightInput, snippet));
     },
     [snippet],
   );
@@ -218,26 +233,37 @@ function PdfViewer({
       return;
     }
     const scroller = scrollRef.current;
-    const mark = scroller?.querySelector('mark');
-    if (scroller && mark) {
-      autoScrolledToMark.current = true;
-      const markTop = mark.getBoundingClientRect().top;
-      const scrollerTop = scroller.getBoundingClientRect().top;
-      scroller.scrollTop += markTop - scrollerTop - scroller.clientHeight * 0.3;
+    const marks = scroller?.querySelectorAll('mark');
+    if (!scroller || !marks || marks.length === 0) {
+      return;
     }
+    autoScrolledToMark.current = true;
+    // Visually topmost mark, NOT the first in the DOM: pdf.js text layers
+    // follow the PDF content stream, which can put a footer before the body.
+    let markTop = Number.POSITIVE_INFINITY;
+    for (const mark of marks) {
+      markTop = Math.min(markTop, mark.getBoundingClientRect().top);
+    }
+    const scrollerTop = scroller.getBoundingClientRect().top;
+    scroller.scrollTop += markTop - scrollerTop - scroller.clientHeight * 0.3;
   }, []);
 
+  // Keep the reading position anchored across a zoom change. The scroll
+  // correction must land AFTER React commits the new page sizes — an rAF can
+  // fire before the re-render and then scale against the old layout.
+  const pendingZoomRatio = useRef<number | null>(null);
   const changeZoom = (nextIndex: number) => {
-    const scroller = scrollRef.current;
-    const ratio = ZOOM_STEPS[nextIndex] / ZOOM_STEPS[zoomIndex];
+    pendingZoomRatio.current = ZOOM_STEPS[nextIndex] / ZOOM_STEPS[zoomIndex];
     setZoomIndex(nextIndex);
-    // Keep the current reading position anchored across the resize.
-    if (scroller) {
-      requestAnimationFrame(() => {
-        scroller.scrollTop *= ratio;
-      });
-    }
   };
+  useLayoutEffect(() => {
+    const scroller = scrollRef.current;
+    const ratio = pendingZoomRatio.current;
+    if (scroller && ratio !== null) {
+      pendingZoomRatio.current = null;
+      scroller.scrollTop *= ratio;
+    }
+  }, [zoomIndex]);
 
   const pageNumbers = numPages
     ? Array.from({ length: numPages }, (_, i) => i + 1)
@@ -317,9 +343,13 @@ function PdfViewer({
               ? Math.abs(page - currentPage) <= RENDER_WINDOW
               : isCitedPage;
             return (
+              // mx-auto centers a zoomed-out page; wider than the viewport it
+              // degrades to left-anchored horizontal scrolling.
               <div
                 key={page}
+                className="mx-auto"
                 style={{
+                  width: pageWidth ?? undefined,
                   height: pageHeight ?? undefined,
                   marginBottom: PAGE_GAP,
                 }}
@@ -349,13 +379,7 @@ function PdfViewer({
                     aria-label={`${title} – Seite ${page}`}
                   />
                 ) : (
-                  <div
-                    className="mx-auto bg-background/50"
-                    style={{
-                      width: pageWidth ?? undefined,
-                      height: pageHeight ?? undefined,
-                    }}
-                  />
+                  <div className="size-full bg-background/50" />
                 )}
               </div>
             );

--- a/web/components/chat/pdf-viewer.tsx
+++ b/web/components/chat/pdf-viewer.tsx
@@ -19,6 +19,12 @@ pdfjs.GlobalWorkerOptions.workerSrc = new URL(
 ).toString();
 
 const ZOOM_STEPS = [0.6, 0.8, 1, 1.25, 1.5, 2, 3];
+const PAGE_GAP = 8;
+// Pages rendered around the visible one; the rest are placeholders so an
+// 85-page manifesto stays cheap, especially on phones.
+const RENDER_WINDOW = 2;
+// A4 portrait, used until the real page size is known.
+const FALLBACK_ASPECT = Math.SQRT2;
 
 /**
  * Highlight style is inlined (not a class) because customTextRenderer output is
@@ -31,7 +37,7 @@ const MARK_HTML_OPEN =
 type PdfViewerProps = {
   /** Resolved fetchable URL (direct GCS or same-origin proxy). */
   fileUrl: string;
-  /** 1-based page to open at. */
+  /** 1-based page the citation points at. */
   initialPage?: number;
   /** Cited text to highlight (best effort — no match, no highlight). */
   snippet?: string;
@@ -44,11 +50,14 @@ type PdfViewerProps = {
 
 /**
  * In-page PDF viewer rendered with pdf.js instead of the browser's native
- * viewer, so cited-page jumps (and text highlighting) behave identically across
+ * viewer, so cited-page jumps and text highlighting behave identically across
  * browsers and devices — mobile browsers ignore `#page=N` open parameters and
  * iOS renders PDF iframes unreliably, which is exactly what this replaces.
- * Single-page view with page/zoom controls; the cited snippet is re-matched on
- * whatever page is shown, so it also survives manual navigation.
+ *
+ * Continuously scrollable like a native viewer: all pages are stacked, but only
+ * those near the viewport actually render (placeholders elsewhere). The view
+ * opens centered on the cited passage's highlight when the snippet matches,
+ * else at the top of the cited page.
  */
 function PdfViewer({
   fileUrl,
@@ -61,14 +70,24 @@ function PdfViewer({
   const containerRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const [numPages, setNumPages] = useState<number | null>(null);
-  const [pageNumber, setPageNumber] = useState(
+  const [currentPage, setCurrentPage] = useState(
     initialPage && initialPage > 0 ? initialPage : 1,
   );
   const [zoomIndex, setZoomIndex] = useState(2); // 1 = fit width
   const [containerWidth, setContainerWidth] = useState<number | null>(null);
+  const [pageAspect, setPageAspect] = useState<number | null>(null);
   const [highlightItems, setHighlightItems] = useState<Set<number>>(
     () => new Set(),
   );
+  // The page the citation targets — highlight matching only happens there.
+  const rawCitedPage = initialPage && initialPage > 0 ? initialPage : 1;
+  const citedPage = numPages ? Math.min(rawCitedPage, numPages) : rawCitedPage;
+  // Until the cited page has painted, it is the ONLY page mounted: five large
+  // canvases rendering at once starve the visible one and the viewer opens as
+  // a white void for seconds. Neighbors mount after the first paint.
+  const [citedPagePainted, setCitedPagePainted] = useState(false);
+  // Center the highlight exactly once; afterwards the user owns the scroll.
+  const autoScrolledToMark = useRef(false);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -85,14 +104,87 @@ function PdfViewer({
     return () => observer.disconnect();
   }, []);
 
-  const onDocumentLoad = useCallback(
-    ({ numPages: total }: { numPages: number }) => {
-      setNumPages(total);
-      setPageNumber((current) => Math.min(current, total));
-      onReady();
+  const zoom = ZOOM_STEPS[zoomIndex];
+  const pageWidth = containerWidth ? containerWidth * zoom : null;
+  const pageHeight = pageWidth
+    ? pageWidth * (pageAspect ?? FALLBACK_ASPECT)
+    : null;
+  const slotHeight = pageHeight ? pageHeight + PAGE_GAP : null;
+
+  const scrollToPage = useCallback(
+    (page: number) => {
+      if (scrollRef.current && slotHeight) {
+        scrollRef.current.scrollTop = (page - 1) * slotHeight;
+      }
     },
-    [onReady],
+    [slotHeight],
   );
+
+  const onDocumentLoad = useCallback(
+    (pdf: { numPages: number; getPage: (n: number) => Promise<unknown> }) => {
+      setNumPages(pdf.numPages);
+      const target = Math.min(citedPage, pdf.numPages);
+      setCurrentPage(target);
+      // Real page geometry for placeholder sizing and the initial jump.
+      pdf
+        .getPage(target)
+        .then((page) => {
+          const viewport = (
+            page as {
+              getViewport: (o: { scale: number }) => {
+                width: number;
+                height: number;
+              };
+            }
+          ).getViewport({ scale: 1 });
+          setPageAspect(viewport.height / viewport.width);
+        })
+        .catch(() => {
+          // Placeholder fallback aspect is fine; highlight scroll still refines.
+        });
+    },
+    [citedPage],
+  );
+
+  // The parent overlay drops when the cited page has actually PAINTED — after
+  // document load the canvas still needs seconds on big manifestos, and hiding
+  // the spinner then would show a white void.
+  const onCitedPageRendered = useCallback(() => {
+    setCitedPagePainted(true);
+    onReady();
+  }, [onReady]);
+
+  // Jump to the cited page as soon as slot geometry exists, and re-anchor when
+  // the aspect refines from fallback to real — both happen before first paint
+  // settles. Never re-run afterwards (zoom handles its own anchoring).
+  const initialJumpDone = useRef(false);
+  const lastJumpAspect = useRef<number | null>(null);
+  useEffect(() => {
+    if (!numPages || !slotHeight) {
+      return;
+    }
+    if (!initialJumpDone.current || lastJumpAspect.current !== pageAspect) {
+      initialJumpDone.current = true;
+      lastJumpAspect.current = pageAspect;
+      if (!autoScrolledToMark.current) {
+        scrollToPage(Math.min(citedPage, numPages));
+      }
+    }
+  }, [numPages, slotHeight, pageAspect, citedPage, scrollToPage]);
+
+  // Scroll-derived page indicator: the page under the viewport's midline.
+  const onScroll = useCallback(() => {
+    const scroller = scrollRef.current;
+    if (!scroller || !slotHeight || !numPages) {
+      return;
+    }
+    const midline = scroller.scrollTop + scroller.clientHeight / 2;
+    const page = Math.min(
+      numPages,
+      Math.max(1, Math.floor(midline / slotHeight) + 1),
+    );
+    setCurrentPage(page);
+  }, [slotHeight, numPages]);
 
   // TextItem vs TextMarkedContent: only real text items carry `str`; marked-
   // content entries still occupy indices, so keep positions aligned with ''.
@@ -119,25 +211,37 @@ function PdfViewer({
     [highlightItems],
   );
 
-  // Bring the highlight into view once the text layer of the cited page is up.
-  const onTextLayerRendered = useCallback(() => {
+  // Center the highlight once the cited page's text layer carries the marks.
+  // Runs after every text-layer render of that page, but only acts once.
+  const onCitedTextLayerRendered = useCallback(() => {
+    if (autoScrolledToMark.current) {
+      return;
+    }
     const scroller = scrollRef.current;
     const mark = scroller?.querySelector('mark');
     if (scroller && mark) {
+      autoScrolledToMark.current = true;
       const markTop = mark.getBoundingClientRect().top;
       const scrollerTop = scroller.getBoundingClientRect().top;
-      scroller.scrollTop +=
-        markTop - scrollerTop - scroller.clientHeight * 0.35;
+      scroller.scrollTop += markTop - scrollerTop - scroller.clientHeight * 0.3;
     }
   }, []);
 
-  const goTo = (page: number) => {
-    setHighlightItems(new Set());
-    setPageNumber(page);
+  const changeZoom = (nextIndex: number) => {
+    const scroller = scrollRef.current;
+    const ratio = ZOOM_STEPS[nextIndex] / ZOOM_STEPS[zoomIndex];
+    setZoomIndex(nextIndex);
+    // Keep the current reading position anchored across the resize.
+    if (scroller) {
+      requestAnimationFrame(() => {
+        scroller.scrollTop *= ratio;
+      });
+    }
   };
 
-  const zoom = ZOOM_STEPS[zoomIndex];
-  const pageWidth = containerWidth ? containerWidth * zoom : undefined;
+  const pageNumbers = numPages
+    ? Array.from({ length: numPages }, (_, i) => i + 1)
+    : [];
 
   return (
     <div ref={containerRef} className="flex size-full min-h-0 flex-col">
@@ -147,14 +251,14 @@ function PdfViewer({
           variant="ghost"
           size="sm"
           className="h-7 px-2"
-          disabled={pageNumber <= 1}
-          onClick={() => goTo(pageNumber - 1)}
+          disabled={currentPage <= 1}
+          onClick={() => scrollToPage(currentPage - 1)}
           aria-label="Vorherige Seite"
         >
           <ChevronLeftIcon className="size-4" />
         </Button>
         <span className="min-w-20 text-center text-xs tabular-nums text-muted-foreground">
-          Seite {pageNumber}
+          Seite {currentPage}
           {numPages ? ` / ${numPages}` : ''}
         </span>
         <Button
@@ -162,8 +266,8 @@ function PdfViewer({
           variant="ghost"
           size="sm"
           className="h-7 px-2"
-          disabled={numPages !== null && pageNumber >= numPages}
-          onClick={() => goTo(pageNumber + 1)}
+          disabled={numPages !== null && currentPage >= numPages}
+          onClick={() => scrollToPage(currentPage + 1)}
           aria-label="Nächste Seite"
         >
           <ChevronRightIcon className="size-4" />
@@ -175,7 +279,7 @@ function PdfViewer({
           size="sm"
           className="h-7 px-2"
           disabled={zoomIndex <= 0}
-          onClick={() => setZoomIndex(zoomIndex - 1)}
+          onClick={() => changeZoom(zoomIndex - 1)}
           aria-label="Verkleinern"
         >
           <ZoomOutIcon className="size-4" />
@@ -186,13 +290,17 @@ function PdfViewer({
           size="sm"
           className="h-7 px-2"
           disabled={zoomIndex >= ZOOM_STEPS.length - 1}
-          onClick={() => setZoomIndex(zoomIndex + 1)}
+          onClick={() => changeZoom(zoomIndex + 1)}
           aria-label="Vergrößern"
         >
           <ZoomInIcon className="size-4" />
         </Button>
       </div>
-      <div ref={scrollRef} className="min-h-0 grow overflow-auto">
+      <div
+        ref={scrollRef}
+        onScroll={onScroll}
+        className="min-h-0 grow overflow-auto"
+      >
         <Document
           file={fileUrl}
           onLoadSuccess={onDocumentLoad}
@@ -203,20 +311,55 @@ function PdfViewer({
           error={null}
           externalLinkTarget="_blank"
         >
-          <Page
-            pageNumber={pageNumber}
-            width={pageWidth}
-            customTextRenderer={textRenderer}
-            onGetTextSuccess={onTextSuccess}
-            onRenderTextLayerSuccess={onTextLayerRendered}
-            renderAnnotationLayer={false}
-            loading={
-              <div className="flex h-40 items-center justify-center text-muted-foreground">
-                <Loader2Icon className="size-6 animate-spin" />
+          {pageNumbers.map((page) => {
+            const isCitedPage = page === citedPage;
+            const isNearViewport = citedPagePainted
+              ? Math.abs(page - currentPage) <= RENDER_WINDOW
+              : isCitedPage;
+            return (
+              <div
+                key={page}
+                style={{
+                  height: pageHeight ?? undefined,
+                  marginBottom: PAGE_GAP,
+                }}
+              >
+                {isNearViewport && pageWidth ? (
+                  <Page
+                    pageNumber={page}
+                    width={pageWidth}
+                    customTextRenderer={isCitedPage ? textRenderer : undefined}
+                    onGetTextSuccess={isCitedPage ? onTextSuccess : undefined}
+                    onRenderTextLayerSuccess={
+                      isCitedPage ? onCitedTextLayerRendered : undefined
+                    }
+                    onRenderSuccess={
+                      isCitedPage ? onCitedPageRendered : undefined
+                    }
+                    onRenderError={isCitedPage ? onFail : undefined}
+                    renderAnnotationLayer={false}
+                    loading={
+                      <div
+                        className="flex items-center justify-center text-muted-foreground"
+                        style={{ height: pageHeight ?? 160 }}
+                      >
+                        <Loader2Icon className="size-6 animate-spin" />
+                      </div>
+                    }
+                    aria-label={`${title} – Seite ${page}`}
+                  />
+                ) : (
+                  <div
+                    className="mx-auto bg-background/50"
+                    style={{
+                      width: pageWidth ?? undefined,
+                      height: pageHeight ?? undefined,
+                    }}
+                  />
+                )}
               </div>
-            }
-            aria-label={title}
-          />
+            );
+          })}
         </Document>
       </div>
     </div>

--- a/web/components/chat/source-media.tsx
+++ b/web/components/chat/source-media.tsx
@@ -9,8 +9,7 @@ import {
   formatGermanDate,
   getSourceMediaLinks,
   isPdfUrl,
-  isProxyablePdfHost,
-  pdfProxyUrl,
+  pdfViewerFileUrl,
   sourceBadgeLabel,
   videoTimestampSeconds,
 } from '@/lib/utils';
@@ -21,7 +20,13 @@ import {
   Loader2Icon,
   PlayIcon,
 } from 'lucide-react';
+import dynamic from 'next/dynamic';
 import { useEffect, useRef, useState } from 'react';
+
+// pdf.js + worker only load when a PDF is actually opened.
+const PdfViewer = dynamic(() => import('@/components/chat/pdf-viewer'), {
+  ssr: false,
+});
 
 export type ActiveMedia = {
   kind: 'video' | 'pdf';
@@ -29,19 +34,9 @@ export type ActiveMedia = {
   title: string;
   /** 1-based PDF page to open at (e.g. an AW Wahlprogramm page citation). */
   page?: number;
+  /** Cited text to highlight in the PDF viewer (best effort). */
+  snippet?: string;
 };
-
-/**
- * True when the current device should view PDFs in-page (fine pointer / desktop).
- * On coarse-pointer (touch) devices in-page PDF <iframe>s are unreliable — iOS
- * Safari commonly renders them blank — so those open in a new tab instead.
- */
-function prefersInPagePdf(): boolean {
-  if (typeof window === 'undefined' || !window.matchMedia) {
-    return true;
-  }
-  return window.matchMedia('(pointer: fine)').matches;
-}
 
 function openExternally(url: string): void {
   window.open(url, '_blank', 'noopener,noreferrer');
@@ -67,16 +62,12 @@ function withPdfFragment(url: string, page?: number): string {
   return `${url}${pdfFragment(page)}`;
 }
 
-/** Same-origin proxied PDF URL to frame, deep-linked to `page` when known. */
-function pdfViewerSrc(url: string, page?: number): string {
-  return `${pdfProxyUrl(url)}${pdfFragment(page)}`;
-}
-
 /**
  * Decide how a source's format link opens: the in-page viewer (videos always;
- * PDFs on the proxy allowlist AND on a device where in-page PDFs are reliable)
- * or a new tab (off-allowlist PDFs, touch devices, plain weblinks). PDF page
- * citations carry their `page` through to both paths.
+ * PDFs the pdf.js viewer can fetch — our GCS buckets directly, allowlisted
+ * institution hosts via the proxy) or a new tab (everything else). The viewer
+ * renders with pdf.js on every device, so cited-page jumps and highlighting
+ * work on mobile too — native viewers ignore `#page=N` there.
  */
 function resolveMediaOpen(
   link: SourceMediaLink,
@@ -86,17 +77,18 @@ function resolveMediaOpen(
   if (link.kind === 'video') {
     return { viewer: { kind: 'video', url: link.url, title } };
   }
-  if (isProxyablePdfHost(link.url) && prefersInPagePdf()) {
+  if (pdfViewerFileUrl(link.url) !== null) {
     return {
       viewer: {
         kind: 'pdf',
         url: link.url,
         title,
         page: source.page,
+        snippet: source.snippet,
       },
     };
   }
-  // New tab (off-allowlist / touch): keep the page anchor on the raw URL.
+  // New tab (unfetchable host): keep the page anchor on the raw URL.
   // `link.kind` is 'pdf' here (video returned above), and withPdfFragment
   // skips URLs that already carry a fragment.
   return { newTab: withPdfFragment(link.url, source.page) };
@@ -133,9 +125,9 @@ export function openSourceMedia(
 /**
  * The in-page media view that replaces the sources list inside the "Quellen"
  * dialog: a native <video> for speech deep-links (seeks to the cited moment via
- * `#t=`) or an <iframe> of the same-origin PDF proxy for documents. A "Neuer Tab"
- * escape hatch is always available, and a load failure shows an explicit
- * fallback instead of a silent blank box.
+ * `#t=`) or the pdf.js viewer for documents. A "Neuer Tab" escape hatch is
+ * always available, and a load failure shows an explicit fallback instead of a
+ * silent blank box.
  */
 export function SourceMediaViewer({
   media,
@@ -195,10 +187,8 @@ export function SourceMediaViewer({
           </a>
         </Button>
       </div>
-      {/* Definite height (not just min-height): a percentage-height <iframe>
-          collapses without a resolved parent height, which rendered the PDF as a
-          thin broken strip. A <video> survives via its intrinsic size; the iframe
-          needs this. */}
+      {/* Definite height (not just min-height): the viewer sizes itself from
+          its parent, which needs a resolved height to size against. */}
       <div className="relative flex h-[72vh] items-center justify-center bg-muted">
         {failed ? (
           <div className="flex flex-col items-center gap-3 p-6 text-center">
@@ -240,18 +230,14 @@ export function SourceMediaViewer({
                 onError={() => setFailed(true)}
               />
             ) : (
-              <iframe
-                src={pdfViewerSrc(media.url, media.page)}
+              <PdfViewer
+                // Non-null: resolveMediaOpen only routes fetchable PDFs here.
+                fileUrl={pdfViewerFileUrl(media.url) as string}
+                initialPage={media.page}
+                snippet={media.snippet}
                 title={media.title}
-                // Deliberately NOT sandboxed: Chromium disables its built-in
-                // PDF viewer inside sandboxed iframes (any token set), which
-                // renders a blank frame after load. The frame only ever shows
-                // our own same-origin /api/pdf-proxy output (allowlisted host,
-                // per-hop redirect validation, PDF-only content-type, nosniff),
-                // so third-party content cannot reach this frame anyway.
-                className="size-full border-0"
-                onLoad={() => setLoaded(true)}
-                onError={() => setFailed(true)}
+                onReady={() => setLoaded(true)}
+                onFail={() => setFailed(true)}
               />
             )}
           </>

--- a/web/lib/firebase/firebase-emulators.ts
+++ b/web/lib/firebase/firebase-emulators.ts
@@ -5,7 +5,11 @@
 // before — so production is unaffected and this is a no-op unless deliberately
 // enabled. Ports mirror firebase/firebase.json's emulators block.
 
-export const FIREBASE_EMULATOR_HOST = '127.0.0.1';
+// In the browser, follow the hostname the page was loaded from so a phone on
+// the same LAN (http://<mac-ip>:3000) reaches the emulators on the Mac instead
+// of itself; on the server 127.0.0.1 stays correct.
+export const FIREBASE_EMULATOR_HOST =
+  typeof window === 'undefined' ? '127.0.0.1' : window.location.hostname;
 export const FIRESTORE_EMULATOR_PORT = 8081;
 export const AUTH_EMULATOR_PORT = 9099;
 

--- a/web/lib/pdf-highlight.ts
+++ b/web/lib/pdf-highlight.ts
@@ -1,22 +1,41 @@
 /**
  * Fuzzy matching between a cited source snippet and a PDF page's text layer.
  *
- * PDF text extraction is noisy (line-break hyphenation, soft hyphens, arbitrary
- * whitespace between text items), so both sides are reduced to a bare
- * letters-and-digits stream before matching. The snippet is searched in fixed
- * windows rather than as one block, so a partial overlap (e.g. a chunk that
- * starts mid-page or carries a heading the page does not) still highlights the
- * parts that do appear. No match simply means no highlight.
+ * PDF text extraction is noisy, so both sides are reduced to a bare
+ * letters-only stream before matching:
+ * - hyphenation and arbitrary whitespace between text items disappear;
+ * - digits are dropped deliberately — protocol and manifesto PDFs interleave
+ *   LINE NUMBERS with the text ("Russ-43 land"), which would break every
+ *   window that crosses a line, and chunk text never carries them.
+ *
+ * The snippet is searched in fixed windows rather than as one block, so a
+ * partial overlap (a chunk that starts mid-page, or carries a running
+ * header/footer from extraction) still anchors the parts that appear. Matched
+ * ranges then cluster by stream adjacency AND vertical position — a footer is
+ * often stream-adjacent to the body (drawn right before it) but hundreds of
+ * points away vertically — and only the largest cluster is highlighted.
+ * No match simply means no highlight.
  */
 
 const WINDOW_CHARS = 60;
 const MIN_WINDOW_CHARS = 24;
+// Matched ranges merge when both this close in the stream…
+const MERGE_GAP_CHARS = 120;
+// …and this close vertically (PDF text-space units; a page is ~842 tall,
+// body lines sit ~15-25 apart, a footer is several hundred away).
+const MERGE_Y_UNITS = 150;
+
+export type HighlightTextItem = {
+  str: string;
+  /** Vertical position in PDF text space (transform[5]); null when unknown. */
+  y: number | null;
+};
 
 function isStreamChar(char: string): boolean {
-  return /[\p{L}\p{N}]/u.test(char);
+  return /\p{L}/u.test(char);
 }
 
-/** Letters+digits only, lowercased — the common denominator of PDF text noise. */
+/** Letters only, lowercased — the common denominator of PDF text noise. */
 export function toStream(text: string): string {
   let stream = '';
   for (const char of text.toLowerCase()) {
@@ -27,6 +46,8 @@ export function toStream(text: string): string {
   return stream;
 }
 
+type Range = { start: number; end: number; y: number | null };
+
 /**
  * Text-item indices of a page's text layer that overlap the snippet.
  *
@@ -34,19 +55,21 @@ export function toStream(text: string): string {
  * `customTextRenderer` addresses them by index).
  */
 export function matchSnippetItems(
-  items: string[],
+  items: HighlightTextItem[],
   snippet: string,
 ): Set<number> {
   const matched = new Set<number>();
 
-  // Page stream + map from stream position back to the item that produced it.
+  // Page stream + per-char maps back to the item and its y position.
   let pageStream = '';
   const itemAt: number[] = [];
+  const yAt: Array<number | null> = [];
   items.forEach((item, itemIndex) => {
-    for (const char of item.toLowerCase()) {
+    for (const char of item.str.toLowerCase()) {
       if (isStreamChar(char)) {
         pageStream += char;
         itemAt.push(itemIndex);
+        yAt.push(item.y);
       }
     }
   });
@@ -56,10 +79,11 @@ export function matchSnippetItems(
     return matched;
   }
 
+  const ranges: Range[] = [];
   for (let start = 0; start < snippetStream.length; start += WINDOW_CHARS) {
     let window = snippetStream.slice(start, start + WINDOW_CHARS);
     if (window.length < MIN_WINDOW_CHARS) {
-      // Short tail: re-anchor it to end at the snippet end so it stays distinctive.
+      // Short tail: only usable when the whole snippet fits one window.
       if (snippetStream.length < WINDOW_CHARS) {
         window = snippetStream;
       } else {
@@ -70,9 +94,36 @@ export function matchSnippetItems(
     if (pos === -1) {
       continue;
     }
-    for (let i = pos; i < pos + window.length; i++) {
-      matched.add(itemAt[i]);
+    ranges.push({ start: pos, end: pos + window.length, y: yAt[pos] });
+  }
+  if (ranges.length === 0) {
+    return matched;
+  }
+
+  // Merge ranges that are close in the stream AND on the page; keep the
+  // largest merged cluster (by matched span).
+  ranges.sort((a, b) => a.start - b.start);
+  const clusters: Range[] = [];
+  for (const range of ranges) {
+    const last = clusters[clusters.length - 1];
+    const nearInStream = last && range.start - last.end <= MERGE_GAP_CHARS;
+    const nearOnPage =
+      last &&
+      (last.y === null ||
+        range.y === null ||
+        Math.abs(last.y - range.y) <= MERGE_Y_UNITS);
+    if (last && nearInStream && nearOnPage) {
+      last.end = Math.max(last.end, range.end);
+      last.y = range.y ?? last.y;
+    } else {
+      clusters.push({ ...range });
     }
+  }
+  const largest = clusters.reduce((best, cluster) =>
+    cluster.end - cluster.start > best.end - best.start ? cluster : best,
+  );
+  for (let i = largest.start; i < largest.end; i++) {
+    matched.add(itemAt[i]);
   }
 
   return matched;

--- a/web/lib/pdf-highlight.ts
+++ b/web/lib/pdf-highlight.ts
@@ -1,0 +1,87 @@
+/**
+ * Fuzzy matching between a cited source snippet and a PDF page's text layer.
+ *
+ * PDF text extraction is noisy (line-break hyphenation, soft hyphens, arbitrary
+ * whitespace between text items), so both sides are reduced to a bare
+ * letters-and-digits stream before matching. The snippet is searched in fixed
+ * windows rather than as one block, so a partial overlap (e.g. a chunk that
+ * starts mid-page or carries a heading the page does not) still highlights the
+ * parts that do appear. No match simply means no highlight.
+ */
+
+const WINDOW_CHARS = 60;
+const MIN_WINDOW_CHARS = 24;
+
+function isStreamChar(char: string): boolean {
+  return /[\p{L}\p{N}]/u.test(char);
+}
+
+/** Letters+digits only, lowercased — the common denominator of PDF text noise. */
+export function toStream(text: string): string {
+  let stream = '';
+  for (const char of text.toLowerCase()) {
+    if (isStreamChar(char)) {
+      stream += char;
+    }
+  }
+  return stream;
+}
+
+/**
+ * Text-item indices of a page's text layer that overlap the snippet.
+ *
+ * `items` are the page's text items in layer order (react-pdf's
+ * `customTextRenderer` addresses them by index).
+ */
+export function matchSnippetItems(
+  items: string[],
+  snippet: string,
+): Set<number> {
+  const matched = new Set<number>();
+
+  // Page stream + map from stream position back to the item that produced it.
+  let pageStream = '';
+  const itemAt: number[] = [];
+  items.forEach((item, itemIndex) => {
+    for (const char of item.toLowerCase()) {
+      if (isStreamChar(char)) {
+        pageStream += char;
+        itemAt.push(itemIndex);
+      }
+    }
+  });
+
+  const snippetStream = toStream(snippet);
+  if (snippetStream.length < MIN_WINDOW_CHARS || pageStream.length === 0) {
+    return matched;
+  }
+
+  for (let start = 0; start < snippetStream.length; start += WINDOW_CHARS) {
+    let window = snippetStream.slice(start, start + WINDOW_CHARS);
+    if (window.length < MIN_WINDOW_CHARS) {
+      // Short tail: re-anchor it to end at the snippet end so it stays distinctive.
+      if (snippetStream.length < WINDOW_CHARS) {
+        window = snippetStream;
+      } else {
+        break;
+      }
+    }
+    const pos = pageStream.indexOf(window);
+    if (pos === -1) {
+      continue;
+    }
+    for (let i = pos; i < pos + window.length; i++) {
+      matched.add(itemAt[i]);
+    }
+  }
+
+  return matched;
+}
+
+export function escapeHtml(text: string): string {
+  return text
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}

--- a/web/lib/stores/chat-store.types.ts
+++ b/web/lib/stores/chat-store.types.ts
@@ -25,6 +25,9 @@ export type Source = {
   // primary (video-first) link for back-compat.
   video_url?: string;
   pdf_url?: string;
+  // Leading excerpt of the cited chunk — the PDF viewer's highlight anchor.
+  // Absent on votes, Perplexity sources, and messages persisted before it shipped.
+  snippet?: string;
 };
 
 export type CurrentStreamingMessages = {

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -70,7 +70,23 @@ export function prettifiedShortSourceName(source: string): string {
 }
 
 export function generateUuid() {
-  return crypto.randomUUID();
+  // crypto.randomUUID exists only in secure contexts (https / localhost), so
+  // LAN dev on http://<ip> (phone testing) needs the getRandomValues fallback —
+  // same UUIDv4, available everywhere.
+  if (typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0'));
+  return [
+    hex.slice(0, 4).join(''),
+    hex.slice(4, 6).join(''),
+    hex.slice(6, 8).join(''),
+    hex.slice(8, 10).join(''),
+    hex.slice(10).join(''),
+  ].join('-');
 }
 
 export function firestoreTimestampToDate(

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -340,6 +340,33 @@ export function pdfProxyUrl(url: string): string {
   return `/api/pdf-proxy?url=${encodeURIComponent(url)}`;
 }
 
+// Our own GCS buckets serve PDFs with permissive CORS (origin *, GET, range
+// requests), so the pdf.js viewer fetches them directly — no proxy hop, no
+// Vercel streaming cost. Institution hosts block cross-origin fetching and go
+// through the same-origin proxy instead.
+const DIRECT_FETCH_PDF_PREFIXES = [
+  'https://storage.googleapis.com/wahl-chat.firebasestorage.app/',
+  'https://storage.googleapis.com/wahl-chat-dev.firebasestorage.app/',
+];
+
+/**
+ * URL the in-page pdf.js viewer can fetch for this PDF, or null when the host
+ * is neither one of our buckets nor on the proxy allowlist (those open in a
+ * new tab instead).
+ */
+export function pdfViewerFileUrl(url: string | undefined): string | null {
+  if (!url || !isPdfUrl(url)) {
+    return null;
+  }
+  if (DIRECT_FETCH_PDF_PREFIXES.some((prefix) => url.startsWith(prefix))) {
+    return url;
+  }
+  if (isProxyablePdfHost(url)) {
+    return pdfProxyUrl(url);
+  }
+  return null;
+}
+
 export type SourceMediaKind = 'video' | 'pdf';
 export type SourceMediaLink = {
   kind: SourceMediaKind;

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,17 +1,6 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  webpack: (config) => {
-    // pdf.js's default build assumes bleeding-edge engine features and crashes
-    // Safari during module evaluation ("Properties can only be defined on
-    // Objects"); the legacy build is transpiled for wider browser support.
-    // react-pdf imports bare 'pdfjs-dist', so the exact-match alias covers it.
-    config.resolve.alias = {
-      ...config.resolve.alias,
-      'pdfjs-dist$': 'pdfjs-dist/legacy/build/pdf.mjs',
-    };
-    return config;
-  },
   images: {
     remotePatterns: [
       {

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,6 +1,17 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  webpack: (config) => {
+    // pdf.js's default build assumes bleeding-edge engine features and crashes
+    // Safari during module evaluation ("Properties can only be defined on
+    // Objects"); the legacy build is transpiled for wider browser support.
+    // react-pdf imports bare 'pdfjs-dist', so the exact-match alias covers it.
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      'pdfjs-dist$': 'pdfjs-dist/legacy/build/pdf.mjs',
+    };
+    return config;
+  },
   images: {
     remotePatterns: [
       {

--- a/web/package.json
+++ b/web/package.json
@@ -53,7 +53,7 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-markdown": "^9.1.0",
-    "react-pdf": "^10.4.1",
+    "react-pdf": "^9",
     "react-remove-scroll": "^2.7.2",
     "react-share": "^5.3.0",
     "react-textarea-autosize": "^8.5.9",

--- a/web/package.json
+++ b/web/package.json
@@ -53,6 +53,7 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-markdown": "^9.1.0",
+    "react-pdf": "^10.4.1",
     "react-remove-scroll": "^2.7.2",
     "react-share": "^5.3.0",
     "react-textarea-autosize": "^8.5.9",


### PR DESCRIPTION
Citations now open in an in-page pdf.js viewer instead of the browser's native one, so jumping to the cited page works on every device, including mobile. The backend sends a `snippet` of the cited chunk with manifesto and speech sources, and the viewer highlights that passage (fuzzy match, tolerant of hyphenation) and opens centered on it:

<img width="802" height="865" alt="image" src="https://github.com/user-attachments/assets/995b0a7e-0ca7-4294-98cc-7111ef80b529" />

The document scrolls continuously like a native viewer, with windowed rendering so large manifestos stay cheap on phones; GCS-hosted PDFs are fetched directly, Bundestag/AW PDFs keep using the proxy. Pinned to **react-pdf 9** / **pdfjs-dist 4** because **pdfjs-dist 5.4.x** crashes under Next's bundled **webpack** (webpack#20095). Also includes LAN-testing wiring (emulator/backend binds, secure-context UUID fallback), so testing locally on phones via network address works as well.

Verified on Safari (macOS + iOS), Chrome (macOS).