### PR TITLE
Update AI disclaimer to disclose KI use

### DIFF
--- a/web/components/legal/ai-disclaimer.tsx
+++ b/web/components/legal/ai-disclaimer.tsx
@@ -80,7 +80,7 @@ function AiDisclaimer() {
   return (
     <ResponsiveDialog>
       <p className="my-2 text-center text-xs text-muted-foreground">
-        wahl.chat kann Fehler machen.{' '}
+        wahl.chat Antwortet mit KI.{' '}
         <ResponsiveDialogTrigger className="font-semibold underline">
           Erfahre hier mehr.
         </ResponsiveDialogTrigger>


### PR DESCRIPTION
## Summary
- Change the chat footer disclaimer label from “wahl.chat kann Fehler machen.” to “wahl.chat Antwortet mit KI.”
- Keep the existing “Erfahre hier mehr.” dialog trigger and full KI Hinweis content unchanged.

## Test plan
- [ ] Open chat UI and confirm the footer shows “wahl.chat Antwortet mit KI. Erfahre hier mehr.”
- [ ] Click “Erfahre hier mehr.” and confirm the KI Hinweis dialog still opens with the same content


Made with [Cursor](https://cursor.com)