### PR TITLE
fix(firebase): revalidate the live site cache after a real-project seed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,12 @@ make stores-up
 # without FIRESTORE_EMULATOR_HOST, so it can never write to production)
 FIRESTORE_EMULATOR_HOST=localhost:8081 make seed-local
 
+# Real Firebase project (ENV=dev by default). Confirm before ENV=prod.
+# Optional REVALIDATE_SECRET busts that deployment's Next.js cache afterwards.
+make seed
+make seed-prod
+REVALIDATE_SECRET=... make revalidate
+
 # Dev servers: web on :3000, backend on :8080
 make dev            # assumes stores already up
 make dev-local      # stores + both servers

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 
 .PHONY: dev dev-web dev-backend install install-web install-backend \
         lint lint-web lint-backend test-backend test-smoke test-local-mode \
-        stores-up stores-down seed-local dev-local auth bootstrap-collection \
+        stores-up stores-down seed seed-prod seed-local revalidate \
+        dev-local auth bootstrap-collection \
         run-abgeordnetenwatch-votes run-all-landtage-votes run-speeches \
         run-manifestos run-manifesto-uploads upload-manifesto-uploads \
         collect-speeches fetch-mdb-stammdaten \
@@ -91,6 +92,30 @@ stores-down:
 	docker compose down
 	pkill -f "firebase emulators" || true
 
+# REVALIDATE_SECRET is optional for seed (warns and continues) and required
+# for revalidate. Export rather than interpolate so `make -n` cannot leak it.
+ifneq ($(REVALIDATE_SECRET),)
+export REVALIDATE_SECRET
+endif
+
+# seed: write firestore_data/{ENV} into the matching real Firebase project
+# (wahl-chat-dev / wahl-chat) via ADC or the env's service-account JSON.
+# Refuses FIRESTORE_EMULATOR_HOST — that path is seed-local. After the write,
+# the script busts that ENV's Next.js cache when REVALIDATE_SECRET is set.
+#   make seed
+#   make seed ENV=prod
+#   REVALIDATE_SECRET=... make seed
+seed:
+	@test -z "$(FIRESTORE_EMULATOR_HOST)" || (echo "ERROR: FIRESTORE_EMULATOR_HOST is set — use 'make seed-local' for the emulator" && exit 1)
+	@if [ "$(ENV)" = "prod" ]; then \
+		read -r -p "This seeds PRODUCTION Firestore (project wahl-chat). Continue? [y/N] " confirm < /dev/tty; \
+		case "$$confirm" in [yY]|[yY][eE][sS]) ;; *) echo "Aborted." && exit 1;; esac; \
+	fi
+	cd ai-backend && ENV=$(ENV) uv run python ../firebase/scripts/seed_firestore.py
+
+seed-prod:
+	$(MAKE) seed ENV=prod
+
 # Needs no cloud credentials: FIRESTORE_EMULATOR_HOST makes the seed script use the
 # emulator with anonymous credentials. GOOGLE_CLOUD_PROJECT must match the project the
 # emulator runs under, or the data lands in a namespace the app never reads.
@@ -99,6 +124,15 @@ seed-local:
 	cd ai-backend && FIRESTORE_EMULATOR_HOST=$(FIRESTORE_EMULATOR_HOST) \
 		GOOGLE_CLOUD_PROJECT=$(EMULATOR_PROJECT) \
 		uv run python ../firebase/scripts/seed_firestore.py
+
+# revalidate: bust the hosted app's election-config cache for ENV
+# (prod → wahl.chat, dev → dev.wahl.chat). Does not write Firestore.
+#   REVALIDATE_SECRET=... make revalidate
+#   REVALIDATE_SECRET=... make revalidate ENV=prod
+#   REVALIDATE_SECRET=... make revalidate ARGS="--context abgeordnetenhauswahl-berlin-2026"
+revalidate:
+	@test -n "$(REVALIDATE_SECRET)" || (echo "ERROR: REVALIDATE_SECRET is not set — copy it from https://vercel.com/wahl-chat/web/settings/environment-variables" && exit 1)
+	cd ai-backend && ENV=$(ENV) uv run python ../firebase/scripts/revalidate_frontend_cache.py $(ARGS)
 
 dev-local: stores-up bootstrap-collection
 	$(MAKE) -j2 dev-web dev-backend

--- a/ai-backend/tests/test_seed_revalidate.py
+++ b/ai-backend/tests/test_seed_revalidate.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: 2026 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+"""Frontend cache bust that follows a real-project Firestore seed."""
+
+from __future__ import annotations
+
+import io
+import json
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+from tests.test_local_mode import _load_seed_module
+
+
+class _FakeResponse:
+    def __init__(self, body: str = '{"revalidated":{}}') -> None:
+        self._body = body.encode()
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *_a: object) -> None:
+        return None
+
+
+def test_emulator_seed_skips_revalidation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seed = _load_seed_module(
+        monkeypatch,
+        FIRESTORE_EMULATOR_HOST="localhost:8081",
+        GOOGLE_CLOUD_PROJECT="demo-wahl-chat",
+    )
+
+    def _fail(*_a: object, **_k: object) -> None:
+        raise AssertionError("emulator seed must not call /api/revalidate")
+
+    monkeypatch.setattr(seed.urllib.request, "urlopen", _fail)
+    seed.revalidate_frontend_cache(["abgeordnetenhauswahl-berlin-2026"])
+
+
+def test_cloud_seed_without_secret_exits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seed = _load_seed_module(monkeypatch, ENV="prod")
+    monkeypatch.delenv("REVALIDATE_SECRET", raising=False)
+    monkeypatch.delenv("SITE_URL", raising=False)
+    monkeypatch.delenv("REVALIDATE_URL", raising=False)
+    with pytest.raises(SystemExit):
+        seed.revalidate_frontend_cache(["abgeordnetenhauswahl-berlin-2026"])
+
+
+def test_cloud_seed_posts_tags_and_context_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seed = _load_seed_module(
+        monkeypatch,
+        ENV="prod",
+        REVALIDATE_SECRET="test-secret",
+    )
+    captured: dict[str, object] = {}
+
+    def _urlopen(request: object, timeout: int = 0) -> _FakeResponse:
+        captured["url"] = request.full_url  # type: ignore[attr-defined]
+        captured["timeout"] = timeout
+        captured["headers"] = dict(request.header_items())  # type: ignore[attr-defined]
+        captured["body"] = json.loads(request.data.decode())  # type: ignore[attr-defined]
+        return _FakeResponse()
+
+    monkeypatch.setattr(seed.urllib.request, "urlopen", _urlopen)
+    seed.revalidate_frontend_cache(["abgeordnetenhauswahl-berlin-2026"])
+
+    assert captured["url"] == "https://wahl.chat/api/revalidate"
+    assert captured["timeout"] == 30
+    headers = {k.lower(): v for k, v in captured["headers"].items()}  # type: ignore[union-attr]
+    assert headers["authorization"] == "Bearer test-secret"
+    body = captured["body"]
+    assert body["tags"] == list(seed.SEED_CACHE_TAGS)
+    assert body["paths"] == [
+        "/",
+        "/abgeordnetenhauswahl-berlin-2026",
+        "/abgeordnetenhauswahl-berlin-2026/sources",
+    ]
+
+
+def test_site_url_override_wins_over_prod_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seed = _load_seed_module(
+        monkeypatch,
+        ENV="prod",
+        REVALIDATE_SECRET="test-secret",
+        SITE_URL="https://preview.example",
+    )
+    captured: dict[str, str] = {}
+
+    def _urlopen(request: object, timeout: int = 0) -> _FakeResponse:
+        captured["url"] = request.full_url  # type: ignore[attr-defined]
+        return _FakeResponse()
+
+    monkeypatch.setattr(seed.urllib.request, "urlopen", _urlopen)
+    seed.revalidate_frontend_cache([])
+    assert captured["url"] == "https://preview.example/api/revalidate"
+
+
+def test_http_error_exits(monkeypatch: pytest.MonkeyPatch) -> None:
+    seed = _load_seed_module(
+        monkeypatch,
+        ENV="prod",
+        REVALIDATE_SECRET="test-secret",
+    )
+
+    def _urlopen(*_a: object, **_k: object) -> None:
+        raise HTTPError(
+            "https://wahl.chat/api/revalidate",
+            401,
+            "Unauthorized",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=io.BytesIO(b"Unauthorized"),
+        )
+
+    monkeypatch.setattr(seed.urllib.request, "urlopen", _urlopen)
+    with pytest.raises(SystemExit):
+        seed.revalidate_frontend_cache(["bundestagswahl-2025"])
+
+
+def test_network_error_exits(monkeypatch: pytest.MonkeyPatch) -> None:
+    seed = _load_seed_module(
+        monkeypatch,
+        ENV="prod",
+        REVALIDATE_SECRET="test-secret",
+    )
+
+    def _urlopen(*_a: object, **_k: object) -> None:
+        raise URLError("timed out")
+
+    monkeypatch.setattr(seed.urllib.request, "urlopen", _urlopen)
+    with pytest.raises(SystemExit):
+        seed.revalidate_frontend_cache(["bundestagswahl-2025"])

--- a/ai-backend/tests/test_seed_revalidate.py
+++ b/ai-backend/tests/test_seed_revalidate.py
@@ -64,7 +64,7 @@ def test_cloud_seed_without_secret_warns_and_continues(
     seed.revalidate_frontend_cache(["abgeordnetenhauswahl-berlin-2026"])
 
 
-def test_cloud_seed_posts_tags_and_context_paths(
+def test_cloud_seed_posts_per_context_tags(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     seed = _load_seed_module(
@@ -89,12 +89,24 @@ def test_cloud_seed_posts_tags_and_context_paths(
     headers = {k.lower(): v for k, v in captured["headers"].items()}  # type: ignore[union-attr]
     assert headers["authorization"] == "Bearer test-secret"
     body = captured["body"]
-    assert body["tags"] == list(seed.frontend_cache.SEED_CACHE_TAGS)
-    assert body["paths"] == [
-        "/",
-        "/abgeordnetenhauswahl-berlin-2026",
-        "/abgeordnetenhauswahl-berlin-2026/sources",
-    ]
+    assert "paths" not in body
+    assert body["tags"] == seed.frontend_cache.seed_cache_tags(
+        ["abgeordnetenhauswahl-berlin-2026"]
+    )
+    assert "contexts" in body["tags"]
+    assert "context:abgeordnetenhauswahl-berlin-2026:parties" in body["tags"]
+    assert "context:abgeordnetenhauswahl-berlin-2026:sources" in body["tags"]
+    assert "context:abgeordnetenhauswahl-berlin-2026:questions" in body["tags"]
+
+
+def test_seed_cache_tags_include_coarse_and_per_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seed = _load_seed_module(monkeypatch, ENV="prod")
+    tags = seed.frontend_cache.seed_cache_tags(["berlin-2026", "mv-2026"])
+    assert tags[:4] == list(seed.frontend_cache.COARSE_CACHE_TAGS)
+    assert "context:berlin-2026:parties" in tags
+    assert "context:mv-2026:sources" in tags
 
 
 def test_dev_env_defaults_to_dev_wahl_chat(
@@ -189,11 +201,9 @@ def test_standalone_script_posts_and_returns_zero(
         seed.frontend_cache.main(["--context", "abgeordnetenhauswahl-berlin-2026"]) == 0
     )
     body = captured["body"]
-    assert body["paths"] == [
-        "/",
-        "/abgeordnetenhauswahl-berlin-2026",
-        "/abgeordnetenhauswahl-berlin-2026/sources",
-    ]
+    assert body["tags"] == seed.frontend_cache.seed_cache_tags(
+        ["abgeordnetenhauswahl-berlin-2026"]
+    )
 
 
 def test_standalone_script_exits_on_network_error(

--- a/ai-backend/tests/test_seed_revalidate.py
+++ b/ai-backend/tests/test_seed_revalidate.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
-"""Frontend cache bust that follows a real-project Firestore seed."""
+"""Frontend cache bust: optional after seed, required on the standalone script."""
 
 from __future__ import annotations
 
@@ -29,6 +29,10 @@ class _FakeResponse:
         return None
 
 
+def _patch_urlopen(seed, monkeypatch, fn):
+    monkeypatch.setattr(seed.frontend_cache.urllib.request, "urlopen", fn)
+
+
 def test_emulator_seed_skips_revalidation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -41,19 +45,23 @@ def test_emulator_seed_skips_revalidation(
     def _fail(*_a: object, **_k: object) -> None:
         raise AssertionError("emulator seed must not call /api/revalidate")
 
-    monkeypatch.setattr(seed.urllib.request, "urlopen", _fail)
+    _patch_urlopen(seed, monkeypatch, _fail)
     seed.revalidate_frontend_cache(["abgeordnetenhauswahl-berlin-2026"])
 
 
-def test_cloud_seed_without_secret_exits(
+def test_cloud_seed_without_secret_warns_and_continues(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     seed = _load_seed_module(monkeypatch, ENV="prod")
     monkeypatch.delenv("REVALIDATE_SECRET", raising=False)
     monkeypatch.delenv("SITE_URL", raising=False)
     monkeypatch.delenv("REVALIDATE_URL", raising=False)
-    with pytest.raises(SystemExit):
-        seed.revalidate_frontend_cache(["abgeordnetenhauswahl-berlin-2026"])
+
+    def _fail(*_a: object, **_k: object) -> None:
+        raise AssertionError("missing secret must not call /api/revalidate")
+
+    _patch_urlopen(seed, monkeypatch, _fail)
+    seed.revalidate_frontend_cache(["abgeordnetenhauswahl-berlin-2026"])
 
 
 def test_cloud_seed_posts_tags_and_context_paths(
@@ -73,7 +81,7 @@ def test_cloud_seed_posts_tags_and_context_paths(
         captured["body"] = json.loads(request.data.decode())  # type: ignore[attr-defined]
         return _FakeResponse()
 
-    monkeypatch.setattr(seed.urllib.request, "urlopen", _urlopen)
+    _patch_urlopen(seed, monkeypatch, _urlopen)
     seed.revalidate_frontend_cache(["abgeordnetenhauswahl-berlin-2026"])
 
     assert captured["url"] == "https://wahl.chat/api/revalidate"
@@ -81,12 +89,33 @@ def test_cloud_seed_posts_tags_and_context_paths(
     headers = {k.lower(): v for k, v in captured["headers"].items()}  # type: ignore[union-attr]
     assert headers["authorization"] == "Bearer test-secret"
     body = captured["body"]
-    assert body["tags"] == list(seed.SEED_CACHE_TAGS)
+    assert body["tags"] == list(seed.frontend_cache.SEED_CACHE_TAGS)
     assert body["paths"] == [
         "/",
         "/abgeordnetenhauswahl-berlin-2026",
         "/abgeordnetenhauswahl-berlin-2026/sources",
     ]
+
+
+def test_dev_env_defaults_to_dev_wahl_chat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seed = _load_seed_module(
+        monkeypatch,
+        ENV="dev",
+        REVALIDATE_SECRET="test-secret",
+    )
+    monkeypatch.delenv("SITE_URL", raising=False)
+    monkeypatch.delenv("REVALIDATE_URL", raising=False)
+    captured: dict[str, str] = {}
+
+    def _urlopen(request: object, timeout: int = 0) -> _FakeResponse:
+        captured["url"] = request.full_url  # type: ignore[attr-defined]
+        return _FakeResponse()
+
+    _patch_urlopen(seed, monkeypatch, _urlopen)
+    seed.revalidate_frontend_cache([])
+    assert captured["url"] == "https://dev.wahl.chat/api/revalidate"
 
 
 def test_site_url_override_wins_over_prod_default(
@@ -104,12 +133,14 @@ def test_site_url_override_wins_over_prod_default(
         captured["url"] = request.full_url  # type: ignore[attr-defined]
         return _FakeResponse()
 
-    monkeypatch.setattr(seed.urllib.request, "urlopen", _urlopen)
+    _patch_urlopen(seed, monkeypatch, _urlopen)
     seed.revalidate_frontend_cache([])
     assert captured["url"] == "https://preview.example/api/revalidate"
 
 
-def test_http_error_exits(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_http_error_does_not_fail_the_seed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     seed = _load_seed_module(
         monkeypatch,
         ENV="prod",
@@ -125,12 +156,49 @@ def test_http_error_exits(monkeypatch: pytest.MonkeyPatch) -> None:
             fp=io.BytesIO(b"Unauthorized"),
         )
 
-    monkeypatch.setattr(seed.urllib.request, "urlopen", _urlopen)
-    with pytest.raises(SystemExit):
-        seed.revalidate_frontend_cache(["bundestagswahl-2025"])
+    _patch_urlopen(seed, monkeypatch, _urlopen)
+    seed.revalidate_frontend_cache(["bundestagswahl-2025"])
 
 
-def test_network_error_exits(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_standalone_script_requires_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seed = _load_seed_module(monkeypatch, ENV="prod")
+    monkeypatch.delenv("REVALIDATE_SECRET", raising=False)
+    monkeypatch.delenv("SITE_URL", raising=False)
+    monkeypatch.delenv("REVALIDATE_URL", raising=False)
+    assert seed.frontend_cache.main(["--context", "bundestagswahl-2025"]) == 1
+
+
+def test_standalone_script_posts_and_returns_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seed = _load_seed_module(
+        monkeypatch,
+        ENV="prod",
+        REVALIDATE_SECRET="test-secret",
+    )
+    captured: dict[str, object] = {}
+
+    def _urlopen(request: object, timeout: int = 0) -> _FakeResponse:
+        captured["body"] = json.loads(request.data.decode())  # type: ignore[attr-defined]
+        return _FakeResponse()
+
+    _patch_urlopen(seed, monkeypatch, _urlopen)
+    assert (
+        seed.frontend_cache.main(["--context", "abgeordnetenhauswahl-berlin-2026"]) == 0
+    )
+    body = captured["body"]
+    assert body["paths"] == [
+        "/",
+        "/abgeordnetenhauswahl-berlin-2026",
+        "/abgeordnetenhauswahl-berlin-2026/sources",
+    ]
+
+
+def test_standalone_script_exits_on_network_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     seed = _load_seed_module(
         monkeypatch,
         ENV="prod",
@@ -140,6 +208,5 @@ def test_network_error_exits(monkeypatch: pytest.MonkeyPatch) -> None:
     def _urlopen(*_a: object, **_k: object) -> None:
         raise URLError("timed out")
 
-    monkeypatch.setattr(seed.urllib.request, "urlopen", _urlopen)
-    with pytest.raises(SystemExit):
-        seed.revalidate_frontend_cache(["bundestagswahl-2025"])
+    _patch_urlopen(seed, monkeypatch, _urlopen)
+    assert seed.frontend_cache.main(["--context", "bundestagswahl-2025"]) == 1

--- a/ai-backend/tests/test_seed_revalidate.py
+++ b/ai-backend/tests/test_seed_revalidate.py
@@ -220,3 +220,80 @@ def test_standalone_script_exits_on_network_error(
 
     _patch_urlopen(seed, monkeypatch, _urlopen)
     assert seed.frontend_cache.main(["--context", "bundestagswahl-2025"]) == 1
+
+
+def test_mismatched_firestore_project_skips_revalidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seed = _load_seed_module(
+        monkeypatch,
+        ENV="prod",
+        REVALIDATE_SECRET="test-secret",
+    )
+
+    def _fail(*_a: object, **_k: object) -> None:
+        raise AssertionError("must not flush the other deployment")
+
+    _patch_urlopen(seed, monkeypatch, _fail)
+    seed.revalidate_frontend_cache(
+        ["bundestagswahl-2025"], firestore_project="wahl-chat-dev"
+    )
+
+
+def test_matching_firestore_project_still_revalidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seed = _load_seed_module(
+        monkeypatch,
+        ENV="prod",
+        REVALIDATE_SECRET="test-secret",
+    )
+    captured: dict[str, str] = {}
+
+    def _urlopen(request: object, timeout: int = 0) -> _FakeResponse:
+        captured["url"] = request.full_url  # type: ignore[attr-defined]
+        return _FakeResponse()
+
+    _patch_urlopen(seed, monkeypatch, _urlopen)
+    seed.revalidate_frontend_cache([], firestore_project="wahl-chat")
+    assert captured["url"] == "https://wahl.chat/api/revalidate"
+
+
+def test_standalone_script_ignores_ambient_google_cloud_project(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A leftover GOOGLE_CLOUD_PROJECT from local gcloud must not block a flush."""
+    seed = _load_seed_module(
+        monkeypatch,
+        ENV="prod",
+        REVALIDATE_SECRET="test-secret",
+        GOOGLE_CLOUD_PROJECT="wahl-chat-dev",
+    )
+    captured: dict[str, str] = {}
+
+    def _urlopen(request: object, timeout: int = 0) -> _FakeResponse:
+        captured["url"] = request.full_url  # type: ignore[attr-defined]
+        return _FakeResponse()
+
+    _patch_urlopen(seed, monkeypatch, _urlopen)
+    assert seed.frontend_cache.main(["--context", "bundestagswahl-2025"]) == 0
+    assert captured["url"] == "https://wahl.chat/api/revalidate"
+
+
+def test_post_revalidate_raises_on_project_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seed = _load_seed_module(
+        monkeypatch,
+        ENV="dev",
+        REVALIDATE_SECRET="test-secret",
+    )
+
+    def _fail(*_a: object, **_k: object) -> None:
+        raise AssertionError("must not flush the other deployment")
+
+    _patch_urlopen(seed, monkeypatch, _fail)
+    with pytest.raises(seed.frontend_cache.RevalidateProjectMismatchError):
+        seed.frontend_cache.post_revalidate(
+            ["bundestagswahl-2025"], firestore_project="wahl-chat"
+        )

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -102,8 +102,17 @@ Run from the `firebase/` directory:
 ```bash
 python scripts/seed_firestore.py
 
-# For production (set REVALIDATE_SECRET so the live site drops its ISR cache):
-REVALIDATE_SECRET=... ENV=prod python scripts/seed_firestore.py
+# Production or hosted dev. REVALIDATE_SECRET is optional; without it
+# the seed warns that that deployment may keep the previous hour's pages.
+# Use the secret of the matching Vercel environment (Production vs
+# Preview/Development) from:
+# https://vercel.com/wahl-chat/web/settings/environment-variables
+ENV=prod python scripts/seed_firestore.py
+ENV=dev python scripts/seed_firestore.py
+
+# Bust ISR separately (or after a seed that skipped it):
+REVALIDATE_SECRET=... ENV=prod python scripts/revalidate_frontend_cache.py
+REVALIDATE_SECRET=... ENV=dev python scripts/revalidate_frontend_cache.py
 ```
 
 Or simply from the repo root:
@@ -143,7 +152,7 @@ firestore-import -a ../ai-backend/wahl-chat-dev-firebase-adminsdk.json \
 1. Add the context to `firestore_data/dev/contexts.json`
 2. Create `firestore_data/dev/parties_{context_id}.json`
 3. Create `firestore_data/dev/proposed_questions_{context_id}.json`
-4. Run `python scripts/seed_firestore.py` from `firebase/`. A real-project seed (not the emulator) then calls `/api/revalidate` so the site does not keep serving the previous hour's empty party list. Export `REVALIDATE_SECRET` (and `SITE_URL` unless this is `ENV=prod`).
+4. Run `python scripts/seed_firestore.py` from `firebase/`. A real-project seed calls `/api/revalidate` when `REVALIDATE_SECRET` is set (`ENV=prod` → wahl.chat, `ENV=dev` → dev.wahl.chat) so that deployment does not keep the previous hour's empty party list; without the secret it warns and continues. Use the secret of the matching Vercel environment. To bust the cache later: `REVALIDATE_SECRET=... ENV=dev python scripts/revalidate_frontend_cache.py`.
 
 ## Managing Data
 
@@ -210,8 +219,9 @@ Ensure all referenced assets (logos, PDFs, etc.) exist in the prod Firebase Stor
 # From repo root:
 make seed-prod
 
-# Or from firebase/ (REVALIDATE_SECRET busts the live site's ISR cache):
-REVALIDATE_SECRET=... ENV=prod python scripts/seed_firestore.py
+# Or from firebase/:
+ENV=prod python scripts/seed_firestore.py
+REVALIDATE_SECRET=... ENV=prod python scripts/revalidate_frontend_cache.py
 ```
 
 ### 5. Deploy Qdrant vector store data

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -102,8 +102,8 @@ Run from the `firebase/` directory:
 ```bash
 python scripts/seed_firestore.py
 
-# For production:
-ENV=prod python scripts/seed_firestore.py
+# For production (set REVALIDATE_SECRET so the live site drops its ISR cache):
+REVALIDATE_SECRET=... ENV=prod python scripts/seed_firestore.py
 ```
 
 Or simply from the repo root:
@@ -143,7 +143,7 @@ firestore-import -a ../ai-backend/wahl-chat-dev-firebase-adminsdk.json \
 1. Add the context to `firestore_data/dev/contexts.json`
 2. Create `firestore_data/dev/parties_{context_id}.json`
 3. Create `firestore_data/dev/proposed_questions_{context_id}.json`
-4. Run `python scripts/seed_firestore.py` from `firebase/`
+4. Run `python scripts/seed_firestore.py` from `firebase/`. A real-project seed (not the emulator) then calls `/api/revalidate` so the site does not keep serving the previous hour's empty party list. Export `REVALIDATE_SECRET` (and `SITE_URL` unless this is `ENV=prod`).
 
 ## Managing Data
 
@@ -210,8 +210,8 @@ Ensure all referenced assets (logos, PDFs, etc.) exist in the prod Firebase Stor
 # From repo root:
 make seed-prod
 
-# Or from firebase/:
-ENV=prod python scripts/seed_firestore.py
+# Or from firebase/ (REVALIDATE_SECRET busts the live site's ISR cache):
+REVALIDATE_SECRET=... ENV=prod python scripts/seed_firestore.py
 ```
 
 ### 5. Deploy Qdrant vector store data

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -103,14 +103,14 @@ Run from the `firebase/` directory:
 python scripts/seed_firestore.py
 
 # Production or hosted dev. REVALIDATE_SECRET is optional; without it
-# the seed warns that that deployment may keep the previous hour's pages.
+# the seed warns that that deployment may keep a cached empty party list.
 # Use the secret of the matching Vercel environment (Production vs
 # Preview/Development) from:
 # https://vercel.com/wahl-chat/web/settings/environment-variables
 ENV=prod python scripts/seed_firestore.py
 ENV=dev python scripts/seed_firestore.py
 
-# Bust ISR separately (or after a seed that skipped it):
+# Bust the data cache separately (or after a seed that skipped it):
 REVALIDATE_SECRET=... ENV=prod python scripts/revalidate_frontend_cache.py
 REVALIDATE_SECRET=... ENV=dev python scripts/revalidate_frontend_cache.py
 ```
@@ -152,7 +152,7 @@ firestore-import -a ../ai-backend/wahl-chat-dev-firebase-adminsdk.json \
 1. Add the context to `firestore_data/dev/contexts.json`
 2. Create `firestore_data/dev/parties_{context_id}.json`
 3. Create `firestore_data/dev/proposed_questions_{context_id}.json`
-4. Run `python scripts/seed_firestore.py` from `firebase/`. A real-project seed calls `/api/revalidate` when `REVALIDATE_SECRET` is set (`ENV=prod` → wahl.chat, `ENV=dev` → dev.wahl.chat) so that deployment does not keep the previous hour's empty party list; without the secret it warns and continues. Use the secret of the matching Vercel environment. To bust the cache later: `REVALIDATE_SECRET=... ENV=dev python scripts/revalidate_frontend_cache.py`.
+4. Run `python scripts/seed_firestore.py` from `firebase/`. A real-project seed calls `/api/revalidate` when `REVALIDATE_SECRET` is set (`ENV=prod` → wahl.chat, `ENV=dev` → dev.wahl.chat) so that deployment drops the per-context data tags; without the secret it warns and continues. Use the secret of the matching Vercel environment. To bust the cache later: `REVALIDATE_SECRET=... ENV=dev python scripts/revalidate_frontend_cache.py`.
 
 ## Managing Data
 

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -119,12 +119,13 @@ Or simply from the repo root:
 
 ```bash
 make seed
-
-# For production:
 make seed-prod
+REVALIDATE_SECRET=... make revalidate
+REVALIDATE_SECRET=... make revalidate ENV=prod
+REVALIDATE_SECRET=... make revalidate ARGS="--context abgeordnetenhauswahl-berlin-2026"
 ```
 
-The script requires `firebase-admin`. The `make seed` targets use the ai-backend's Poetry environment automatically. To run standalone:
+The script requires `firebase-admin`. The `make seed` / `make revalidate` targets use the ai-backend uv environment. To run standalone:
 
 ```bash
 cd firebase && python -m venv venv && source venv/bin/activate
@@ -218,6 +219,7 @@ Ensure all referenced assets (logos, PDFs, etc.) exist in the prod Firebase Stor
 ```bash
 # From repo root:
 make seed-prod
+REVALIDATE_SECRET=... make revalidate ENV=prod
 
 # Or from firebase/:
 ENV=prod python scripts/seed_firestore.py

--- a/firebase/scripts/revalidate_frontend_cache.py
+++ b/firebase/scripts/revalidate_frontend_cache.py
@@ -2,10 +2,11 @@
 # SPDX-FileCopyrightText: 2026 wahl.chat
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
-"""Bust the Next.js ISR cache for seeded Firestore data.
+"""Bust the Next.js data cache for seeded Firestore data.
 
-The live site caches contexts and parties for about an hour. After a
-real-project seed, call this so a newly added election does not stay empty.
+The hosted app caches election config (contexts, parties, sources,
+questions) by tag. After a real-project seed, call this so a newly added
+election does not stay empty.
 
 Usage (from the repo root or firebase/):
 
@@ -43,9 +44,9 @@ def _data_dir() -> Path:
     return FIREBASE_DIR / "firestore_data" / _env()
 
 
-# Tags the web app attaches to unstable_cache / ISR for the collections the
-# seed script writes.
-SEED_CACHE_TAGS = (
+# Coarse tags still attached on the web cache (covers entries written before
+# per-context tags). Also busted so a deploy mid-seed cannot leave both.
+COARSE_CACHE_TAGS = (
     "contexts",
     "context_parties",
     "proposed_questions",
@@ -78,12 +79,22 @@ def site_url() -> str | None:
     return DEFAULT_SITE_URLS.get(_env())
 
 
-def revalidate_payload(context_ids: list[str]) -> dict[str, list[str]]:
-    paths = ["/"]
+def seed_cache_tags(context_ids: list[str]) -> list[str]:
+    tags = list(COARSE_CACHE_TAGS)
     for context_id in context_ids:
-        paths.append(f"/{context_id}")
-        paths.append(f"/{context_id}/sources")
-    return {"tags": list(SEED_CACHE_TAGS), "paths": paths}
+        tags.extend(
+            [
+                f"context:{context_id}",
+                f"context:{context_id}:parties",
+                f"context:{context_id}:sources",
+                f"context:{context_id}:questions",
+            ]
+        )
+    return tags
+
+
+def revalidate_payload(context_ids: list[str]) -> dict[str, list[str]]:
+    return {"tags": seed_cache_tags(context_ids)}
 
 
 def context_ids_from_fixtures() -> list[str]:
@@ -135,7 +146,7 @@ def post_revalidate(context_ids: list[str]) -> str:
             f"Cache revalidation failed: {exc.reason}"
         ) from exc
 
-    print(f"  tags={payload['tags']} paths={len(payload['paths'])} ({body})")
+    print(f"  tags={len(payload['tags'])} ({body})")
     return body
 
 
@@ -144,9 +155,9 @@ def missing_secret_warning() -> str:
     return (
         "============================================================\n"
         " Frontend cache was not revalidated.\n"
-        " Firestore is written, but the live site may keep serving the\n"
-        " previous hour's cached pages — a newly added context can look\n"
-        " empty (no parties to select) until ISR expires.\n"
+        " Firestore is written, but the hosted app may keep a cached\n"
+        " empty party list until that tag is busted or the 24h safety\n"
+        " TTL expires.\n"
         "\n"
         " Bust the cache when you are ready:\n"
         f"   REVALIDATE_SECRET=... ENV={_env()} python {script}\n"
@@ -161,7 +172,7 @@ def missing_secret_warning() -> str:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Bust the wahl.chat ISR cache for seeded Firestore data.",
+        description="Bust the hosted app's election-config data cache after a seed.",
     )
     parser.add_argument(
         "--context",

--- a/firebase/scripts/revalidate_frontend_cache.py
+++ b/firebase/scripts/revalidate_frontend_cache.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+"""Bust the Next.js ISR cache for seeded Firestore data.
+
+The live site caches contexts and parties for about an hour. After a
+real-project seed, call this so a newly added election does not stay empty.
+
+Usage (from the repo root or firebase/):
+
+    REVALIDATE_SECRET=... ENV=prod python scripts/revalidate_frontend_cache.py
+    REVALIDATE_SECRET=... ENV=dev python scripts/revalidate_frontend_cache.py
+
+    # One election only:
+    REVALIDATE_SECRET=... ENV=prod python scripts/revalidate_frontend_cache.py \\
+        --context abgeordnetenhauswahl-berlin-2026
+
+Use the REVALIDATE_SECRET of the matching Vercel deployment
+(Production vs Preview/Development):
+https://vercel.com/wahl-chat/web/settings/environment-variables
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+FIREBASE_DIR = SCRIPT_DIR.parent
+
+
+def _env() -> str:
+    return os.getenv("ENV", "dev")
+
+
+def _data_dir() -> Path:
+    return FIREBASE_DIR / "firestore_data" / _env()
+
+
+# Tags the web app attaches to unstable_cache / ISR for the collections the
+# seed script writes.
+SEED_CACHE_TAGS = (
+    "contexts",
+    "context_parties",
+    "proposed_questions",
+    "source_documents",
+)
+DEFAULT_SITE_URLS = {
+    "prod": "https://wahl.chat",
+    "dev": "https://dev.wahl.chat",
+}
+VERCEL_ENV_VARS_URL = "https://vercel.com/wahl-chat/web/settings/environment-variables"
+
+
+class RevalidateConfigError(Exception):
+    """Secret or site URL is missing — nothing was sent."""
+
+
+class RevalidateRequestError(Exception):
+    """The /api/revalidate request failed."""
+
+
+def site_url() -> str | None:
+    """Public origin of the Next.js app whose cache we must bust.
+
+    REVALIDATE_URL / SITE_URL win; otherwise ENV=prod → wahl.chat and
+    ENV=dev → dev.wahl.chat.
+    """
+    explicit = os.getenv("REVALIDATE_URL") or os.getenv("SITE_URL")
+    if explicit:
+        return explicit.rstrip("/")
+    return DEFAULT_SITE_URLS.get(_env())
+
+
+def revalidate_payload(context_ids: list[str]) -> dict[str, list[str]]:
+    paths = ["/"]
+    for context_id in context_ids:
+        paths.append(f"/{context_id}")
+        paths.append(f"/{context_id}/sources")
+    return {"tags": list(SEED_CACHE_TAGS), "paths": paths}
+
+
+def context_ids_from_fixtures() -> list[str]:
+    contexts_file = _data_dir() / "contexts.json"
+    if not contexts_file.exists():
+        raise RevalidateConfigError(f"contexts file not found: {contexts_file}")
+    with open(contexts_file) as f:
+        contexts = json.load(f)
+    return list(contexts)
+
+
+def post_revalidate(context_ids: list[str]) -> str:
+    """POST tags and context paths to /api/revalidate. Returns the response body."""
+    # Use the REVALIDATE_SECRET of the matching Vercel deployment
+    # (Production vs Preview/Development):
+    # https://vercel.com/wahl-chat/web/settings/environment-variables
+    secret = os.getenv("REVALIDATE_SECRET")
+    site = site_url()
+    if not secret or not site:
+        raise RevalidateConfigError(
+            "Set REVALIDATE_SECRET to the value for this deployment "
+            "(Production for ENV=prod, Preview/Development for ENV=dev). "
+            f"Copy it from {VERCEL_ENV_VARS_URL}. "
+            "Override the target with SITE_URL or REVALIDATE_URL if needed."
+        )
+
+    payload = revalidate_payload(context_ids)
+    url = f"{site}/api/revalidate"
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers={
+            "Authorization": f"Bearer {secret}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    print(f"Revalidating frontend cache at {url} ...")
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            body = response.read().decode()
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")
+        raise RevalidateRequestError(
+            f"Cache revalidation failed ({exc.code}): {detail}"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise RevalidateRequestError(
+            f"Cache revalidation failed: {exc.reason}"
+        ) from exc
+
+    print(f"  tags={payload['tags']} paths={len(payload['paths'])} ({body})")
+    return body
+
+
+def missing_secret_warning() -> str:
+    script = "firebase/scripts/revalidate_frontend_cache.py"
+    return (
+        "============================================================\n"
+        " Frontend cache was not revalidated.\n"
+        " Firestore is written, but the live site may keep serving the\n"
+        " previous hour's cached pages — a newly added context can look\n"
+        " empty (no parties to select) until ISR expires.\n"
+        "\n"
+        " Bust the cache when you are ready:\n"
+        f"   REVALIDATE_SECRET=... ENV={_env()} python {script}\n"
+        "\n"
+        " Copy the REVALIDATE_SECRET of that deployment (Production\n"
+        " for ENV=prod / wahl.chat, Preview or Development for ENV=dev\n"
+        " / dev.wahl.chat) from:\n"
+        f"   {VERCEL_ENV_VARS_URL}\n"
+        "============================================================"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Bust the wahl.chat ISR cache for seeded Firestore data.",
+    )
+    parser.add_argument(
+        "--context",
+        action="append",
+        dest="contexts",
+        metavar="CONTEXT_ID",
+        help="Revalidate this context (repeatable). Default: every id in contexts.json.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        context_ids = args.contexts or context_ids_from_fixtures()
+        post_revalidate(context_ids)
+    except (RevalidateConfigError, RevalidateRequestError) as exc:
+        print(f"\n{exc}\n", file=sys.stderr)
+        if isinstance(exc, RevalidateConfigError):
+            print(missing_secret_warning(), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/firebase/scripts/revalidate_frontend_cache.py
+++ b/firebase/scripts/revalidate_frontend_cache.py
@@ -56,6 +56,12 @@ DEFAULT_SITE_URLS = {
     "prod": "https://wahl.chat",
     "dev": "https://dev.wahl.chat",
 }
+# Same aliases as firebase/.firebaserc. Used so a seed that wrote via ADC
+# cannot flush the other deployment's cache.
+EXPECTED_FIRESTORE_PROJECTS = {
+    "prod": "wahl-chat",
+    "dev": "wahl-chat-dev",
+}
 VERCEL_ENV_VARS_URL = "https://vercel.com/wahl-chat/web/settings/environment-variables"
 
 
@@ -63,8 +69,49 @@ class RevalidateConfigError(Exception):
     """Secret or site URL is missing — nothing was sent."""
 
 
+class RevalidateProjectMismatchError(RevalidateConfigError):
+    """Firestore project does not match ENV — refuse to flush the other site."""
+
+
 class RevalidateRequestError(Exception):
     """The /api/revalidate request failed."""
+
+
+def resolved_firestore_project(explicit: str | None = None) -> str | None:
+    """Project the seed just wrote to, if we can tell.
+
+    Prefer the Firestore client the caller already used. Fall back to the
+    initialized Firebase app — not GOOGLE_CLOUD_PROJECT, which is often
+    leftover from local `.env` / `gcloud config` and would block a
+    standalone flush of the other deployment.
+    """
+    if explicit:
+        return explicit
+    try:
+        import firebase_admin  # noqa: PLC0415
+
+        return firebase_admin.get_app().project_id or None
+    except (ImportError, ValueError):
+        return None
+
+
+def ensure_project_matches_env(firestore_project: str | None = None) -> None:
+    """Refuse to pick a site URL when the write went to a different project.
+
+    `ENV` selects both the fixture set and the default deployment
+    (wahl.chat vs dev.wahl.chat). ADC can point the Firestore client at
+    the other project, so a seed would flush the wrong cache.
+    """
+    actual = resolved_firestore_project(firestore_project)
+    expected = EXPECTED_FIRESTORE_PROJECTS.get(_env())
+    if actual is None or expected is None or actual == expected:
+        return
+    site = DEFAULT_SITE_URLS.get(_env()) or f"ENV={_env()}"
+    raise RevalidateProjectMismatchError(
+        f"Firestore project {actual!r} does not match ENV={_env()} "
+        f"(expected {expected!r}). Not revalidating {site} so a seed "
+        "cannot flush the other deployment."
+    )
 
 
 def site_url() -> str | None:
@@ -106,11 +153,14 @@ def context_ids_from_fixtures() -> list[str]:
     return list(contexts)
 
 
-def post_revalidate(context_ids: list[str]) -> str:
+def post_revalidate(
+    context_ids: list[str], firestore_project: str | None = None
+) -> str:
     """POST tags and context paths to /api/revalidate. Returns the response body."""
     # Use the REVALIDATE_SECRET of the matching Vercel deployment
     # (Production vs Preview/Development):
     # https://vercel.com/wahl-chat/web/settings/environment-variables
+    ensure_project_matches_env(firestore_project)
     secret = os.getenv("REVALIDATE_SECRET")
     site = site_url()
     if not secret or not site:

--- a/firebase/scripts/seed_firestore.py
+++ b/firebase/scripts/seed_firestore.py
@@ -5,8 +5,8 @@ Seed Firestore with contexts, parties, and proposed questions data.
 Usage (from the firebase/ directory):
     python scripts/seed_firestore.py
 
-    # For production:
-    ENV=prod python scripts/seed_firestore.py
+    # For production (also busts the live site's ISR cache):
+    REVALIDATE_SECRET=... ENV=prod python scripts/seed_firestore.py
 
 This script:
 1. Imports all contexts from firestore_data/{env}/contexts.json
@@ -32,6 +32,8 @@ File naming convention:
 import json
 import os
 import sys
+import urllib.error
+import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -347,6 +349,98 @@ def seed_sources(db):
     print(f"\nTotal source documents seeded: {total_documents}")
 
 
+# Tags the web app attaches to unstable_cache / ISR for the collections this
+# script writes. A real-project seed that skips this leaves wahl.chat serving
+# the previous hour's empty party list for a newly added context.
+SEED_CACHE_TAGS = (
+    "contexts",
+    "context_parties",
+    "proposed_questions",
+    "source_documents",
+)
+DEFAULT_PROD_SITE_URL = "https://wahl.chat"
+
+
+def _site_url():
+    """Public origin of the Next.js app whose cache we must bust.
+
+    REVALIDATE_URL / SITE_URL win; prod otherwise defaults to wahl.chat so a
+    typical production seed only needs REVALIDATE_SECRET.
+    """
+    explicit = os.getenv("REVALIDATE_URL") or os.getenv("SITE_URL")
+    if explicit:
+        return explicit.rstrip("/")
+    if ENV == "prod":
+        return DEFAULT_PROD_SITE_URL
+    return None
+
+
+def _revalidate_payload(context_ids):
+    paths = ["/"]
+    for context_id in context_ids:
+        paths.append(f"/{context_id}")
+        paths.append(f"/{context_id}/sources")
+    return {"tags": list(SEED_CACHE_TAGS), "paths": paths}
+
+
+def revalidate_frontend_cache(context_ids):
+    """Bust the live site's Firestore cache after a real-project seed.
+
+    Local emulator reads skip Next's unstable_cache, so this is a no-op there.
+    A cloud seed without REVALIDATE_SECRET (and a site URL, unless ENV=prod)
+    exits: Firestore is already written, but the site will keep serving stale
+    ISR until someone remembers to curl /api/revalidate.
+    """
+    if os.getenv("FIRESTORE_EMULATOR_HOST"):
+        print("\nSkipping frontend cache revalidation (Firestore emulator).")
+        return
+
+    # REVALIDATE_SECRET is the web app's Vercel env var:
+    # https://vercel.com/wahl-chat/web/settings/environment-variables
+    secret = os.getenv("REVALIDATE_SECRET")
+    site = _site_url()
+    if not secret or not site:
+        print(
+            "\n"
+            "============================================================\n"
+            " Frontend cache was not revalidated.\n"
+            " Set REVALIDATE_SECRET (same value as the web app) so the\n"
+            " next seed busts ISR automatically. For a non-prod site also\n"
+            " set SITE_URL or REVALIDATE_URL.\n"
+            " Copy it from:\n"
+            " https://vercel.com/wahl-chat/web/settings/environment-variables\n"
+            "============================================================\n"
+        )
+        sys.exit(1)
+
+    payload = _revalidate_payload(context_ids)
+    url = f"{site}/api/revalidate"
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers={
+            "Authorization": f"Bearer {secret}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    print(f"\nRevalidating frontend cache at {url} ...")
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            body = response.read().decode()
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")
+        print(f"\n❌ Cache revalidation failed ({exc.code}): {detail}")
+        sys.exit(1)
+    except urllib.error.URLError as exc:
+        print(f"\n❌ Cache revalidation failed: {exc.reason}")
+        sys.exit(1)
+
+    print(
+        f"  ✅ tags={payload['tags']} paths={len(payload['paths'])} ({body})"
+    )
+
+
 def main():
     print("=" * 60)
     print("Firestore Seed Script")
@@ -361,7 +455,7 @@ def main():
     db = initialize_firebase()
 
     # Seed contexts first
-    seed_contexts(db)
+    context_ids = seed_contexts(db)
 
     # Seed parties for each context
     seed_parties(db)
@@ -371,6 +465,8 @@ def main():
 
     # Seed source documents for each context's sources page
     seed_sources(db)
+
+    revalidate_frontend_cache(context_ids)
 
     print("\n" + "=" * 60)
     print("✅ Seeding complete!")

--- a/firebase/scripts/seed_firestore.py
+++ b/firebase/scripts/seed_firestore.py
@@ -5,8 +5,11 @@ Seed Firestore with contexts, parties, and proposed questions data.
 Usage (from the firebase/ directory):
     python scripts/seed_firestore.py
 
-    # For production (also busts the live site's ISR cache):
+    # Optional: also bust that deployment's ISR cache (use that env's secret):
     REVALIDATE_SECRET=... ENV=prod python scripts/seed_firestore.py
+    REVALIDATE_SECRET=... ENV=dev python scripts/seed_firestore.py
+    # Or seed first, then:
+    REVALIDATE_SECRET=... ENV=prod python scripts/revalidate_frontend_cache.py
 
 This script:
 1. Imports all contexts from firestore_data/{env}/contexts.json
@@ -32,8 +35,6 @@ File naming convention:
 import json
 import os
 import sys
-import urllib.error
-import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -46,6 +47,10 @@ SCRIPT_DIR = Path(__file__).parent
 FIREBASE_DIR = SCRIPT_DIR.parent
 REPO_ROOT = FIREBASE_DIR.parent
 DATA_DIR = FIREBASE_DIR / "firestore_data" / ENV
+
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+import revalidate_frontend_cache as frontend_cache  # noqa: E402
 
 # Service account JSON file (looked up in ai-backend/ where it's typically placed)
 CREDENTIALS_FILE = (
@@ -124,9 +129,7 @@ def _emulator_client():
         sys.exit(1)
 
     print(f"Using the Firestore emulator at {host} (project {project}, no credentials)")
-    return gcp_firestore.Client(
-        project=project, credentials=AnonymousCredentials()
-    )
+    return gcp_firestore.Client(project=project, credentials=AnonymousCredentials())
 
 
 def initialize_firebase():
@@ -349,96 +352,31 @@ def seed_sources(db):
     print(f"\nTotal source documents seeded: {total_documents}")
 
 
-# Tags the web app attaches to unstable_cache / ISR for the collections this
-# script writes. A real-project seed that skips this leaves wahl.chat serving
-# the previous hour's empty party list for a newly added context.
-SEED_CACHE_TAGS = (
-    "contexts",
-    "context_parties",
-    "proposed_questions",
-    "source_documents",
-)
-DEFAULT_PROD_SITE_URL = "https://wahl.chat"
-
-
-def _site_url():
-    """Public origin of the Next.js app whose cache we must bust.
-
-    REVALIDATE_URL / SITE_URL win; prod otherwise defaults to wahl.chat so a
-    typical production seed only needs REVALIDATE_SECRET.
-    """
-    explicit = os.getenv("REVALIDATE_URL") or os.getenv("SITE_URL")
-    if explicit:
-        return explicit.rstrip("/")
-    if ENV == "prod":
-        return DEFAULT_PROD_SITE_URL
-    return None
-
-
-def _revalidate_payload(context_ids):
-    paths = ["/"]
-    for context_id in context_ids:
-        paths.append(f"/{context_id}")
-        paths.append(f"/{context_id}/sources")
-    return {"tags": list(SEED_CACHE_TAGS), "paths": paths}
-
-
 def revalidate_frontend_cache(context_ids):
-    """Bust the live site's Firestore cache after a real-project seed.
+    """Optionally bust the live site's Firestore cache after a real-project seed.
 
     Local emulator reads skip Next's unstable_cache, so this is a no-op there.
-    A cloud seed without REVALIDATE_SECRET (and a site URL, unless ENV=prod)
-    exits: Firestore is already written, but the site will keep serving stale
-    ISR until someone remembers to curl /api/revalidate.
+    A missing REVALIDATE_SECRET only warns: Firestore is already written, and
+    `revalidate_frontend_cache.py` can be run afterwards.
     """
     if os.getenv("FIRESTORE_EMULATOR_HOST"):
         print("\nSkipping frontend cache revalidation (Firestore emulator).")
         return
 
-    # REVALIDATE_SECRET is the web app's Vercel env var:
-    # https://vercel.com/wahl-chat/web/settings/environment-variables
-    secret = os.getenv("REVALIDATE_SECRET")
-    site = _site_url()
-    if not secret or not site:
-        print(
-            "\n"
-            "============================================================\n"
-            " Frontend cache was not revalidated.\n"
-            " Set REVALIDATE_SECRET (same value as the web app) so the\n"
-            " next seed busts ISR automatically. For a non-prod site also\n"
-            " set SITE_URL or REVALIDATE_URL.\n"
-            " Copy it from:\n"
-            " https://vercel.com/wahl-chat/web/settings/environment-variables\n"
-            "============================================================\n"
-        )
-        sys.exit(1)
-
-    payload = _revalidate_payload(context_ids)
-    url = f"{site}/api/revalidate"
-    request = urllib.request.Request(
-        url,
-        data=json.dumps(payload).encode(),
-        headers={
-            "Authorization": f"Bearer {secret}",
-            "Content-Type": "application/json",
-        },
-        method="POST",
-    )
-    print(f"\nRevalidating frontend cache at {url} ...")
     try:
-        with urllib.request.urlopen(request, timeout=30) as response:
-            body = response.read().decode()
-    except urllib.error.HTTPError as exc:
-        detail = exc.read().decode(errors="replace")
-        print(f"\n❌ Cache revalidation failed ({exc.code}): {detail}")
-        sys.exit(1)
-    except urllib.error.URLError as exc:
-        print(f"\n❌ Cache revalidation failed: {exc.reason}")
-        sys.exit(1)
-
-    print(
-        f"  ✅ tags={payload['tags']} paths={len(payload['paths'])} ({body})"
-    )
+        print()
+        frontend_cache.post_revalidate(context_ids)
+    except frontend_cache.RevalidateConfigError:
+        print()
+        print(frontend_cache.missing_secret_warning())
+    except frontend_cache.RevalidateRequestError as exc:
+        print(f"\n⚠️  {exc}")
+        print(
+            " Seeding finished, but the live cache was not busted.\n"
+            " Retry with:\n"
+            f"   REVALIDATE_SECRET=... ENV={ENV} python "
+            "firebase/scripts/revalidate_frontend_cache.py\n"
+        )
 
 
 def main():

--- a/firebase/scripts/seed_firestore.py
+++ b/firebase/scripts/seed_firestore.py
@@ -5,7 +5,7 @@ Seed Firestore with contexts, parties, and proposed questions data.
 Usage (from the firebase/ directory):
     python scripts/seed_firestore.py
 
-    # Optional: also bust that deployment's ISR cache (use that env's secret):
+    # Optional: also bust that deployment's data cache (use that env's secret):
     REVALIDATE_SECRET=... ENV=prod python scripts/seed_firestore.py
     REVALIDATE_SECRET=... ENV=dev python scripts/seed_firestore.py
     # Or seed first, then:

--- a/firebase/scripts/seed_firestore.py
+++ b/firebase/scripts/seed_firestore.py
@@ -352,12 +352,14 @@ def seed_sources(db):
     print(f"\nTotal source documents seeded: {total_documents}")
 
 
-def revalidate_frontend_cache(context_ids):
+def revalidate_frontend_cache(context_ids, firestore_project=None):
     """Optionally bust the live site's Firestore cache after a real-project seed.
 
     Local emulator reads skip Next's unstable_cache, so this is a no-op there.
     A missing REVALIDATE_SECRET only warns: Firestore is already written, and
-    `revalidate_frontend_cache.py` can be run afterwards.
+    `revalidate_frontend_cache.py` can be run afterwards. A project/ENV
+    mismatch (ADC wrote a different Firebase project than ENV selects)
+    also warns and skips, so the other deployment's cache is left alone.
     """
     if os.getenv("FIRESTORE_EMULATOR_HOST"):
         print("\nSkipping frontend cache revalidation (Firestore emulator).")
@@ -365,7 +367,18 @@ def revalidate_frontend_cache(context_ids):
 
     try:
         print()
-        frontend_cache.post_revalidate(context_ids)
+        frontend_cache.post_revalidate(
+            context_ids, firestore_project=firestore_project
+        )
+    except frontend_cache.RevalidateProjectMismatchError as exc:
+        print(f"\n⚠️  {exc}")
+        print(
+            " Seeding finished, but the live cache was not busted.\n"
+            " Point ADC / the service account at the project for this ENV,\n"
+            " then retry:\n"
+            f"   REVALIDATE_SECRET=... ENV={ENV} python "
+            "firebase/scripts/revalidate_frontend_cache.py\n"
+        )
     except frontend_cache.RevalidateConfigError:
         print()
         print(frontend_cache.missing_secret_warning())
@@ -404,7 +417,9 @@ def main():
     # Seed source documents for each context's sources page
     seed_sources(db)
 
-    revalidate_frontend_cache(context_ids)
+    revalidate_frontend_cache(
+        context_ids, firestore_project=getattr(db, "project", None)
+    )
 
     print("\n" + "=" * 60)
     print("✅ Seeding complete!")

--- a/web/.env.example
+++ b/web/.env.example
@@ -52,6 +52,8 @@ PROLIFIC_MIN_CHAT_INTERACTIONS=10
 
 # Settings
 BUDGET_SPENT=false
-# Same value the seed script sends to /api/revalidate after a real-project seed.
+# Per-deployment secret the seed script (optional) and revalidate_frontend_cache.py
+# send to /api/revalidate. Use Production for ENV=prod, Preview/Development for ENV=dev:
+# https://vercel.com/wahl-chat/web/settings/environment-variables
 REVALIDATE_SECRET=
 IS_EMBEDDED=false

--- a/web/.env.example
+++ b/web/.env.example
@@ -52,5 +52,6 @@ PROLIFIC_MIN_CHAT_INTERACTIONS=10
 
 # Settings
 BUDGET_SPENT=false
+# Same value the seed script sends to /api/revalidate after a real-project seed.
 REVALIDATE_SECRET=
 IS_EMBEDDED=false

--- a/web/README.md
+++ b/web/README.md
@@ -45,9 +45,18 @@ Deployed via the [Vercel Platform](https://vercel.com). See the [Next.js deploym
 
 ### Cache Revalidation
 
-The app caches Firestore data (sources, parties, contexts) for about an hour. A real-project `seed_firestore.py` run busts that cache itself: export `REVALIDATE_SECRET` (same value as this app) and, unless `ENV=prod`, `SITE_URL` or `REVALIDATE_URL`. The emulator path skips this.
+The app caches Firestore data (sources, parties, contexts) for about an hour. A real-project `seed_firestore.py` run busts that cache when `REVALIDATE_SECRET` is set. Use the secret of the matching Vercel deployment (Production for `ENV=prod` / [wahl.chat](https://wahl.chat), Preview or Development for `ENV=dev` / [dev.wahl.chat](https://dev.wahl.chat)) from [the Vercel env vars page](https://vercel.com/wahl-chat/web/settings/environment-variables). The secret is optional — without it the seed still writes Firestore and warns that ISR may stay stale. The emulator path skips this.
 
-To revalidate by hand:
+To revalidate separately (or after a seed that skipped it):
+
+```bash
+REVALIDATE_SECRET=... ENV=prod python firebase/scripts/revalidate_frontend_cache.py
+REVALIDATE_SECRET=... ENV=dev python firebase/scripts/revalidate_frontend_cache.py
+REVALIDATE_SECRET=... ENV=prod python firebase/scripts/revalidate_frontend_cache.py \
+  --context abgeordnetenhauswahl-berlin-2026
+```
+
+To revalidate by hand with curl:
 
 ```bash
 # One or more cache tags

--- a/web/README.md
+++ b/web/README.md
@@ -45,23 +45,25 @@ Deployed via the [Vercel Platform](https://vercel.com). See the [Next.js deploym
 
 ### Cache Revalidation
 
-The app caches Firestore data (sources, parties, contexts) for performance. To revalidate:
+The app caches Firestore data (sources, parties, contexts) for about an hour. A real-project `seed_firestore.py` run busts that cache itself: export `REVALIDATE_SECRET` (same value as this app) and, unless `ENV=prod`, `SITE_URL` or `REVALIDATE_URL`. The emulator path skips this.
+
+To revalidate by hand:
 
 ```bash
-# By cache tag
+# One or more cache tags
 curl -X POST https://wahl.chat/api/revalidate \
   -H "Authorization: Bearer <REVALIDATE_SECRET>" \
   -H "Content-Type: application/json" \
-  -d '{"tag": "source_documents"}'
+  -d '{"tags": ["context_parties", "contexts"]}'
 
-# By path
+# One or more paths (layout scope — a context root also busts nested pages)
 curl -X POST https://wahl.chat/api/revalidate \
   -H "Authorization: Bearer <REVALIDATE_SECRET>" \
   -H "Content-Type: application/json" \
-  -d '{"path": "/bundestagswahl-2025/sources"}'
+  -d '{"paths": ["/abgeordnetenhauswahl-berlin-2026"]}'
 ```
 
-Available cache tags (defined in `lib/cache-tags.ts`):
+Single `tag` / `path` keys still work. Available cache tags (defined in `lib/cache-tags.ts`):
 - `source_documents` — Source documents for the sources page
 - `parties` — Global party data
 - `contexts` — Election contexts

--- a/web/README.md
+++ b/web/README.md
@@ -45,7 +45,7 @@ Deployed via the [Vercel Platform](https://vercel.com). See the [Next.js deploym
 
 ### Cache Revalidation
 
-The app caches Firestore data (sources, parties, contexts) for about an hour. A real-project `seed_firestore.py` run busts that cache when `REVALIDATE_SECRET` is set. Use the secret of the matching Vercel deployment (Production for `ENV=prod` / [wahl.chat](https://wahl.chat), Preview or Development for `ENV=dev` / [dev.wahl.chat](https://dev.wahl.chat)) from [the Vercel env vars page](https://vercel.com/wahl-chat/web/settings/environment-variables). The secret is optional — without it the seed still writes Firestore and warns that ISR may stay stale. The emulator path skips this.
+Election pages are rendered on request. Firestore election config (contexts, parties, sources, questions) is cached by tag, with a 24h safety TTL. Empty lists and failed reads are not cached, so a context published before its parties does not stay blank. A real-project `seed_firestore.py` run busts those tags when `REVALIDATE_SECRET` is set. Use the secret of the matching Vercel deployment (Production for `ENV=prod` / [wahl.chat](https://wahl.chat), Preview or Development for `ENV=dev` / [dev.wahl.chat](https://dev.wahl.chat)) from [the Vercel env vars page](https://vercel.com/wahl-chat/web/settings/environment-variables). The secret is optional — without it the seed still writes Firestore and warns. The emulator path skips the cache entirely.
 
 To revalidate separately (or after a seed that skipped it):
 
@@ -59,22 +59,17 @@ REVALIDATE_SECRET=... ENV=prod python firebase/scripts/revalidate_frontend_cache
 To revalidate by hand with curl:
 
 ```bash
-# One or more cache tags
+# Tags (preferred — one election, or the coarse tag for every election)
 curl -X POST https://wahl.chat/api/revalidate \
   -H "Authorization: Bearer <REVALIDATE_SECRET>" \
   -H "Content-Type: application/json" \
-  -d '{"tags": ["context_parties", "contexts"]}'
-
-# One or more paths (layout scope — a context root also busts nested pages)
-curl -X POST https://wahl.chat/api/revalidate \
-  -H "Authorization: Bearer <REVALIDATE_SECRET>" \
-  -H "Content-Type: application/json" \
-  -d '{"paths": ["/abgeordnetenhauswahl-berlin-2026"]}'
+  -d '{"tags": ["contexts", "context:abgeordnetenhauswahl-berlin-2026:parties"]}'
 ```
 
-Single `tag` / `path` keys still work. Available cache tags (defined in `lib/cache-tags.ts`):
-- `source_documents` — Source documents for the sources page
-- `parties` — Global party data
-- `contexts` — Election contexts
-- `context_parties` — Parties per context
-- `proposed_questions` — Suggested questions
+Single `tag` / `path` keys still work. Tags (defined in `lib/cache-tags.ts`):
+- `contexts` — Active election list
+- `context:{id}` — One election document
+- `context:{id}:parties` / `context_parties` — Parties for one / every election
+- `context:{id}:sources` / `source_documents` — Sources for one / every election
+- `context:{id}:questions` / `proposed_questions` — Suggested questions
+- `parties` — Global party collection (not the per-context list)

--- a/web/app/[contextId]/layout.tsx
+++ b/web/app/[contextId]/layout.tsx
@@ -10,7 +10,9 @@ import { shuffleArray } from '@/lib/utils';
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 
-export const revalidate = 3600;
+// Page is not the photocopy: election config is cached in unstable_cache and
+// busted by tag on seed. ISR here would snapshot empty party lists again.
+export const dynamic = 'force-dynamic';
 
 type Props = {
   children: React.ReactNode;
@@ -53,9 +55,8 @@ async function ContextLayout({ children, params }: Props) {
     redirect(`/${DEFAULT_CONTEXT_ID}`);
   }
 
-  // Shuffle parties randomly for fair display order.
-  // Note: With ISR (revalidate = 3600), this shuffle is cached for ~1 hour,
-  // meaning all users see the same party order during that period.
+  // Shuffle per request for fair display order. The party *list* is cached;
+  // the order is not.
   const shuffledParties = shuffleArray(parties);
 
   const jsonLd = buildContextJsonLd(context);

--- a/web/app/api/revalidate/route.ts
+++ b/web/app/api/revalidate/route.ts
@@ -5,6 +5,16 @@ import type { NextRequest } from 'next/server';
 
 const REVALIDATE_SECRET = process.env.REVALIDATE_SECRET;
 
+function collectStrings(single: unknown, many: unknown): string[] {
+  const values = [
+    ...(typeof single === 'string' ? [single] : []),
+    ...(Array.isArray(many) ? many : []),
+  ];
+  return values.filter(
+    (value): value is string => typeof value === 'string' && value.length > 0,
+  );
+}
+
 // Constant-time comparison of strings to prevent timing attacks
 function safeCompare(a: string, b: string): boolean {
   try {
@@ -30,19 +40,25 @@ export async function POST(request: NextRequest) {
       return new Response('Unauthorized', { status: 401 });
     }
 
-    const { tag, path } = await request.json();
+    const body = await request.json();
+    const tags = collectStrings(body.tag, body.tags);
+    const paths = collectStrings(body.path, body.paths);
 
-    if (path && typeof path === 'string') {
-      revalidatePath(path);
-      return new Response(`Revalidated path: ${path}`, { status: 200 });
+    if (tags.length === 0 && paths.length === 0) {
+      return new Response('Bad Request: Provide tag(s) or path(s)', {
+        status: 400,
+      });
     }
 
-    if (tag && typeof tag === 'string') {
+    // layout so a context root also busts the ISR page that embeds parties.
+    for (const path of paths) {
+      revalidatePath(path, 'layout');
+    }
+    for (const tag of tags) {
       revalidateTag(tag);
-      return new Response(`Revalidated tag: ${tag}`, { status: 200 });
     }
 
-    return new Response('Bad Request: Provide tag or path', { status: 400 });
+    return Response.json({ revalidated: { tags, paths } }, { status: 200 });
   } catch (error) {
     console.error('Revalidation error:', error);
     return new Response('Internal Server Error', { status: 500 });

--- a/web/app/api/revalidate/route.ts
+++ b/web/app/api/revalidate/route.ts
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    // layout so a context root also busts the ISR page that embeds parties.
+    // layout if a path is sent (manual); seeds bust tags only.
     for (const path of paths) {
       revalidatePath(path, 'layout');
     }

--- a/web/lib/cache-tags.ts
+++ b/web/lib/cache-tags.ts
@@ -10,3 +10,20 @@ export enum CacheTags {
   EXAMPLE_QUESTIONS_SHAREABLE_CHAT_SESSIONS = 'example_questions_shareable_chat_sessions',
   WAHL_SWIPER_THESES = 'wahl_swiper_theses',
 }
+
+/** Per-election tags so a seed can bust one context without dropping the others. */
+export function contextPartiesTag(contextId: string) {
+  return `context:${contextId}:parties`;
+}
+
+export function contextSourcesTag(contextId: string) {
+  return `context:${contextId}:sources`;
+}
+
+export function contextQuestionsTag(contextId: string) {
+  return `context:${contextId}:questions`;
+}
+
+export function contextTag(contextId: string) {
+  return `context:${contextId}`;
+}

--- a/web/lib/firebase/firebase-server.ts
+++ b/web/lib/firebase/firebase-server.ts
@@ -1,7 +1,13 @@
 'use server';
 
 import type { FullUser } from '@/components/anonymous-auth';
-import { CacheTags } from '@/lib/cache-tags';
+import {
+  CacheTags,
+  contextPartiesTag,
+  contextQuestionsTag,
+  contextSourcesTag,
+  contextTag,
+} from '@/lib/cache-tags';
 import { GROUP_PARTY_ID, WAHL_CHAT_PARTY_ID } from '@/lib/constants';
 import type { PartyDetails } from '@/lib/party-details';
 import type {
@@ -53,11 +59,31 @@ class ContextNotFoundError extends Error {
   }
 }
 
+// Thrown from inside unstable_cache so Next does not persist an empty list
+// (or a miss). The wrapper converts it back to [] / undefined for callers.
+class UncacheableEmptyError extends Error {
+  constructor() {
+    super('uncacheable empty');
+    this.name = 'UncacheableEmptyError';
+  }
+}
+
+// Safety net if on-demand revalidate is skipped. Election config is tag-busted
+// on seed; this is only so a forgotten bust still heals within a day.
+const SAFETY_REVALIDATE_SECONDS = 60 * 60 * 24;
+
+function rejectEmpty<T>(items: T[]): T[] {
+  if (items.length === 0) {
+    throw new UncacheableEmptyError();
+  }
+  return items;
+}
+
 // Persistent-data-cache wrapper. In production this is unstable_cache. Against
 // the local emulator it is a no-op passthrough: unstable_cache persists to
 // .next/cache and survives dev-server restarts, so a successful-but-empty fetch
-// (e.g. a read before the emulator is seeded) would otherwise stay pinned for
-// `revalidate` seconds and mask freshly-seeded data. Local reads must be live.
+// (e.g. a read before the emulator is seeded) would otherwise stay pinned and
+// mask freshly-seeded data. Local reads must be live.
 function cache<A extends unknown[], R>(
   fn: (...args: A) => Promise<R>,
   keyParts?: string[],
@@ -67,6 +93,33 @@ function cache<A extends unknown[], R>(
     return fn;
   }
   return unstable_cache(fn, keyParts, options);
+}
+
+function cachedRead<A extends unknown[], R>(
+  fn: (...args: A) => Promise<R>,
+  keyParts: string[],
+  tags: string[],
+): (...args: A) => Promise<R> {
+  return cache(fn, keyParts, {
+    revalidate: SAFETY_REVALIDATE_SECONDS,
+    tags,
+  });
+}
+
+async function uncachedFallback<T>(
+  read: () => Promise<T>,
+  fallback: T,
+  logLabel: string,
+): Promise<T> {
+  try {
+    return await read();
+  } catch (error) {
+    if (error instanceof UncacheableEmptyError) {
+      return fallback;
+    }
+    console.error(`[Firestore] ${logLabel}:`, error);
+    return fallback;
+  }
 }
 
 async function getServerApp({
@@ -156,158 +209,147 @@ export const getParty = cache(getPartyImpl, undefined, {
 
 // Context-related functions
 async function getContextsImpl() {
-  try {
-    console.log('[Firestore] Fetching contexts (where is_active == true)');
-    const serverDb = await getServerFirestore({ useHeaders: false });
-    const queryRef = query(
-      collection(serverDb, 'contexts'),
-      where('is_active', '==', true),
-    );
-    const snapshot = await getDocs(queryRef);
-    console.log(
-      '[Firestore] Successfully fetched contexts:',
-      snapshot.docs.length,
-    );
+  console.log('[Firestore] Fetching contexts (where is_active == true)');
+  const serverDb = await getServerFirestore({ useHeaders: false });
+  const queryRef = query(
+    collection(serverDb, 'contexts'),
+    where('is_active', '==', true),
+  );
+  const snapshot = await getDocs(queryRef);
+  console.log(
+    '[Firestore] Successfully fetched contexts:',
+    snapshot.docs.length,
+  );
 
-    return snapshot.docs.map((doc) => {
+  return rejectEmpty(
+    snapshot.docs.map((doc) => {
       const data = doc.data();
       return {
         ...data,
         context_id: doc.id,
         date: firestoreTimestampToDate(data.date),
       } as unknown as Context;
-    });
-  } catch (error) {
-    console.error('[Firestore] FAILED to fetch contexts:', error);
-    return [];
-  }
+    }),
+  );
 }
 
-export const getContexts = cache(getContextsImpl, ['getContexts', 'v2'], {
-  revalidate: 3600,
-  tags: [CacheTags.CONTEXTS],
-});
+export async function getContexts() {
+  return uncachedFallback(
+    () =>
+      cachedRead(
+        getContextsImpl,
+        ['getContexts', 'v3'],
+        [CacheTags.CONTEXTS],
+      )(),
+    [],
+    'FAILED to fetch contexts',
+  );
+}
 
 async function getContextImpl(contextId: string) {
-  try {
-    console.log(`[Firestore] Fetching context: /contexts/${contextId}`);
-    const serverDb = await getServerFirestore({ useHeaders: false });
-    const docRef = doc(serverDb, 'contexts', contextId);
-    const snapshot = await getDoc(docRef);
+  console.log(`[Firestore] Fetching context: /contexts/${contextId}`);
+  const serverDb = await getServerFirestore({ useHeaders: false });
+  const docRef = doc(serverDb, 'contexts', contextId);
+  const snapshot = await getDoc(docRef);
 
-    if (!snapshot.exists()) {
-      console.log(`[Firestore] Context not found: /contexts/${contextId}`);
-      return undefined;
-    }
-
-    console.log(
-      `[Firestore] Successfully fetched context: /contexts/${contextId}`,
-    );
-    const data = snapshot.data();
-    return {
-      ...data,
-      context_id: snapshot.id,
-      date: firestoreTimestampToDate(data?.date),
-    } as unknown as Context;
-  } catch (error) {
-    console.error(
-      `[Firestore] FAILED to fetch context "/contexts/${contextId}":`,
-      error,
-    );
-    throw error;
+  if (!snapshot.exists()) {
+    console.log(`[Firestore] Context not found: /contexts/${contextId}`);
+    throw new ContextNotFoundError(contextId);
   }
+
+  console.log(
+    `[Firestore] Successfully fetched context: /contexts/${contextId}`,
+  );
+  const data = snapshot.data();
+  return {
+    ...data,
+    context_id: snapshot.id,
+    date: firestoreTimestampToDate(data?.date),
+  } as unknown as Context;
 }
-
-const getContextCached = cache(
-  async (contextId: string) => {
-    const context = await getContextImpl(contextId);
-
-    if (!context) {
-      throw new ContextNotFoundError(contextId);
-    }
-
-    return context;
-  },
-  ['getContext', 'v3'],
-  {
-    revalidate: 3600,
-    tags: [CacheTags.CONTEXTS],
-  },
-);
 
 export async function getContext(contextId: string) {
   try {
-    return await getContextCached(contextId);
+    return await cachedRead(
+      getContextImpl,
+      ['getContext', 'v4', contextId],
+      [CacheTags.CONTEXTS, contextTag(contextId)],
+    )(contextId);
   } catch (error) {
     if (error instanceof ContextNotFoundError) {
       return undefined;
     }
-
-    return getContextImpl(contextId);
-  }
-}
-
-async function getPartiesForContextImpl(contextId: string) {
-  try {
-    console.log(`[Firestore] Fetching parties: /contexts/${contextId}/parties`);
-    const serverDb = await getServerFirestore({ useHeaders: false });
-    const queryRef = query(
-      collection(serverDb, 'contexts', contextId, 'parties'),
-    );
-    const snapshot = await getDocs(queryRef);
-    console.log(
-      `[Firestore] Successfully fetched parties for context: ${snapshot.docs.length} parties`,
-    );
-
-    return snapshot.docs.map((doc) => {
-      const data = doc.data();
-      return {
-        ...data,
-        party_id: doc.id,
-      } as PartyDetails;
-    });
-  } catch (error) {
     console.error(
-      `[Firestore] FAILED to fetch parties "/contexts/${contextId}/parties":`,
-      error,
-    );
-    return [];
-  }
-}
-
-export const getPartiesForContext = cache(getPartiesForContextImpl, undefined, {
-  revalidate: 3600,
-  tags: [CacheTags.CONTEXT_PARTIES],
-});
-
-async function getPartyForContextImpl(contextId: string, partyId: string) {
-  try {
-    const serverDb = await getServerFirestore({ useHeaders: false });
-    const docRef = doc(serverDb, 'contexts', contextId, 'parties', partyId);
-    const snapshot = await getDoc(docRef);
-
-    if (!snapshot.exists()) {
-      return undefined;
-    }
-
-    const data = snapshot.data();
-    return {
-      ...data,
-      party_id: snapshot.id,
-    } as PartyDetails;
-  } catch (error) {
-    console.error(
-      `Failed to fetch party "${partyId}" for context "${contextId}":`,
+      `[Firestore] FAILED to fetch context "/contexts/${contextId}":`,
       error,
     );
     return undefined;
   }
 }
 
-export const getPartyForContext = cache(getPartyForContextImpl, undefined, {
-  revalidate: 3600,
-  tags: [CacheTags.CONTEXT_PARTIES],
-});
+async function getPartiesForContextImpl(contextId: string) {
+  console.log(`[Firestore] Fetching parties: /contexts/${contextId}/parties`);
+  const serverDb = await getServerFirestore({ useHeaders: false });
+  const queryRef = query(
+    collection(serverDb, 'contexts', contextId, 'parties'),
+  );
+  const snapshot = await getDocs(queryRef);
+  console.log(
+    `[Firestore] Successfully fetched parties for context: ${snapshot.docs.length} parties`,
+  );
+
+  return rejectEmpty(
+    snapshot.docs.map((doc) => {
+      const data = doc.data();
+      return {
+        ...data,
+        party_id: doc.id,
+      } as PartyDetails;
+    }),
+  );
+}
+
+export async function getPartiesForContext(contextId: string) {
+  return uncachedFallback(
+    () =>
+      cachedRead(
+        getPartiesForContextImpl,
+        ['getPartiesForContext', 'v2', contextId],
+        [CacheTags.CONTEXT_PARTIES, contextPartiesTag(contextId)],
+      )(contextId),
+    [],
+    `FAILED to fetch parties "/contexts/${contextId}/parties"`,
+  );
+}
+
+async function getPartyForContextImpl(contextId: string, partyId: string) {
+  const serverDb = await getServerFirestore({ useHeaders: false });
+  const docRef = doc(serverDb, 'contexts', contextId, 'parties', partyId);
+  const snapshot = await getDoc(docRef);
+
+  if (!snapshot.exists()) {
+    throw new UncacheableEmptyError();
+  }
+
+  const data = snapshot.data();
+  return {
+    ...data,
+    party_id: snapshot.id,
+  } as PartyDetails;
+}
+
+export async function getPartyForContext(contextId: string, partyId: string) {
+  return uncachedFallback(
+    () =>
+      cachedRead(
+        getPartyForContextImpl,
+        ['getPartyForContext', 'v2', contextId, partyId],
+        [CacheTags.CONTEXT_PARTIES, contextPartiesTag(contextId)],
+      )(contextId, partyId),
+    undefined,
+    `Failed to fetch party "${partyId}" for context "${contextId}"`,
+  );
+}
 
 export async function getPartiesForContextById(
   contextId: string,
@@ -446,50 +488,54 @@ async function getProposedQuestionsForContextImpl(
     : WAHL_CHAT_PARTY_ID;
 
   const path = `contexts/${contextId}/proposed_questions/${normalizedId}/questions`;
-  try {
-    console.log(`[Firestore] Fetching proposed questions: ${path}`);
-    const queryRef = query(
-      collection(
-        serverDb,
-        'contexts',
-        contextId,
-        'proposed_questions',
-        normalizedId,
-        'questions',
-      ),
-      where('location', '==', 'chat'),
-    );
-    const snapshot = await getDocs(queryRef);
-    console.log(
-      `[Firestore] Successfully fetched proposed questions: ${snapshot.docs.length} questions`,
-    );
+  console.log(`[Firestore] Fetching proposed questions: ${path}`);
+  const queryRef = query(
+    collection(
+      serverDb,
+      'contexts',
+      contextId,
+      'proposed_questions',
+      normalizedId,
+      'questions',
+    ),
+    where('location', '==', 'chat'),
+  );
+  const snapshot = await getDocs(queryRef);
+  console.log(
+    `[Firestore] Successfully fetched proposed questions: ${snapshot.docs.length} questions`,
+  );
 
-    const questions = snapshot.docs.map((doc) => {
-      return {
-        id: doc.id,
-        partyId: normalizedId,
-        ...doc.data(),
-      } as ProposedQuestion;
-    });
+  const questions = snapshot.docs.map((doc) => {
+    return {
+      id: doc.id,
+      partyId: normalizedId,
+      ...doc.data(),
+    } as ProposedQuestion;
+  });
 
-    return questions.sort(() => Math.random() - 0.5);
-  } catch (error) {
-    console.error(
-      `[Firestore] FAILED to fetch proposed questions "${path}":`,
-      error,
-    );
-    return [];
-  }
+  return questions.sort(() => Math.random() - 0.5);
 }
 
-export const getProposedQuestionsForContext = cache(
-  getProposedQuestionsForContextImpl,
-  undefined,
-  {
-    revalidate: 60 * 60 * 24,
-    tags: [CacheTags.PROPOSED_QUESTIONS],
-  },
-);
+export async function getProposedQuestionsForContext(
+  contextId: string,
+  partyIds?: string[],
+) {
+  return uncachedFallback(
+    () =>
+      cachedRead(
+        getProposedQuestionsForContextImpl,
+        [
+          'getProposedQuestionsForContext',
+          'v2',
+          contextId,
+          JSON.stringify(partyIds ?? null),
+        ],
+        [CacheTags.PROPOSED_QUESTIONS, contextQuestionsTag(contextId)],
+      )(contextId, partyIds),
+    [],
+    `FAILED to fetch proposed questions for context "${contextId}"`,
+  );
+}
 
 async function getHomeInputProposedQuestionsImpl() {
   // Home questions are global, not context-specific
@@ -609,14 +655,22 @@ async function getSourceDocumentsForContextImpl(contextId: string) {
   return sources.flat();
 }
 
-export const getSourceDocumentsForContext = cache(
-  getSourceDocumentsForContextImpl,
-  undefined,
-  {
-    revalidate: 60 * 60 * 24,
-    tags: [CacheTags.SOURCE_DOCUMENTS],
-  },
-);
+async function getSourceDocumentsForContextCached(contextId: string) {
+  return rejectEmpty(await getSourceDocumentsForContextImpl(contextId));
+}
+
+export async function getSourceDocumentsForContext(contextId: string) {
+  return uncachedFallback(
+    () =>
+      cachedRead(
+        getSourceDocumentsForContextCached,
+        ['getSourceDocumentsForContext', 'v2', contextId],
+        [CacheTags.SOURCE_DOCUMENTS, contextSourcesTag(contextId)],
+      )(contextId),
+    [],
+    `FAILED to fetch source documents for context "${contextId}"`,
+  );
+}
 
 async function getExampleQuestionsShareableChatSessionImpl() {
   const serverDb = await getServerFirestore({ useHeaders: false });


### PR DESCRIPTION
## Summary
- After a real-project Firestore seed, automatically call `/api/revalidate` so a newly added context does not stay empty on wahl.chat for an hour (ISR still holding the pre-seed party list).
- The revalidate route now accepts `tags` / `paths` arrays in one request, and uses layout scope so a context root also busts nested pages.
- A cloud seed without `REVALIDATE_SECRET` still writes Firestore, then exits with a pointer to the Vercel env-var page instead of leaving the site stale.

## Test plan
- [ ] `REVALIDATE_SECRET=... ENV=prod python firebase/scripts/seed_firestore.py` prints a successful revalidation against https://wahl.chat/api/revalidate
- [ ] The same command without `REVALIDATE_SECRET` writes Firestore, then exits and prints https://vercel.com/wahl-chat/web/settings/environment-variables
- [ ] An emulator seed (`FIRESTORE_EMULATOR_HOST` set) skips revalidation
- [ ] `cd ai-backend && uv run python -m pytest tests/test_seed_revalidate.py`


Made with [Cursor](https://cursor.com)