### PR TITLE
fix: send initial question to backend when starting a new chat session

### DIFF
--- a/web/components/chat/chat-messages-view.tsx
+++ b/web/components/chat/chat-messages-view.tsx
@@ -53,7 +53,8 @@ function ChatMessagesView({
       chatSessionId: sessionId,
       messages,
       preSelectedPartyIds: parties?.map((party) => party.party_id),
-      initialQuestion,
+      // Only auto-send the initial question the first time this component hydrates
+      initialQuestion: hasFetched.current ? undefined : initialQuestion,
       userId: user.uid,
       tenant,
     });

--- a/web/lib/stores/actions/hydrate-chat-session.ts
+++ b/web/lib/stores/actions/hydrate-chat-session.ts
@@ -21,6 +21,7 @@ export const hydrateChatSession: ChatStoreActionHandlerFor<
       partyIds: currentPartyIds,
       loadChatSession,
       initializeChatSession,
+      addUserMessage,
     } = get();
 
     const partyIds = new Set(preSelectedPartyIds ?? []);
@@ -106,4 +107,8 @@ export const hydrateChatSession: ChatStoreActionHandlerFor<
     }
 
     initializeChatSession();
+
+    if (initialQuestion && userId) {
+      addUserMessage(userId, initialQuestion, true);
+    }
   };


### PR DESCRIPTION
**Summary**

- `chat-messages-view.tsx`: `initialQuestion` is now only passed on the very first hydration of the component (`hasFetched.current ? undefined : initialQuestion`), so subsequent re-hydrations don't re-trigger it
- `hydrate-chat-session.ts`: after `initializeChatSession()`, we now call `addUserMessage(userId, initialQuestion, true)`, so the initial question passed via the URL (e.g. `?q=Testfrage`) is actually sent to the backend instead of being silently dropped

Fixes #147

**Steps to reproduce (before)**
1. Open [https://wahl.chat/landtagswahl-sachsen-anhalt-2026/session?q=Testfrage](https://wahl.chat/landtagswahl-sachsen-anhalt-2026/session?q=Testfrage)
2. The first question is not sent to the backend