### PR TITLE
Show AI disclaimer under landing page input

### DIFF
--- a/web/components/home/home-input.tsx
+++ b/web/components/home/home-input.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import DynamicRateLimitStickyInput from '@/components/dynamic-rate-limit-sticky-input';
+import AiDisclaimer from '@/components/legal/ai-disclaimer';
 import { DEFAULT_CONTEXT_ID } from '@/lib/constants';
 import type {
   LlmSystemStatus,
@@ -42,14 +43,16 @@ function HomeInput({
   };
 
   return (
-    <DynamicRateLimitStickyInput
-      isLoading={isLoading}
-      onSubmit={pushLink}
-      quickReplies={questions.map((question) => question.content)}
-      initialSystemStatus={initialSystemStatus}
-      hasValidServerUser={hasValidServerUser}
-      className={cn('mt-4', className)}
-    />
+    <div className={cn('mt-4', className)}>
+      <DynamicRateLimitStickyInput
+        isLoading={isLoading}
+        onSubmit={pushLink}
+        quickReplies={questions.map((question) => question.content)}
+        initialSystemStatus={initialSystemStatus}
+        hasValidServerUser={hasValidServerUser}
+      />
+      <AiDisclaimer />
+    </div>
   );
 }
 

--- a/web/components/legal/ai-disclaimer.tsx
+++ b/web/components/legal/ai-disclaimer.tsx
@@ -82,7 +82,7 @@ function AiDisclaimer() {
       <p className="my-2 text-center text-xs text-muted-foreground">
         wahl.chat Antwortet mit KI.{' '}
         <ResponsiveDialogTrigger className="font-semibold underline">
-          Erfahre hier mehr.
+          Mehr erfahren
         </ResponsiveDialogTrigger>
       </p>
       <ResponsiveDialogContent>


### PR DESCRIPTION
## Summary
- Render the shared AI disclaimer under the landing-page chat input (`HomeInput`)
- Align the learn-more trigger copy to “Mehr erfahren” (also used in chat)

## Test plan
- [ ] On a context home page (desktop), confirm “wahl.chat Antwortet mit KI. Mehr erfahren” appears under the input
- [ ] On mobile, confirm the same disclaimer under the sticky bottom input
- [ ] Click “Mehr erfahren” and confirm the KI Hinweis dialog opens
- [ ] Confirm chat session footer still shows the same label + trigger


Made with [Cursor](https://cursor.com)