### PR TITLE
Move chat to Gemini 3.6 Flash and Gemini 3.1 Flash-Lite

### DIFF
--- a/ai-backend/.env.example
+++ b/ai-backend/.env.example
@@ -10,7 +10,8 @@ QDRANT_URL=http://localhost:6333
 FIRESTORE_EMULATOR_HOST=localhost:8081
 
 # --- LLM / AI API keys (required for chat functionality) ---
-# OPENAI_API_KEY: fallback chat LLMs (GPT-4o-mini) when Gemini rate-limits.
+# OPENAI_API_KEY: fallback chat LLMs (GPT-5.6-Terra / GPT-5.6-Luna) when Gemini
+# is unavailable.
 OPENAI_API_KEY=your_openai_api_key
 GOOGLE_API_KEY=your_google_api_key
 
@@ -35,8 +36,8 @@ GOOGLE_API_KEY=your_google_api_key
 #
 # Vertex location. Defaults to "global", matching the AI Studio status quo (which
 # has no regional pinning either). It is also the only location where
-# gemini-embedding-2 and the 2.5-lite / 3-preview chat models resolve — regional
-# endpoints serve gemini-2.5-flash alone and 404 on the rest.
+# gemini-embedding-2 and the current Flash / Flash-Lite chat models resolve —
+# regional endpoints 404 on most of them.
 # VERTEX_LOCATION=global
 #
 # Kill-switch: set to 0 to keep embeddings on AI Studio while chat uses Vertex.
@@ -78,11 +79,6 @@ LANGCHAIN_TRACING_V2=true
 LANGCHAIN_ENDPOINT=https://api.smith.langchain.com
 LANGCHAIN_API_KEY=your_langchain_api_key
 LANGCHAIN_PROJECT=wahl-chat-dev
-
-# --- Azure OpenAI (optional alternative to OpenAI) ---
-OPENAI_API_VERSION=2024-08-01-preview
-AZURE_OPENAI_ENDPOINT=your_azure_openai_endpoint
-AZURE_OPENAI_API_KEY=your_azure_openai_api_key
 
 # --- Qdrant Cloud (prod only — leave unset in local mode) ---
 # QDRANT_API_KEY=your_qdrant_api_key

--- a/ai-backend/README.md
+++ b/ai-backend/README.md
@@ -134,13 +134,10 @@ revision is noticed in minutes; mis-billing is noticed at the end of the month.
 #### Location
 
 > **`VERTEX_LOCATION=global` is load-bearing.** On the billing project, regional
-> endpoints (`europe-west3`/`-west4`, `us-central1`) serve `gemini-2.5-flash`
-> alone and 404 on `gemini-embedding-2`, `gemini-2.5-flash-lite` and
-> `gemini-3-flash-preview`. Because a 404 falls through to AI Studio silently,
-> switching to a regional value would quietly stop most traffic from being billed
-> to Vertex rather than producing a visible error. `gemini-2.0-flash` is
-> unavailable in every location tested and is deliberately not registered on the
-> Vertex tier at all.
+> endpoints (`europe-west3`/`-west4`, `us-central1`) 404 on `gemini-embedding-2`
+> and on most Flash / Flash-Lite chat models. Because a 404 falls through to AI
+> Studio silently, switching to a regional value would quietly stop most traffic
+> from being billed to Vertex rather than producing a visible error.
 
 ## Run
 

--- a/ai-backend/src/answer_cache.py
+++ b/ai-backend/src/answer_cache.py
@@ -20,12 +20,12 @@ from langchain_core.language_models.chat_models import BaseChatModel
 from src.chatbot_async import get_rag_context
 from src.llms import select_streaming_llms
 from src.models.context import ContextParty
-from src.models.general import LLM, LLMSize
+from src.models.general import LLM
 
 
 def _llm_model_id(model: BaseChatModel) -> str:
-    """Stable model identifier across Gemini / OpenAI / Azure client classes."""
-    for attr in ("model", "model_name", "deployment_name", "azure_deployment"):
+    """Stable model identifier across Gemini / OpenAI client classes."""
+    for attr in ("model", "model_name"):
         value = getattr(model, attr, None)
         if value:
             return str(value)
@@ -41,22 +41,14 @@ def _llm_line(llm: LLM) -> str:
             str(getattr(model, "temperature", "")),
             str(getattr(model, "thinking_level", "")),
             str(getattr(model, "thinking_budget", "")),
+            str(getattr(model, "reasoning_effort", "")),
         ]
     )
 
 
-def llm_generation_fingerprint(
-    llms: list[LLM],
-    preferred_llm_size: LLMSize,
-    use_premium_llms: bool,
-) -> str:
+def llm_generation_fingerprint(llms: list[LLM]) -> str:
     """Models ``stream_answer_from_llms`` will try, in order."""
-    candidates = select_streaming_llms(
-        llms,
-        preferred_llm_size=preferred_llm_size,
-        use_premium_llms=use_premium_llms,
-    )
-    return "\n".join(_llm_line(llm) for llm in candidates)
+    return "\n".join(_llm_line(llm) for llm in select_streaming_llms(llms))
 
 
 def llm_invoke_fingerprint(llms: list[LLM]) -> str:
@@ -124,8 +116,6 @@ def build_answer_cache_key(
     context_id: str,
     answer_guidelines: str,
     rag_context: str,
-    llm_size: LLMSize,
-    use_premium_llms: bool,
     llms: list[LLM],
     context_name: str = "",
     context_date_info: str = "",
@@ -157,11 +147,9 @@ def build_answer_cache_key(
             ("parties", all_parties_list),
             ("guidelines", answer_guidelines),
             ("rag", rag_context),
-            ("llm_size", llm_size.value),
-            ("premium", str(use_premium_llms)),
             (
                 "llm",
-                llm_generation_fingerprint(llms, llm_size, use_premium_llms),
+                llm_generation_fingerprint(llms),
             ),
         ]
     )

--- a/ai-backend/src/auth.py
+++ b/ai-backend/src/auth.py
@@ -4,11 +4,9 @@
 Optional Firebase ID-token verification for backend routes.
 
 The backend routes are reachable without authentication by design (anonymous
-chat is a product requirement), but privileged request flags — currently
-``user_is_logged_in``, which selects premium LLMs — must never be trusted from
-the request body alone. Routes read an optional ``Authorization: Bearer
-<Firebase ID token>`` header and verify it server-side; the body flag is
-honored ONLY when a valid token is present.
+chat is a product requirement). Privileged request flags must never be trusted
+from the request body alone: callers read an optional ``Authorization: Bearer
+<Firebase ID token>`` header and verify it server-side.
 
 Verification never rejects a request: an absent/invalid token simply resolves
 to anonymous (no 401s). The web proxy routes forward the client's
@@ -36,8 +34,8 @@ def verify_optional_bearer_token(request: Request) -> Optional[dict]:
 
     Returns the decoded token claims when a valid token is present, else None.
     NEVER raises and NEVER rejects the request — anonymous access stays
-    allowed. Callers must only honor privileged flags (e.g. premium LLM
-    selection) when this returns non-None.
+    allowed. Callers must only honor privileged flags when this returns
+    non-None.
     """
     header = request.headers.get("Authorization", "")
     if not header.startswith("Bearer "):
@@ -59,9 +57,9 @@ def _has_real_signin(claims: dict) -> bool:
     visitor in anonymously, and an anonymous session yields a fully valid
     Firebase ID token. The provider lives at
     ``claims["firebase"]["sign_in_provider"]`` ("anonymous" for anon sessions;
-    "password"/"google.com"/… for real sign-ins). Premium requires an explicit
-    non-anonymous provider; anything else (anonymous, or an unexpected token
-    shape) is denied.
+    "password"/"google.com"/… for real sign-ins). A real sign-in requires an
+    explicit non-anonymous provider; anything else (anonymous, or an unexpected
+    token shape) is denied.
     """
     firebase_claims = claims.get("firebase")
     if not isinstance(firebase_claims, dict):
@@ -71,24 +69,23 @@ def _has_real_signin(claims: dict) -> bool:
 
 
 def resolve_user_is_logged_in(request: Optional[Request], route: str) -> bool:
-    """Server-side truth for premium LLM gating.
+    """Server-side truth for whether the caller has a real (non-anonymous) sign-in.
 
     Derived SOLELY from the request's Firebase token — never from a
     client-supplied flag. Returns True only when the request carries a valid,
     NON-anonymous Firebase ID token (every visitor is signed in anonymously, so
-    an anonymous token — though valid — must not unlock premium). A missing
+    an anonymous token — though valid — must not count as a real user). A missing
     request (non-HTTP callers) is treated as anonymous.
     """
     if request is None:
         return False
     claims = verify_optional_bearer_token(request)
     if claims is None:
-        logger.debug("%s: no valid Firebase ID token — premium not granted.", route)
+        logger.debug("%s: no valid Firebase ID token — not signed in.", route)
         return False
     if not _has_real_signin(claims):
         logger.debug(
-            "%s: token is anonymous / lacks a real sign-in provider — premium "
-            "not granted.",
+            "%s: token is anonymous / lacks a real sign-in provider.",
             route,
         )
         return False

--- a/ai-backend/src/chat_service.py
+++ b/ai-backend/src/chat_service.py
@@ -64,7 +64,6 @@ from src.answer_cache import (
     build_rag_query_cache_key,
     canonicalize_rag_context,
 )
-from src.auth import resolve_user_is_logged_in
 from src.sse import (
     DONE as _DONE,
     data_event as _data_event,
@@ -504,7 +503,6 @@ async def _lookup_cached_party_answer(
     group_chat_session: GroupChatSession,
     combined_docs: List[Document],
     *,
-    use_premium_llms: bool,
     election_level: Optional[str],
     present_sources: tuple[bool, bool, bool],
     has_historic: bool,
@@ -550,8 +548,6 @@ async def _lookup_cached_party_answer(
         context_id=group_chat_session.context_id,
         answer_guidelines=answer_guidelines,
         rag_context=canonicalize_rag_context(combined_docs),
-        llm_size=group_chat_session.chat_response_llm_size,
-        use_premium_llms=use_premium_llms,
         llms=chat_response_llms,
         context_name=context_name,
         context_date_info=context_date_info,
@@ -926,7 +922,6 @@ async def fetch_party_response_stream(
     question_for_party: str,
     group_chat_session: GroupChatSession,
     all_available_parties: List[ContextParty],
-    use_premium_llms: bool,
     is_cacheable_chat: bool = True,
     relevant_docs: Optional[Union[List[Document], Dict[str, List[Document]]]] = None,
     parties_being_compared: Optional[List[ContextParty]] = None,
@@ -1179,7 +1174,6 @@ async def fetch_party_response_stream(
                     conversation_history_str,
                     group_chat_session,
                     combined_docs,
-                    use_premium_llms=use_premium_llms,
                     election_level=election_level,
                     present_sources=present_sources,
                     has_historic=has_historic,
@@ -1240,9 +1234,7 @@ async def fetch_party_response_stream(
                 question_for_party,
                 combined_docs,
                 all_parties=all_available_parties,
-                chat_response_llm_size=group_chat_session.chat_response_llm_size,
                 context_id=group_chat_session.context_id,
-                use_premium_llms=use_premium_llms,
                 election_level=election_level,
                 present_sources=present_sources,
                 has_historic=has_historic,
@@ -1259,8 +1251,6 @@ async def fetch_party_response_stream(
                 question_for_party,
                 relevant_docs_dict or {},
                 parties_being_compared or [],
-                chat_response_llm_size=group_chat_session.chat_response_llm_size,
-                use_premium_llms=use_premium_llms,
                 election_level=election_level,
                 has_historic=_has_historic_docs(relevant_docs_dict, term_window),
                 source_filter=source_filter,
@@ -1583,10 +1573,6 @@ async def generate_chat_stream(  # type: ignore[no-untyped-def]
     # Record wall-clock start time for per-stream budget enforcement.
     _stream_start = time.monotonic()
 
-    # Premium LLM selection is derived server-side from the request's token —
-    # never from the client (no request → anonymous → no premium).
-    use_premium_llms = resolve_user_is_logged_in(request, "chat")
-
     message_id = str(uuid.uuid4())
 
     for part in _start_message(message_id):
@@ -1603,7 +1589,6 @@ async def generate_chat_stream(  # type: ignore[no-untyped-def]
     from src.models.chat import (
         GroupChatSession as _GroupChatSession,
     )  # local import avoids circular
-    from src.models.general import LLMSize
 
     # body.chat_history is the route-specific ChatHistoryTurn (role/content/party_id
     # only, already validated + bounded by FastAPI). Rehydrate into the internal
@@ -1621,7 +1606,6 @@ async def generate_chat_stream(  # type: ignore[no-untyped-def]
         session_id=body.session_id,
         context_id=body.context_id,
         chat_history=chat_history,
-        chat_response_llm_size=LLMSize.LARGE,
     )
 
     # cacheable only for quick-reply-driven sessions
@@ -1819,7 +1803,6 @@ async def generate_chat_stream(  # type: ignore[no-untyped-def]
                         general_question,
                         group_chat_session,
                         all_available_parties=all_parties,
-                        use_premium_llms=use_premium_llms,
                         is_cacheable_chat=group_chat_session.is_cacheable,
                         region_path=region_path,
                         legislature_period_id=legislature_period_id,
@@ -1888,7 +1871,6 @@ async def generate_chat_stream(  # type: ignore[no-untyped-def]
                     user_message.content,
                     group_chat_session,
                     all_available_parties=all_parties,
-                    use_premium_llms=use_premium_llms,
                     is_cacheable_chat=group_chat_session.is_cacheable,
                     relevant_docs=relevant_doc_dict,
                     parties_being_compared=parties_being_compared,

--- a/ai-backend/src/chatbot_async.py
+++ b/ai-backend/src/chatbot_async.py
@@ -99,6 +99,23 @@ load_env()
 
 logger = logging.getLogger(__name__)
 
+
+def _message_text(response) -> str:
+    """Flatten an LLM reply to a string.
+
+    Gemini 3 returns ``content`` as a list of blocks (``type`` / ``text``, plus a
+    thought signature). Gemini 2.x returned a plain string. ``AIMessage.text``
+    handles both. Fall back to ``content`` for test doubles that only set that.
+    """
+    text = getattr(response, "text", None)
+    if isinstance(text, str):
+        return text
+    content = getattr(response, "content", "")
+    if isinstance(content, str):
+        return content
+    return str(content or "")
+
+
 chat_response_llms: list[LLM] = RESPONSE_GENERATION_LLMS
 
 voting_behavior_summary_llms: list[LLM] = RESPONSE_GENERATION_LLMS
@@ -345,12 +362,7 @@ async def generate_improvement_rag_query(
 
     response = await get_answer_from_llms(prompt_improvement_llms, messages)
 
-    if isinstance(response.content, list):
-        if isinstance(response.content[0], str):
-            return response.content[0]
-        else:
-            return response.content[0]["content"]
-    return response.content
+    return _message_text(response)
 
 
 async def generate_pro_con_perspective(
@@ -566,7 +578,7 @@ async def get_improved_rag_query_voting_behavior(
 
     response = await get_answer_from_llms(prompt_improvement_llms, messages)
 
-    return getattr(response, "content", "")
+    return _message_text(response)
 
 
 async def generate_streaming_chatbot_response(

--- a/ai-backend/src/chatbot_async.py
+++ b/ai-backend/src/chatbot_async.py
@@ -15,7 +15,7 @@ from openai.types.chat.chat_completion_message_param import (
     ChatCompletionUserMessageParam,
 )
 
-from src.models.general import LLM, LLMSize
+from src.models.general import LLM
 from src.llms import (
     PRE_AND_POST_PROCESSING_LLMS,
     RESPONSE_GENERATION_LLMS,
@@ -575,9 +575,7 @@ async def generate_streaming_chatbot_response(
     user_message: str,
     relevant_docs: List[Document],
     all_parties: list[ContextParty],
-    chat_response_llm_size: LLMSize,
     context_id: str = DEFAULT_CONTEXT_ID,
-    use_premium_llms: bool = False,
     election_level: Optional[str] = None,
     present_sources: Optional[tuple[bool, bool, bool]] = None,
     has_historic: bool = False,
@@ -642,8 +640,6 @@ async def generate_streaming_chatbot_response(
     return await stream_answer_from_llms(
         chat_response_llms,
         messages,
-        preferred_llm_size=chat_response_llm_size,
-        use_premium_llms=use_premium_llms,
     )
 
 
@@ -800,8 +796,6 @@ async def generate_streaming_chatbot_comparing_response(
     user_message: str,
     relevant_docs: Dict[str, List[Document]],
     relevant_parties: List[ContextParty],
-    chat_response_llm_size: LLMSize,
-    use_premium_llms: bool = False,
     election_level: Optional[str] = None,
     has_historic: bool = False,
     source_filter: Optional[List[str]] = None,
@@ -852,8 +846,6 @@ async def generate_streaming_chatbot_comparing_response(
     return await stream_answer_from_llms(
         chat_response_llms,
         messages,
-        preferred_llm_size=chat_response_llm_size,
-        use_premium_llms=use_premium_llms,
     )
 
 
@@ -912,8 +904,6 @@ async def generate_party_vote_behavior_summary(
     last_user_message: str,
     last_assistant_message: str,
     votes: List[Vote],
-    summary_llm_size: LLMSize,
-    use_premium_llms: bool = False,
 ) -> AsyncIterator[BaseMessageChunk]:
     votes_list = ""
     # sort votes by date (oldest first)
@@ -967,8 +957,6 @@ async def generate_party_vote_behavior_summary(
     return await stream_answer_from_llms(
         voting_behavior_summary_llms,
         messages,
-        preferred_llm_size=summary_llm_size,
-        use_premium_llms=use_premium_llms,
     )
 
 
@@ -1004,7 +992,6 @@ async def generate_swiper_assistant_response(
     current_political_question: str,
     conversation_history: str,
     user_message: str,
-    chat_response_llm_size: LLMSize,
 ) -> Message:
     now = datetime.now()
     answer_guidelines = get_swiper_answer_guidelines()
@@ -1029,9 +1016,8 @@ async def generate_swiper_assistant_response(
     ]
 
     # perplexity chat completion without streaming
-    model = "sonar" if chat_response_llm_size == LLMSize.SMALL else "sonar-pro"
     response = await perplexity_client.chat.completions.create(
-        model=model,
+        model="sonar-pro",
         messages=messages,
     )
 

--- a/ai-backend/src/google_credentials.py
+++ b/ai-backend/src/google_credentials.py
@@ -53,10 +53,10 @@ _SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
 # "global" matches the status quo: Google AI Studio, which served all Gemini
 # traffic before this change, offers no regional pinning either — so this is not
 # a data-residency regression. It is also the only location on the billing
-# project where gemini-embedding-2 and the 2.5-lite / 3-preview chat models
-# resolve; regional endpoints (europe-west3/4, us-central1) 404 on all of them
-# and serve gemini-2.5-flash alone. Revisit if EU residency becomes a hard
-# requirement — that would mean europe-west3 plus a much narrower model set.
+# project where gemini-embedding-2 and the current Flash / Flash-Lite chat
+# models resolve; regional endpoints (europe-west3/4, us-central1) 404 on most
+# of them. Revisit if EU residency becomes a hard requirement — that would mean
+# europe-west3 plus a much narrower model set.
 _DEFAULT_LOCATION = "global"
 
 _TRUTHY = ("1", "true", "yes")

--- a/ai-backend/src/ingestion/retrieve.py
+++ b/ai-backend/src/ingestion/retrieve.py
@@ -902,16 +902,16 @@ def get_gemini_tool_binding(llm: Any) -> Any:
 
     Usage::
 
-        from src.llms import google_gemini_2_5_flash
+        from src.llms import google_gemini_3_6_flash
         from src.ingestion.retrieve import get_gemini_tool_binding
 
-        llm_with_tools = get_gemini_tool_binding(google_gemini_2_5_flash)
+        llm_with_tools = get_gemini_tool_binding(google_gemini_3_6_flash)
 
     The tool declaration is standalone — this does NOT import or modify
     chat_service or vector_store_helper.
 
     Args:
-        llm: A ChatGoogleGenerativeAI instance (e.g. ``google_gemini_2_5_flash``).
+        llm: A ChatGoogleGenerativeAI instance (e.g. ``google_gemini_3_6_flash``).
 
     Returns:
         The LLM with the ``retrieve`` tool bound via ``bind_tools([RetrieveSchema])``.

--- a/ai-backend/src/llms.py
+++ b/ai-backend/src/llms.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
 import logging
-import os
 from typing import AsyncIterator
 from langchain_google_genai import ChatGoogleGenerativeAI
-from langchain_openai import AzureChatOpenAI, ChatOpenAI
+from langchain_openai import ChatOpenAI
+from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages.base import BaseMessage, BaseMessageChunk
 from pydantic import BaseModel
 from src.firebase_service import awrite_llm_status
@@ -14,7 +14,7 @@ from src.google_credentials import (
     vertex_location,
     vertex_project,
 )
-from src.models.general import LLM, LLMSize
+from src.models.general import LLM
 from src.utils import load_env, safe_load_api_key
 
 load_env()
@@ -25,8 +25,8 @@ logger = logging.getLogger(__name__)
 # billing project is configured, the Gemini models below are also constructed
 # against Vertex and registered at a HIGHER priority than their AI Studio twins,
 # so Gemini spend lands on that project. Absent credentials, VERTEX_AVAILABLE is
-# False and the LLM lists are exactly what they were before — that is the local
-# dev / CI path, and the reason nothing here may raise.
+# False and the LLM lists are exactly the AI Studio / OpenAI roster — that is the
+# local dev / CI path, and the reason nothing here may raise.
 VERTEX_AVAILABLE = vertex_enabled()
 _VERTEX_CREDS = get_vertex_credentials() if VERTEX_AVAILABLE else None
 _VERTEX_PROJECT = vertex_project() if VERTEX_AVAILABLE else None
@@ -91,204 +91,154 @@ def _gemini(model: str, *, vertex: bool = False, **kwargs) -> ChatGoogleGenerati
     )
 
 
-azure_gpt_4o = AzureChatOpenAI(
-    azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
-    deployment_name="gpt-4o-2024-08-06",
-    openai_api_version=os.getenv("OPENAI_API_VERSION"),
-    api_key=safe_load_api_key("AZURE_OPENAI_API_KEY"),
-    max_retries=0,
+def _openai(model: str, **kwargs) -> ChatOpenAI:
+    return ChatOpenAI(
+        model=model,
+        api_key=safe_load_api_key("OPENAI_API_KEY"),
+        max_retries=0,
+        **kwargs,
+    )
+
+
+def _llm(name: str, model: BaseChatModel, priority: int) -> LLM:
+    return LLM(name=name, model=model, priority=priority)
+
+
+# ---------------------------------------------------------------------------
+# Response generation — temperature 1 on every model.
+# Gemini 3.6 Flash is the primary; 3.7 Flash does not support thinking_level
+# "minimal", so it uses "low". Gemini 2.5-era models are not on this roster.
+# ---------------------------------------------------------------------------
+google_gemini_3_6_flash = _gemini(
+    "gemini-3.6-flash", temperature=1.0, thinking_level="minimal"
 )
-
-azure_gpt_4o_mini = AzureChatOpenAI(
-    azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
-    deployment_name="gpt-4o-mini-2024-07-18",
-    openai_api_version=os.getenv("OPENAI_API_VERSION"),
-    api_key=safe_load_api_key("AZURE_OPENAI_API_KEY"),
-    max_retries=0,
+google_gemini_3_7_flash = _gemini(
+    "gemini-3.7-flash", temperature=1.0, thinking_level="low"
 )
-
-google_gemini_2_flash = _gemini("gemini-2.0-flash")
-
 google_gemini_3_flash_preview = _gemini(
-    "gemini-3-flash-preview",
-    temperature=1.0,  # Explicitly set temperature to 1.0 based on Google's recommendation in https://ai.google.dev/gemini-api/docs/gemini-3#temperature,
-    thinking_level="low",  # Set thinking level to low for faster responses
+    "gemini-3-flash-preview", temperature=1.0, thinking_level="minimal"
 )
-
-google_gemini_2_5_flash = _gemini(
-    "gemini-2.5-flash",
-    thinking_budget=0,  # Disable thinking budget for faster responses
+google_gemini_3_5_flash = _gemini(
+    "gemini-3.5-flash", temperature=1.0, thinking_level="minimal"
 )
-
-openai_gpt_4o = ChatOpenAI(
-    model="gpt-4o-2024-08-06",
-    api_key=safe_load_api_key("OPENAI_API_KEY"),
-    max_retries=0,
-)
-
-openai_gpt_4o_mini = ChatOpenAI(
-    model="gpt-4o-mini",
-    api_key=safe_load_api_key("OPENAI_API_KEY"),
-    max_retries=0,
+openai_gpt_5_6_terra = _openai(
+    "gpt-5.6-terra", temperature=1.0, reasoning_effort="minimal"
 )
 
 RESPONSE_GENERATION_LLMS: list[LLM] = [
-    LLM(
-        name="google-gemini-3.0-flash-preview",
-        model=google_gemini_3_flash_preview,
-        sizes=[LLMSize.SMALL, LLMSize.LARGE],
-        priority=100,
-        is_at_rate_limit=False,
-    ),
-    LLM(
-        name="google-gemini-2.5-flash",
-        model=google_gemini_2_5_flash,
-        sizes=[LLMSize.SMALL, LLMSize.LARGE],
-        priority=95,
-        is_at_rate_limit=False,
-    ),
-    LLM(
-        name="google-gemini-2.0-flash",
-        model=google_gemini_2_flash,
-        sizes=[LLMSize.SMALL, LLMSize.LARGE],
-        priority=92,
-        is_at_rate_limit=False,
-    ),
-    LLM(
-        name="azure-gpt-4o",
-        model=azure_gpt_4o,
-        sizes=[LLMSize.LARGE],
-        priority=90,
-        is_at_rate_limit=False,
-        premium_only=True,
-    ),
-    LLM(
-        name="openai-gpt-4o",
-        model=openai_gpt_4o,
-        sizes=[LLMSize.LARGE],
-        priority=60,
-        is_at_rate_limit=False,
-        premium_only=False,
-    ),
-    LLM(
-        name="azure-gpt-4o-mini",
-        model=azure_gpt_4o_mini,
-        sizes=[LLMSize.SMALL],
-        priority=50,
-        is_at_rate_limit=False,
-    ),
-    LLM(
-        name="openai-gpt-4o-mini",
-        model=openai_gpt_4o_mini,
-        sizes=[LLMSize.SMALL],
-        priority=40,
-        is_at_rate_limit=False,
-    ),
+    _llm("google-gemini-3.6-flash", google_gemini_3_6_flash, 100),
+    _llm("openai-gpt-5.6-terra", openai_gpt_5_6_terra, 90),
+    _llm("google-gemini-3.7-flash", google_gemini_3_7_flash, 80),
+    _llm("google-gemini-3-flash-preview", google_gemini_3_flash_preview, 70),
+    _llm("google-gemini-3.5-flash", google_gemini_3_5_flash, 60),
 ]
 
 # Vertex tier — the same Gemini models, billed to the Vertex project. Priorities
-# sit above every AI Studio entry (highest existing: 100), so the priority-sorted
-# failover already in get_answer_from_llms / get_structured_output_from_llms /
-# stream_answer_from_llms tries Vertex first and falls through to the IDENTICAL
-# AI Studio model on any error. No change to those functions is required.
-#
-# gemini-2.0-flash is deliberately absent: it 404s on the billing project in
-# every location tested (global, europe-west3/4, us-central1). Registering it
-# would 404 on every request and silently fall through to AI Studio — the failure
-# mode that looks like "Vertex billing is mysteriously low" rather than an error.
-# Its AI Studio twin below still serves, so nothing is lost.
+# sit above every AI Studio / OpenAI entry (highest existing: 100), so the
+# priority-sorted failover already in get_answer_from_llms /
+# get_structured_output_from_llms / stream_answer_from_llms tries Vertex first
+# and falls through to the IDENTICAL AI Studio model on any error. No change to
+# those functions is required. OpenAI models have no Vertex twin.
 if VERTEX_AVAILABLE:
     RESPONSE_GENERATION_LLMS = [
-        LLM(
-            name="vertex-gemini-3.0-flash-preview",
-            model=_gemini(
-                "gemini-3-flash-preview",
+        _llm(
+            "vertex-gemini-3.6-flash",
+            _gemini(
+                "gemini-3.6-flash",
+                vertex=True,
+                temperature=1.0,
+                thinking_level="minimal",
+            ),
+            200,
+        ),
+        _llm(
+            "vertex-gemini-3.7-flash",
+            _gemini(
+                "gemini-3.7-flash",
                 vertex=True,
                 temperature=1.0,
                 thinking_level="low",
             ),
-            sizes=[LLMSize.SMALL, LLMSize.LARGE],
-            priority=200,
-            is_at_rate_limit=False,
+            190,
         ),
-        LLM(
-            name="vertex-gemini-2.5-flash",
-            model=_gemini("gemini-2.5-flash", vertex=True, thinking_budget=0),
-            sizes=[LLMSize.SMALL, LLMSize.LARGE],
-            priority=195,
-            is_at_rate_limit=False,
+        _llm(
+            "vertex-gemini-3-flash-preview",
+            _gemini(
+                "gemini-3-flash-preview",
+                vertex=True,
+                temperature=1.0,
+                thinking_level="minimal",
+            ),
+            180,
+        ),
+        _llm(
+            "vertex-gemini-3.5-flash",
+            _gemini(
+                "gemini-3.5-flash",
+                vertex=True,
+                temperature=1.0,
+                thinking_level="minimal",
+            ),
+            170,
         ),
     ] + RESPONSE_GENERATION_LLMS
 
-azure_gpt_4o_mini_det = AzureChatOpenAI(
-    azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
-    deployment_name="gpt-4o-mini-2024-07-18",
-    openai_api_version=os.getenv("OPENAI_API_VERSION"),
-    api_key=safe_load_api_key("AZURE_OPENAI_API_KEY"),
-    temperature=0.0,
-    max_retries=0,
+# ---------------------------------------------------------------------------
+# Pre- and post-processing — temperature 1, minimal reasoning on every model.
+# Gemini 2.5 Flash-Lite has no thinking_level; thinking_budget=0 is the 2.5
+# equivalent of minimal/off thinking.
+# ---------------------------------------------------------------------------
+google_gemini_3_1_flash_lite = _gemini(
+    "gemini-3.1-flash-lite", temperature=1.0, thinking_level="minimal"
 )
-
-google_gemini_2_5_flash_lite_det = _gemini("gemini-2.5-flash-lite", temperature=0.0)
-
-google_gemini_2_flash_det = _gemini("gemini-2.0-flash", temperature=0.0)
-
-openai_gpt_4o_mini_det = ChatOpenAI(
-    model="gpt-4o-mini",
-    api_key=safe_load_api_key("OPENAI_API_KEY"),
-    temperature=0.0,
-    max_retries=0,
+google_gemini_2_5_flash_lite = _gemini(
+    "gemini-2.5-flash-lite", temperature=1.0, thinking_budget=0
+)
+google_gemini_3_5_flash_lite = _gemini(
+    "gemini-3.5-flash-lite", temperature=1.0, thinking_level="minimal"
+)
+openai_gpt_5_6_luna = _openai(
+    "gpt-5.6-luna", temperature=1.0, reasoning_effort="minimal"
 )
 
 PRE_AND_POST_PROCESSING_LLMS: list[LLM] = [
-    LLM(
-        name="google-gemini-2.5-flash-lite-det",
-        model=google_gemini_2_5_flash_lite_det,
-        sizes=[LLMSize.SMALL],
-        priority=100,
-        is_at_rate_limit=False,
-    ),
-    LLM(
-        name="google-gemini-2.0-flash-det",
-        model=google_gemini_2_flash_det,
-        sizes=[LLMSize.SMALL, LLMSize.LARGE],
-        priority=95,
-        is_at_rate_limit=False,
-    ),
-    LLM(
-        name="azure-gpt-4o-mini-det",
-        model=azure_gpt_4o_mini_det,
-        sizes=[LLMSize.SMALL],
-        priority=90,
-        is_at_rate_limit=False,
-    ),
-    LLM(
-        name="openai-gpt-4o-mini-det",
-        model=openai_gpt_4o_mini_det,
-        sizes=[LLMSize.SMALL],
-        priority=80,
-        is_at_rate_limit=False,
-    ),
+    _llm("google-gemini-3.1-flash-lite", google_gemini_3_1_flash_lite, 100),
+    _llm("openai-gpt-5.6-luna", openai_gpt_5_6_luna, 90),
+    _llm("google-gemini-2.5-flash-lite", google_gemini_2_5_flash_lite, 80),
+    _llm("google-gemini-3.5-flash-lite", google_gemini_3_5_flash_lite, 70),
 ]
 
-# Vertex tier for pre/post-processing — same rationale as above, and likewise
-# without gemini-2.0-flash. gemini-2.5-flash covers the LARGE size here so the
-# deterministic path is not left Vertex-less when a caller asks for it.
 if VERTEX_AVAILABLE:
     PRE_AND_POST_PROCESSING_LLMS = [
-        LLM(
-            name="vertex-gemini-2.5-flash-lite-det",
-            model=_gemini("gemini-2.5-flash-lite", vertex=True, temperature=0.0),
-            sizes=[LLMSize.SMALL],
-            priority=200,
-            is_at_rate_limit=False,
+        _llm(
+            "vertex-gemini-3.1-flash-lite",
+            _gemini(
+                "gemini-3.1-flash-lite",
+                vertex=True,
+                temperature=1.0,
+                thinking_level="minimal",
+            ),
+            200,
         ),
-        LLM(
-            name="vertex-gemini-2.5-flash-det",
-            model=_gemini("gemini-2.5-flash", vertex=True, temperature=0.0),
-            sizes=[LLMSize.SMALL, LLMSize.LARGE],
-            priority=195,
-            is_at_rate_limit=False,
+        _llm(
+            "vertex-gemini-2.5-flash-lite",
+            _gemini(
+                "gemini-2.5-flash-lite",
+                vertex=True,
+                temperature=1.0,
+                thinking_budget=0,
+            ),
+            190,
+        ),
+        _llm(
+            "vertex-gemini-3.5-flash-lite",
+            _gemini(
+                "gemini-3.5-flash-lite",
+                vertex=True,
+                temperature=1.0,
+                thinking_level="minimal",
+            ),
+            180,
         ),
     ] + PRE_AND_POST_PROCESSING_LLMS
 
@@ -306,12 +256,9 @@ async def get_answer_from_llms(
     for llm in llms:
         try:
             logger.debug(f"Invoking LLM {llm.name}...")
-            response = await llm.model.ainvoke(messages)
-            llm.is_at_rate_limit = False
-            return response
+            return await llm.model.ainvoke(messages)
         except Exception as e:
             logger.warning(f"Error invoking LLM {llm.name}: {e}")
-            llm.is_at_rate_limit = True
             continue
 
     await handle_rate_limit_hit_for_all_llms()
@@ -319,13 +266,10 @@ async def get_answer_from_llms(
     for llm in back_up_llms:
         try:
             logger.debug(f"Invoking LLM {llm.name}...")
-            response = await llm.model.ainvoke(messages)
-            llm.is_at_rate_limit = False
-            return response
+            return await llm.model.ainvoke(messages)
         except Exception as e:
             logger.warning(f"Error invoking LLM {llm.name}: {e}")
-            llm.is_at_rate_limit = True
-    raise Exception("All LLMs are at rate limit.")
+    raise Exception("All LLMs failed.")
 
 
 async def get_structured_output_from_llms(
@@ -338,13 +282,9 @@ async def get_structured_output_from_llms(
         try:
             logger.debug(f"Invoking LLM {llm.name}...")
             prepared_model = llm.model.with_structured_output(schema)
-            response = await prepared_model.ainvoke(messages)
-            llm.is_at_rate_limit = False
-            return response
+            return await prepared_model.ainvoke(messages)
         except Exception as e:
             logger.warning(f"Error invoking LLM {llm.name}: {e}")
-            llm.is_at_rate_limit = True
-            # TODO: consider writing to Firestore that this LLM now is at rate limit
             continue
 
     await handle_rate_limit_hit_for_all_llms()
@@ -353,71 +293,32 @@ async def get_structured_output_from_llms(
         try:
             logger.debug(f"Invoking LLM {llm.name}...")
             prepared_model = llm.model.with_structured_output(schema)
-            response = await prepared_model.ainvoke(messages)
-            llm.is_at_rate_limit = False
-            return response
+            return await prepared_model.ainvoke(messages)
         except Exception as e:
             logger.warning(f"Error invoking LLM {llm.name}: {e}")
-            llm.is_at_rate_limit = True
-    raise Exception("All LLMs are at rate limit.")
+    raise Exception("All LLMs failed.")
 
 
-def select_streaming_llms(
-    llms: list[LLM],
-    preferred_llm_size: LLMSize = LLMSize.LARGE,
-    use_premium_llms: bool = False,
-) -> list[LLM]:
+def select_streaming_llms(llms: list[LLM]) -> list[LLM]:
     """Models ``stream_answer_from_llms`` will try, in failover order.
 
     The answer cache uses this list. A model or temperature change must
     change the key.
     """
-    if not use_premium_llms:
-        llms = [llm for llm in llms if not llm.premium_only]
-    if preferred_llm_size == LLMSize.LARGE:
-        large_llms = [llm for llm in llms if LLMSize.LARGE in llm.sizes]
-        small_llms = [
-            llm
-            for llm in llms
-            if LLMSize.SMALL in llm.sizes and LLMSize.LARGE not in llm.sizes
-        ]
-        large_llms = sorted(large_llms, key=lambda x: x.priority, reverse=True)
-        small_llms = sorted(small_llms, key=lambda x: x.priority, reverse=True)
-        return large_llms + small_llms
-    if preferred_llm_size == LLMSize.SMALL:
-        small_llms = [llm for llm in llms if LLMSize.SMALL in llm.sizes]
-        large_llms = [
-            llm
-            for llm in llms
-            if LLMSize.LARGE in llm.sizes and LLMSize.SMALL not in llm.sizes
-        ]
-        large_llms = sorted(large_llms, key=lambda x: x.priority, reverse=True)
-        small_llms = sorted(small_llms, key=lambda x: x.priority, reverse=True)
-        return small_llms + large_llms
-    raise ValueError(f"Invalid preferred LLM size: {preferred_llm_size}")
+    return sorted(llms, key=lambda x: x.priority, reverse=True)
 
 
 async def stream_answer_from_llms(
     llms: list[LLM],
     messages: list[BaseMessage],
-    preferred_llm_size: LLMSize = LLMSize.LARGE,
-    use_premium_llms: bool = False,
 ) -> AsyncIterator[BaseMessageChunk]:
-    logger.debug(f"Preferred LLM size: {preferred_llm_size}")
-    llms = select_streaming_llms(
-        llms,
-        preferred_llm_size=preferred_llm_size,
-        use_premium_llms=use_premium_llms,
-    )
+    llms = select_streaming_llms(llms)
     for llm in llms:
         try:
             logger.debug(f"Invoking LLM {llm.name}...")
-            response = llm.model.astream(messages)
-            llm.is_at_rate_limit = False
-            return response
+            return llm.model.astream(messages)
         except Exception as e:
             logger.warning(f"Error invoking LLM {llm.name}: {e}")
-            llm.is_at_rate_limit = True
             continue
 
     return await handle_rate_limit_hit_for_all_llms()

--- a/ai-backend/src/models/chat.py
+++ b/ai-backend/src/models/chat.py
@@ -7,8 +7,6 @@ from typing import List, Optional
 from pydantic import BaseModel, Field
 from datetime import datetime
 
-from src.models.general import LLMSize
-
 
 class Role(str, Enum):
     USER = "user"
@@ -68,9 +66,6 @@ class GroupChatSession(BaseModel):
     )
     chat_history: List[Message] = Field(..., description="The chat history")
     title: Optional[str] = Field(None, description="The chat title")
-    chat_response_llm_size: LLMSize = Field(
-        ..., description="The LLM size for the chat response"
-    )
     last_quick_replies: List[str] = Field(
         description="The last quick replies for the user", default=[]
     )

--- a/ai-backend/src/models/dtos.py
+++ b/ai-backend/src/models/dtos.py
@@ -6,7 +6,6 @@ import enum
 from pydantic import BaseModel, Field, field_validator, ValidationError
 from typing import List, Optional
 
-from src.models.general import LLMSize
 from src.models.vote import Vote
 from .chat import Message
 from .context import ContextParty
@@ -65,10 +64,6 @@ class InitChatSessionDto(BaseModel):
     session_id: str = Field(..., description="The ID of the chat session")
     chat_history: List[Message] = Field(..., description="The chat history")
     current_title: str = Field(..., description="The current chat title")
-    chat_response_llm_size: LLMSize = Field(
-        description="The size of the LLM model to use for chat response generation",
-        default=LLMSize.LARGE,
-    )
     last_quick_replies: List[str] = Field(
         description="The last quick replies that were shown to the user", default=[]
     )
@@ -147,10 +142,6 @@ class VotingBehaviorRequestDto(BaseModel):
         ...,
         max_length=MAX_ASSISTANT_MESSAGE_CHARS,
         description="The last assistant message",
-    )
-    summary_llm_size: LLMSize = Field(
-        description="The LLM size to use for voting behavior summary generation",
-        default=LLMSize.LARGE,
     )
 
 
@@ -375,10 +366,6 @@ class WahlChatSwiperAnswerRequestDto(BaseModel):
         ...,
         max_length=1_000,
         description="The current wahl.chat Swiper question which the user is answering",
-    )
-    chat_response_llm_size: LLMSize = Field(
-        description="The size of the LLM model to use for chat response generation",
-        default=LLMSize.LARGE,
     )
 
 

--- a/ai-backend/src/models/general.py
+++ b/ai-backend/src/models/general.py
@@ -2,36 +2,18 @@
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
-from enum import Enum
-
 from pydantic import BaseModel, Field
 from langchain_core.language_models.chat_models import BaseChatModel
-
-
-class LLMSize(str, Enum):
-    SMALL = "small"
-    LARGE = "large"
 
 
 class LLM(BaseModel):
     name: str = Field(..., description="The name of the language model.")
     model: BaseChatModel = Field(..., description="The language model.")
-    sizes: list[LLMSize] = Field(
-        ..., description="The sizes as which the LLM is considered."
-    )
     priority: int = Field(
         ...,
         description="The priority for using this LLM above other options. The higher the number, the higher the priority.",
     )
-    is_at_rate_limit: bool = Field(
-        ...,
-        description="Boolean True, if the model is at rate limit, otherwise False.",
-    )
-    premium_only: bool = Field(
-        description="Boolean True, if the model is only available for premium users, otherwise False.",
-        default=False,
-    )
     back_up_only: bool = Field(
-        description="Boolean True, if the model is only used as a backup if all other models are at a rate limit, otherwise False.",
+        description="Boolean True, if the model is only used as a backup if all other models fail, otherwise False.",
         default=False,
     )

--- a/ai-backend/src/routes/chat.py
+++ b/ai-backend/src/routes/chat.py
@@ -105,11 +105,6 @@ async def chat_endpoint(request: Request, body: ChatRequestDto):
     All V1 named chat events are preserved inside `data-chat_event` parts.
     Request body validated via Pydantic (FastAPI returns 422 on invalid input).
     The FastAPI Request is passed to generate_chat_stream for disconnect detection.
-
-    Auth: verification is OPTIONAL (anonymous users are served normally).
-    Premium LLM selection is derived server-side inside generate_chat_stream from
-    the request's token (a valid, non-anonymous `Authorization: Bearer <Firebase
-    ID token>`) — never from the client, so the request carries no such flag.
     """
     # EventSourceResponse frames each yielded payload as one SSE event and
     # emits `: ping` comments during quiet periods (comments are ignored by

--- a/ai-backend/src/routes/misc.py
+++ b/ai-backend/src/routes/misc.py
@@ -98,7 +98,6 @@ async def answer_wahl_chat_swiper_question(body: WahlChatSwiperAnswerRequestDto)
         current_political_question=body.current_political_question,
         conversation_history=chat_history_str,
         user_message=body.user_message,
-        chat_response_llm_size=body.chat_response_llm_size,
     )
 
     chat_history = body.chat_history

--- a/ai-backend/src/routes/pro_con.py
+++ b/ai-backend/src/routes/pro_con.py
@@ -10,10 +10,9 @@ inner type "error", then [DONE]. Framing helpers live in src.sse.
 
 import logging
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter
 from sse_starlette.sse import EventSourceResponse
 
-from src.auth import verify_optional_bearer_token
 from src.chatbot_async import generate_pro_con_perspective
 from src.sse import DONE, data_event, finish
 from src.utils import GENERIC_ERROR_MESSAGE
@@ -37,18 +36,11 @@ _SSE_PING_SECONDS = 15
 
 
 @router.post("/pro-con")
-async def pro_con_endpoint(request: Request, body: ProConPerspectiveRequestDto):
+async def pro_con_endpoint(body: ProConPerspectiveRequestDto):
     """POST /api/v1/pro-con — streams the pro/con result as a v5 data part then [DONE].
 
     Pydantic validates the request body.
-
-    Auth: verification is OPTIONAL (no 401s). This route currently carries no
-    privileged body flag, but the optional Bearer token is verified for parity
-    with /chat and /voting-behavior so future premium gating inherits it.
     """
-    # Verified claims (or None for anonymous) — no privileged flag consumes
-    # them yet; kept so the auth contract is uniform across the SSE routes.
-    _ = verify_optional_bearer_token(request)
 
     async def stream():
         try:

--- a/ai-backend/src/routes/voting_behavior.py
+++ b/ai-backend/src/routes/voting_behavior.py
@@ -35,10 +35,9 @@ add party_ids_contains filter to stay within tenant HNSW.
 import asyncio
 import logging
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter
 from sse_starlette.sse import EventSourceResponse
 
-from src.auth import resolve_user_is_logged_in
 from src.chatbot_async import (
     get_improved_rag_query_voting_behavior,
     generate_party_vote_behavior_summary,
@@ -191,7 +190,7 @@ def _chunk_payload_to_vote(payload: dict, party_id: str) -> Vote | None:
 
 
 @router.post("/voting-behavior")
-async def voting_behavior_endpoint(request: Request, body: VotingBehaviorRequestDto):
+async def voting_behavior_endpoint(body: VotingBehaviorRequestDto):
     """POST /api/v1/voting-behavior — streams votes + summary over SSE.
 
     Retrieves vote_record chunks from the single wahlchat_chunks_{ENV} store
@@ -201,13 +200,7 @@ async def voting_behavior_endpoint(request: Request, body: VotingBehaviorRequest
     text-delta parts for the summary, a final ``data-chat_event``
     (type=voting_behavior_complete), then finish + [DONE].
     Pydantic validates request body.
-
-    Auth: verification is OPTIONAL (no 401s). Premium LLM selection for the
-    summary is derived server-side from the request's token (a valid,
-    non-anonymous `Authorization: Bearer <Firebase ID token>`) — never from the
-    client.
     """
-    use_premium_llms = resolve_user_is_logged_in(request, "voting-behavior")
 
     async def stream():
         improved_rag_query = None
@@ -276,8 +269,6 @@ async def voting_behavior_endpoint(request: Request, body: VotingBehaviorRequest
                     body.last_user_message,
                     body.last_assistant_message,
                     votes,
-                    summary_llm_size=body.summary_llm_size,
-                    use_premium_llms=use_premium_llms,
                 )
                 async for chunk in summary_stream:
                     chunk_content = chunk.text

--- a/ai-backend/tests/conftest.py
+++ b/ai-backend/tests/conftest.py
@@ -23,10 +23,10 @@ also patched here because they are all "external I/O" in the same sense.
 The SSE generator, FastAPI route, EventSourceResponse framing, and
 data-stream protocol (f/0/8/e/d/[DONE]) all run live.
 
-IMPORTANT: The src.* modules instantiate clients at module level (QdrantClient,
-AzureChatOpenAI, firebase_admin, etc.). These require that certain env vars be
-set before import — see the os.environ.setdefault() calls at the top of this
-file which supply safe dummy values for CI.
+IMPORTANT: The src.* modules instantiate clients at module level (ChatOpenAI,
+ChatGoogleGenerativeAI, firebase_admin, etc.). These require that certain env
+vars be set before import — see the os.environ.setdefault() calls at the top of
+this file which supply safe dummy values for CI.
 
 The test uses httpx.AsyncASGITransport(app=app) to run in-process, which
 is the only reliable way to apply monkeypatching to a FastAPI SSE endpoint
@@ -47,11 +47,6 @@ from pathlib import Path
 os.environ.setdefault("API_NAME", "wahl-chat-api")
 os.environ.setdefault("FIRESTORE_EMULATOR_HOST", "localhost:8081")
 os.environ.setdefault("QDRANT_URL", "http://localhost:6333")
-# Dummy values to satisfy module-level LLM client constructors (AzureChatOpenAI
-# requires a non-None endpoint to initialise, even with dummy credentials).
-os.environ.setdefault("AZURE_OPENAI_ENDPOINT", "https://dummy.openai.azure.com")
-os.environ.setdefault("AZURE_OPENAI_API_KEY", "dummy-azure-key-for-ci")
-os.environ.setdefault("OPENAI_API_VERSION", "2024-02-01")
 os.environ.setdefault("OPENAI_API_KEY", "dummy-openai-key-for-ci")
 os.environ.setdefault("GOOGLE_API_KEY", "dummy-google-key-for-ci")
 

--- a/ai-backend/tests/test_answer_cache.py
+++ b/ai-backend/tests/test_answer_cache.py
@@ -29,7 +29,6 @@ from src.prompts import (
     user_prompt_improvement_template_str,
 )
 from src.models.context import ContextParty
-from src.models.general import LLMSize
 
 _SHA256_HEX = re.compile(r"^[0-9a-f]{64}$")
 
@@ -57,8 +56,6 @@ def _key_kwargs(**overrides: object) -> dict:
         context_id="bundestagswahl-2025",
         answer_guidelines="Leitlinien",
         rag_context="RAG-Kontext",
-        llm_size=LLMSize.LARGE,
-        use_premium_llms=False,
         llms=RESPONSE_GENERATION_LLMS,
     )
     kwargs.update(overrides)
@@ -235,18 +232,6 @@ def test_guidelines_change_key() -> None:
     assert a != b
 
 
-def test_premium_flag_changes_key() -> None:
-    a = build_answer_cache_key(**_key_kwargs(use_premium_llms=False))
-    b = build_answer_cache_key(**_key_kwargs(use_premium_llms=True))
-    assert a != b
-
-
-def test_llm_size_changes_key() -> None:
-    a = build_answer_cache_key(**_key_kwargs(llm_size=LLMSize.LARGE))
-    b = build_answer_cache_key(**_key_kwargs(llm_size=LLMSize.SMALL))
-    assert a != b
-
-
 def test_llm_roster_changes_key() -> None:
     """A shorter model list must change the key."""
     full = build_answer_cache_key(**_key_kwargs(llms=RESPONSE_GENERATION_LLMS))
@@ -256,26 +241,18 @@ def test_llm_roster_changes_key() -> None:
 
 def test_fingerprint_tracks_select_streaming_llms() -> None:
     """The fingerprint must follow the streamer roster order."""
-    fp = llm_generation_fingerprint(
-        RESPONSE_GENERATION_LLMS, LLMSize.LARGE, use_premium_llms=False
-    )
-    selected = select_streaming_llms(
-        RESPONSE_GENERATION_LLMS,
-        preferred_llm_size=LLMSize.LARGE,
-        use_premium_llms=False,
-    )
+    fp = llm_generation_fingerprint(RESPONSE_GENERATION_LLMS)
+    selected = select_streaming_llms(RESPONSE_GENERATION_LLMS)
     assert fp.split("\n")[0].startswith(selected[0].name)
-    for llm in selected:
-        assert llm.premium_only is False
+    assert selected == sorted(
+        RESPONSE_GENERATION_LLMS, key=lambda llm: llm.priority, reverse=True
+    )
 
 
-def test_select_streaming_llms_rejects_invalid_size() -> None:
-    try:
-        select_streaming_llms(RESPONSE_GENERATION_LLMS, preferred_llm_size="tiny")  # type: ignore[arg-type]
-    except ValueError as exc:
-        assert "Invalid preferred LLM size" in str(exc)
-    else:
-        raise AssertionError("expected ValueError")
+def test_select_streaming_llms_orders_by_priority() -> None:
+    selected = select_streaming_llms(RESPONSE_GENERATION_LLMS)
+    priorities = [llm.priority for llm in selected]
+    assert priorities == sorted(priorities, reverse=True)
 
 
 def _rag_key_kwargs(**overrides: object) -> dict:

--- a/ai-backend/tests/test_chat_service.py
+++ b/ai-backend/tests/test_chat_service.py
@@ -23,7 +23,6 @@ import src.chat_service as cs
 from src.chat_service import fetch_party_response_stream, process_party
 from src.models.chat import CachedResponse, GroupChatSession, Message
 from src.models.context import ContextParty
-from src.models.general import LLMSize
 
 
 # ---------------------------------------------------------------------------
@@ -261,7 +260,6 @@ def _make_session() -> GroupChatSession:
         session_id="s1",
         context_id="c1",
         chat_history=[Message(id="m1", role="user", content="Frage?")],
-        chat_response_llm_size=LLMSize.LARGE,
     )
 
 
@@ -312,7 +310,6 @@ def _drive_single_party(term_window, **stream_kwargs) -> list[str]:
             "q?",
             _make_session(),
             all_available_parties=[],
-            use_premium_llms=False,
             is_cacheable_chat=False,
             region_path=["DE-BW"],
             term_window=term_window,
@@ -913,7 +910,6 @@ def test_cacheable_lookup_runs_after_retrieval(monkeypatch) -> None:
             "q?",
             _make_session(),
             all_available_parties=[],
-            use_premium_llms=False,
             is_cacheable_chat=True,
             region_path=["DE-BW"],
             term_window=tw,
@@ -974,7 +970,6 @@ def test_cacheable_reuses_cached_rag_query(monkeypatch) -> None:
             "q?",
             _make_session(),
             all_available_parties=[],
-            use_premium_llms=False,
             is_cacheable_chat=True,
             region_path=["DE-BW"],
             term_window=_cacheable_term_window(),
@@ -1014,7 +1009,6 @@ def test_cacheable_writes_rag_query_on_miss(monkeypatch) -> None:
             "q?",
             _make_session(),
             all_available_parties=[],
-            use_premium_llms=False,
             is_cacheable_chat=True,
             region_path=["DE-BW"],
             term_window=_cacheable_term_window(),
@@ -1086,7 +1080,6 @@ def test_cached_rag_query_stabilizes_answer_cache_key(monkeypatch) -> None:
             "q?",
             _make_session(),
             all_available_parties=[],
-            use_premium_llms=False,
             is_cacheable_chat=True,
             region_path=["DE-BW"],
             term_window=_cacheable_term_window(),

--- a/ai-backend/tests/test_chatbot_async.py
+++ b/ai-backend/tests/test_chatbot_async.py
@@ -20,7 +20,6 @@ from src.chatbot_async import (
     generate_streaming_chatbot_response,
 )
 from src.models.context import ContextParty
-from src.models.general import LLMSize
 
 
 # ---------------------------------------------------------------------------
@@ -358,7 +357,6 @@ def _run_single_party(**gen_kwargs) -> None:
             "frage?",
             [],
             all_parties=[],
-            chat_response_llm_size=LLMSize.LARGE,
             **gen_kwargs,
         )
     )
@@ -375,7 +373,6 @@ def _run_comparison(**gen_kwargs) -> None:
             "frage?",
             {party.party_id: []},  # comparison ctx indexes docs per party
             [party],
-            LLMSize.LARGE,
             **gen_kwargs,
         )
     )

--- a/ai-backend/tests/test_chatbot_async.py
+++ b/ai-backend/tests/test_chatbot_async.py
@@ -16,6 +16,7 @@ import asyncio
 import inspect
 
 from src.chatbot_async import (
+    _message_text,
     build_vote_documents,
     generate_streaming_chatbot_response,
 )
@@ -427,3 +428,17 @@ def test_system_prompt_default_no_structure_note(monkeypatch) -> None:
     system_prompt = captured["system"]
     assert "Im Wahlprogramm fordert" not in system_prompt
     assert "Quellenbewusste Struktur deiner Antwort" not in system_prompt
+
+
+def test_message_text_reads_gemini_3_content_blocks() -> None:
+    """Gemini 3 returns content as type/text blocks, not a 'content' key."""
+    from langchain_core.messages import AIMessage
+
+    blocks = [{"type": "text", "text": "Klimaschutz", "extras": {"signature": "s"}}]
+    assert _message_text(AIMessage(content=blocks)) == "Klimaschutz"
+    assert _message_text(AIMessage(content="plain")) == "plain"
+
+    class _Resp:
+        content = "mock-only"
+
+    assert _message_text(_Resp()) == "mock-only"

--- a/ai-backend/tests/test_google_credentials.py
+++ b/ai-backend/tests/test_google_credentials.py
@@ -267,7 +267,7 @@ def test_location_defaults_to_global(no_vertex_env: None) -> None:
     """The default is "global" and that is load-bearing, so pin it.
 
     Regional endpoints on the billing project 404 on gemini-embedding-2 and on
-    every chat model except gemini-2.5-flash, and a 404 falls through to AI
+    most Flash / Flash-Lite chat models, and a 404 falls through to AI
     Studio silently — so a well-meaning change to a regional value here would
     quietly stop most traffic from being billed to Vertex at all.
     """

--- a/ai-backend/tests/test_llms_vertex.py
+++ b/ai-backend/tests/test_llms_vertex.py
@@ -49,17 +49,6 @@ def test_no_vertex_tier_without_credentials() -> None:
     ]
 
 
-def test_no_azure_clients() -> None:
-    """Azure OpenAI is not registered; new OpenAI models would have to be
-    deployed there by hand, which we are not maintaining.
-    """
-    names = [
-        entry.name
-        for entry in llms.RESPONSE_GENERATION_LLMS + llms.PRE_AND_POST_PROCESSING_LLMS
-    ]
-    assert not any(name.startswith("azure-") for name in names)
-
-
 def _ai_studio_gemini_clients():
     return [
         entry.model

--- a/ai-backend/tests/test_llms_vertex.py
+++ b/ai-backend/tests/test_llms_vertex.py
@@ -8,7 +8,7 @@ Tests for the Vertex AI tier in src/llms.py.
 Two properties matter and neither needs a network or a real key:
 
   1. Without Vertex credentials the module is byte-for-byte its old self — the
-     LLM lists contain only the AI Studio / Azure / OpenAI entries. This is the
+     LLM lists contain only the AI Studio / OpenAI entries. This is the
      CI and local-dev-without-a-key path.
   2. The Vertex entries, when present, outrank every AI Studio entry, so the
      existing priority-sorted failover in get_answer_from_llms and friends tries
@@ -31,9 +31,41 @@ def test_no_vertex_tier_without_credentials() -> None:
 
     names = [entry.name for entry in llms.RESPONSE_GENERATION_LLMS]
     assert not any(name.startswith("vertex-") for name in names)
+    assert names == [
+        "google-gemini-3.6-flash",
+        "openai-gpt-5.6-terra",
+        "google-gemini-3.7-flash",
+        "google-gemini-3-flash-preview",
+        "google-gemini-3.5-flash",
+    ]
 
     prepost = [entry.name for entry in llms.PRE_AND_POST_PROCESSING_LLMS]
     assert not any(name.startswith("vertex-") for name in prepost)
+    assert prepost == [
+        "google-gemini-3.1-flash-lite",
+        "openai-gpt-5.6-luna",
+        "google-gemini-2.5-flash-lite",
+        "google-gemini-3.5-flash-lite",
+    ]
+
+
+def test_no_azure_clients() -> None:
+    """Azure OpenAI is not registered; new OpenAI models would have to be
+    deployed there by hand, which we are not maintaining.
+    """
+    names = [
+        entry.name
+        for entry in llms.RESPONSE_GENERATION_LLMS + llms.PRE_AND_POST_PROCESSING_LLMS
+    ]
+    assert not any(name.startswith("azure-") for name in names)
+
+
+def _ai_studio_gemini_clients():
+    return [
+        entry.model
+        for entry in llms.RESPONSE_GENERATION_LLMS + llms.PRE_AND_POST_PROCESSING_LLMS
+        if entry.name.startswith("google-gemini-")
+    ]
 
 
 def test_ai_studio_clients_are_pinned_off_vertex() -> None:
@@ -47,13 +79,7 @@ def test_ai_studio_clients_are_pinned_off_vertex() -> None:
     `_use_vertexai`: the resolved value would also read False with the kwarg
     dropped and the env var absent, so it alone does not prove the pin is there.
     """
-    for client in (
-        llms.google_gemini_2_flash,
-        llms.google_gemini_3_flash_preview,
-        llms.google_gemini_2_5_flash,
-        llms.google_gemini_2_5_flash_lite_det,
-        llms.google_gemini_2_flash_det,
-    ):
+    for client in _ai_studio_gemini_clients():
         assert client.vertexai is False, client.model
         assert client._use_vertexai is False, client.model
 
@@ -68,7 +94,7 @@ def test_vertex_clients_are_pinned_on_vertex() -> None:
     Built through the module's own helper rather than by re-importing with
     credentials, which would need a real key.
     """
-    client = llms._gemini("gemini-2.5-flash", vertex=True)
+    client = llms._gemini("gemini-3.6-flash", vertex=True)
 
     assert client.vertexai is True
     assert client._use_vertexai is True
@@ -76,22 +102,36 @@ def test_vertex_clients_are_pinned_on_vertex() -> None:
 
 def test_model_kwargs_survive_the_helper() -> None:
     """The thinking_* and temperature settings are behavioural, not cosmetic."""
+    assert llms.google_gemini_3_6_flash.temperature == 1.0
+    assert llms.google_gemini_3_6_flash.thinking_level == "minimal"
+    assert llms.google_gemini_3_7_flash.temperature == 1.0
+    assert llms.google_gemini_3_7_flash.thinking_level == "low"
     assert llms.google_gemini_3_flash_preview.temperature == 1.0
-    assert llms.google_gemini_3_flash_preview.thinking_level == "low"
-    assert llms.google_gemini_2_5_flash.thinking_budget == 0
-    assert llms.google_gemini_2_5_flash_lite_det.temperature == 0.0
-    assert llms.google_gemini_2_flash_det.temperature == 0.0
+    assert llms.google_gemini_3_flash_preview.thinking_level == "minimal"
+    assert llms.google_gemini_3_5_flash.temperature == 1.0
+    assert llms.google_gemini_3_5_flash.thinking_level == "minimal"
+    assert llms.openai_gpt_5_6_terra.temperature == 1.0
+    assert llms.openai_gpt_5_6_terra.reasoning_effort == "minimal"
+
+    assert llms.google_gemini_3_1_flash_lite.temperature == 1.0
+    assert llms.google_gemini_3_1_flash_lite.thinking_level == "minimal"
+    assert llms.google_gemini_2_5_flash_lite.temperature == 1.0
+    assert llms.google_gemini_2_5_flash_lite.thinking_budget == 0
+    assert llms.google_gemini_3_5_flash_lite.temperature == 1.0
+    assert llms.google_gemini_3_5_flash_lite.thinking_level == "minimal"
+    assert llms.openai_gpt_5_6_luna.temperature == 1.0
+    assert llms.openai_gpt_5_6_luna.reasoning_effort == "minimal"
 
 
 def test_vertex_entries_would_outrank_ai_studio() -> None:
-    """Vertex priorities (192-200) must exceed every AI Studio priority.
+    """Vertex priorities (170-200) must exceed every AI Studio / OpenAI priority.
 
     Asserted against the live lists so that re-prioritising an AI Studio entry
-    above 192 in future fails here rather than silently sending traffic to the
+    above 170 in future fails here rather than silently sending traffic to the
     wrong project.
     """
     highest_existing = max(
         entry.priority
         for entry in llms.RESPONSE_GENERATION_LLMS + llms.PRE_AND_POST_PROCESSING_LLMS
     )
-    assert highest_existing < 192
+    assert highest_existing < 170

--- a/ai-backend/tests/test_source_filter.py
+++ b/ai-backend/tests/test_source_filter.py
@@ -40,7 +40,6 @@ from src.chatbot_async import (
 )
 from src.models.chat import GroupChatSession, Message
 from src.models.context import ContextParty
-from src.models.general import LLMSize
 from src.models.structured_outputs import SourceFilterClassifier
 
 _TW = (
@@ -63,7 +62,6 @@ def _make_session() -> GroupChatSession:
         session_id="s1",
         context_id="c1",
         chat_history=[Message(id="m1", role="user", content="Frage?")],
-        chat_response_llm_size=LLMSize.LARGE,
     )
 
 
@@ -341,7 +339,6 @@ def _drive_single_party(
             "q?",
             _make_session(),
             all_available_parties=[],
-            use_premium_llms=False,
             is_cacheable_chat=False,
             region_path=["DE"],
             term_window=term_window,

--- a/web/app/api/chat/route.ts
+++ b/web/app/api/chat/route.ts
@@ -32,7 +32,6 @@ type IncomingPayload = {
   session_id?: string;
   context_id?: string;
   party_ids?: string[];
-  user_is_logged_in?: boolean;
   chat_history?: unknown[];
 };
 
@@ -84,12 +83,10 @@ export async function POST(request: NextRequest) {
     context_id: payload.context_id,
     user_message: userMessage,
     party_ids: payload.party_ids,
-    user_is_logged_in: payload.user_is_logged_in ?? false,
     chat_history: payload.chat_history ?? [],
   };
 
-  // Forward the caller's Firebase ID token so the backend can verify
-  // user_is_logged_in / premium claims. Absent when signed out.
+  // Forward the caller's Firebase ID token when present. Absent when signed out.
   const authorization = request.headers.get('authorization');
 
   const upstream = await fetch(targetUrl, {

--- a/web/app/api/pro-con/route.ts
+++ b/web/app/api/pro-con/route.ts
@@ -30,8 +30,7 @@ export async function POST(request: NextRequest) {
     return new NextResponse('Bad Request', { status: 400 });
   }
 
-  // Forward the caller's Firebase ID token so the backend can verify
-  // user_is_logged_in / premium claims. Absent when signed out.
+  // Forward the caller's Firebase ID token when present. Absent when signed out.
   const authorization = request.headers.get('authorization');
 
   const upstream = await fetch(targetUrl, {

--- a/web/app/api/voting-behavior/route.ts
+++ b/web/app/api/voting-behavior/route.ts
@@ -26,8 +26,7 @@ export async function POST(request: NextRequest) {
     return new NextResponse('Bad Request', { status: 400 });
   }
 
-  // Forward the caller's Firebase ID token so the backend can verify
-  // user_is_logged_in / premium claims. Absent when signed out.
+  // Forward the caller's Firebase ID token when present. Absent when signed out.
   const authorization = request.headers.get('authorization');
 
   const upstream = await fetch(targetUrl, {

--- a/web/components/providers/sse-chat-provider.tsx
+++ b/web/components/providers/sse-chat-provider.tsx
@@ -15,7 +15,6 @@ type AppendBody = {
   session_id: string;
   context_id: string;
   party_ids: string[];
-  user_is_logged_in: boolean;
   chat_history?: unknown[];
 };
 
@@ -76,10 +75,9 @@ function SseChatProvider({ children }: Props) {
     // is needed — useChat parses it natively.
     transport: new DefaultChatTransport({
       api: '/api/chat',
-      // Attach the Firebase ID token per request (async resolvable): the proxy
-      // route forwards it so the backend can verify user_is_logged_in/premium
-      // Resolves to {} when signed out / on token errors —
-      // the request degrades gracefully to unauthenticated.
+      // Attach the Firebase ID token per request (async resolvable). Resolves
+      // to {} when signed out / on token errors — the request degrades
+      // gracefully to unauthenticated.
       // (The auth service worker defers to this header — it only injects its
       // own token when a request carries none, so exactly ONE Bearer token
       // reaches the backend.)

--- a/web/lib/firebase/firebase.ts
+++ b/web/lib/firebase/firebase.ts
@@ -58,9 +58,7 @@ if (firebaseEmulatorsEnabled()) {
  *
  * Returns `{ Authorization: 'Bearer <idToken>' }` when a user is signed in,
  * or `{}` when signed out or the token cannot be obtained — callers degrade
- * gracefully to an unauthenticated request instead of failing. The backend
- * honors `user_is_logged_in` / premium ONLY with a verified token; the body
- * flag alone is ignored.
+ * gracefully to an unauthenticated request instead of failing.
  */
 export async function getAuthHeader(): Promise<Record<string, string>> {
   try {

--- a/web/lib/firebase/firebase.types.ts
+++ b/web/lib/firebase/firebase.types.ts
@@ -1,6 +1,5 @@
 import type { Topic } from '@/components/topics/topics.data';
 import type { ProlificMetadata } from '@/lib/prolific-study/prolific-metadata';
-import type { LLMSize } from '@/lib/socket.types';
 import type { GroupedMessage } from '@/lib/stores/chat-store.types';
 import type { WahlSwiperResultHistory } from '@/lib/wahl-swiper/wahl-swiper.types';
 
@@ -60,12 +59,9 @@ export type SourceDocument = {
   party_id: string;
 };
 
-export const DEFAULT_LLM_SIZE: LLMSize = 'large';
-
 export type Tenant = {
   id: string;
   name: string;
-  llm_size?: LLMSize;
 };
 
 export type ExampleQuestionShareableChatSession = {

--- a/web/lib/socket.types.ts
+++ b/web/lib/socket.types.ts
@@ -60,30 +60,6 @@ export type StreamingMessage = {
   feedback?: MessageFeedback;
 };
 
-export type LLMSize = 'small' | 'large';
-
-export type ChatSessionInitPayload = {
-  session_id: string;
-  context_id: string;
-  party_ids: string[];
-  chat_history: MessageItem[];
-  current_title: string;
-  chat_response_llm_size: LLMSize;
-  last_quick_replies: string[];
-};
-
-export type ChatSessionInitializedPayload = {
-  session_id: string;
-};
-
-export type AddUserMessagePayload = {
-  session_id: string;
-  context_id: string;
-  user_message: string;
-  party_ids: string[];
-  user_is_logged_in: boolean;
-};
-
 export type ProConPerspectiveRequestPayload = {
   request_id: string;
   party_id: string;
@@ -156,6 +132,4 @@ export type GenerateVotingBehaviorSummaryPayload = {
   party_id: string;
   last_user_message: string;
   last_assistant_message: string;
-  summary_llm_size: LLMSize;
-  user_is_logged_in: boolean;
 };

--- a/web/lib/stores/actions/chat-add-user-message.ts
+++ b/web/lib/stores/actions/chat-add-user-message.ts
@@ -18,7 +18,6 @@ export const chatAddUserMessage: ChatStoreActionHandlerFor<'addUserMessage'> =
   (get, set) =>
   async (userId: string, message: string, fromInitialQuestion?: boolean) => {
     const {
-      isAnonymous,
       chatSessionId,
       contextId,
       localPreliminaryChatSessionId,
@@ -170,7 +169,6 @@ export const chatAddUserMessage: ChatStoreActionHandlerFor<'addUserMessage'> =
           session_id: safeSessionId,
           context_id: safeContextId,
           party_ids: Array.from(partyIds),
-          user_is_logged_in: !isAnonymous,
           chat_history: chatHistory,
         },
       );

--- a/web/lib/stores/actions/generate-voting-behavior-summary.ts
+++ b/web/lib/stores/actions/generate-voting-behavior-summary.ts
@@ -10,7 +10,6 @@ export const generateVotingBehaviorSummary: ChatStoreActionHandlerFor<
   const {
     messages,
     contextId,
-    getLLMSize,
     addVotingBehaviorResult,
     addVotingBehaviorSummaryChunk,
     completeVotingBehavior,
@@ -53,7 +52,6 @@ export const generateVotingBehaviorSummary: ChatStoreActionHandlerFor<
         last_user_message:
           lastUserMessageBeforeVotingBehavior.messages[0].content,
         last_assistant_message: message.content,
-        summary_llm_size: getLLMSize(),
       }),
     });
 

--- a/web/lib/stores/chat-store.ts
+++ b/web/lib/stores/chat-store.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_LLM_SIZE } from '@/lib/firebase/firebase.types';
 import { devtools } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 import { createStore } from 'zustand/vanilla';
@@ -107,7 +106,6 @@ export function createChatStore(initialState?: Partial<ChatStore>) {
         addVotingBehaviorSummaryChunk: addVotingBehaviorSummaryChunk(get, set),
         completeVotingBehavior: completeVotingBehavior(get, set),
         setPartyIds: setPartyIds(get, set),
-        getLLMSize: () => get().tenant?.llm_size ?? DEFAULT_LLM_SIZE,
         setProlificMetadata: (prolificMetadata) => set({ prolificMetadata }),
         setProlificConfig: ({ minInteractions }) =>
           set({ prolificMinInteractions: minInteractions }),

--- a/web/lib/stores/chat-store.types.ts
+++ b/web/lib/stores/chat-store.types.ts
@@ -2,7 +2,6 @@ import type { ChatSession, Tenant } from '@/lib/firebase/firebase.types';
 import type { PartyDetails } from '@/lib/party-details';
 import type { ProlificMetadata } from '@/lib/prolific-study/prolific-metadata';
 import type {
-  LLMSize,
   PartyResponseChunkReadyPayload,
   StreamingMessage,
   Vote,
@@ -204,7 +203,6 @@ export type ChatStoreActions = {
     message: string,
   ) => void;
   setPartyIds: (partyIds: string[]) => void;
-  getLLMSize: () => LLMSize;
   setProlificMetadata: (metadata: ProlificMetadata) => void;
   setProlificConfig: (config: { minInteractions: number }) => void;
   setProlificDisclaimerDismissed: (dismissed: boolean) => void;


### PR DESCRIPTION
## Summary

We move chat to newer language models. The current models give weaker answers. They add latency. Google will stop some of them. Cost increases only a little.

The main answer model is Gemini 3.6 Flash with minimal reasoning. The pre- and post-processing model is Gemini 3.1 Flash-Lite. If the first model fails, the next model in the list is used: GPT-5.6 Terra then older Gemini Flash models for answers, and GPT-5.6 Luna then older Flash-Lite models for pre- and post-processing. All of these models use temperature 1.

We remove Azure OpenAI. Each new OpenAI model would need a manual deploy on Azure. We do not want to maintain that.

We also remove LLM size, premium-only models, and the unused per-model rate-limit flag. Every user now uses the same model list. The web client no longer sends those flags.

## Test plan

- [ ] Run backend unit tests for the new model list and cache keys.
- [ ] Confirm Vertex Gemini models still run before AI Studio twins when Vertex credentials exist.
- [ ] Send a chat message and confirm a streamed answer.
- [ ] Confirm the voting-behavior summary still streams.
- [ ] Confirm the rate-limit banner still appears only when all models fail.


Made with [Cursor](https://cursor.com)