### PR TITLE
ci: ship production via independent manual promote workflows

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,10 @@
+# Cloud Build only needs this config and the backend image context.
+# Keep the upload small so the manual prod promote is not shipping web/ or
+# firebase/ to the source bucket.
+/*
+!cloudbuild.backend.yaml
+!ai-backend/
+ai-backend/.venv/
+ai-backend/.env
+ai-backend/*-adminsdk-*.json
+ai-backend/vertex-sa*.json

--- a/.github/workflows/promote-backend-prod.yml
+++ b/.github/workflows/promote-backend-prod.yml
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: 2026 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+# Promote a commit to the production Cloud Run backend (wahl-chat-backend).
+#
+# develop keeps auto-deploying to wahl-chat-backend-dev via the Cloud Build
+# trigger on that branch. This workflow is the only prod path: pick a SHA
+# (default: tip of develop), rebuild that commit in the prod project with the
+# same cloudbuild.backend.yaml candidate → smoke → 100% traffic sequence.
+#
+# One-time GitHub setup (Settings → Environments → prod-backend):
+#   Required reviewers — without this the button is not a gate.
+#   vars.GCP_WIF_PROVIDER            projects/<num>/locations/global/workloadIdentityPools/github/providers/github-oidc
+#   vars.GCP_DEPLOY_SERVICE_ACCOUNT  SA that can submit Cloud Builds in wahl-chat
+#                                    and impersonate the Cloud Build runtime SA
+#   vars.GCP_PROJECT                 optional, defaults to wahl-chat
+#   vars.CLOUD_RUN_SERVICE           optional, defaults to wahl-chat-backend
+#
+# The impersonated SA needs: cloudbuild.builds.create/get, storage access for
+# the Cloud Build source bucket, and iam.serviceAccountUser on the project's
+# Cloud Build service account. That Cloud Build SA is what already deploys
+# Cloud Run today — do not grant the GitHub SA Cloud Run admin directly.
+#
+# Also disable (do not delete the YAML) the Cloud Build trigger that fires on
+# push to main, or a merge to main will still ship prod.
+
+name: Promote backend
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: Full git SHA to promote (empty = tip of develop)
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: promote-backend-prod
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    environment: prod-backend
+    timeout-minutes: 30
+    env:
+      GCP_PROJECT: ${{ vars.GCP_PROJECT || 'wahl-chat' }}
+      CLOUD_RUN_SERVICE: ${{ vars.CLOUD_RUN_SERVICE || 'wahl-chat-backend' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: Resolve commit
+        id: resolve
+        env:
+          SHA_INPUT: ${{ inputs.sha }}
+        run: |
+          set -euo pipefail
+          if [ -n "${SHA_INPUT}" ]; then
+            git fetch --depth=1 origin "${SHA_INPUT}"
+            sha="$(git rev-parse --verify "${SHA_INPUT}^{commit}")"
+          else
+            sha="$(git rev-parse --verify 'origin/develop^{commit}')"
+          fi
+          echo "sha=${sha}" >> "${GITHUB_OUTPUT}"
+          echo "Promoting ${sha}"
+
+      - name: Check out commit to promote
+        run: git checkout --detach "${{ steps.resolve.outputs.sha }}"
+
+      - name: Check required configuration
+        env:
+          GCP_WIF_PROVIDER: ${{ vars.GCP_WIF_PROVIDER }}
+          GCP_DEPLOY_SERVICE_ACCOUNT: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+        run: |
+          set -euo pipefail
+          test -n "${GCP_WIF_PROVIDER}" || { echo "Set vars.GCP_WIF_PROVIDER on the prod-backend environment" >&2; exit 1; }
+          test -n "${GCP_DEPLOY_SERVICE_ACCOUNT}" || { echo "Set vars.GCP_DEPLOY_SERVICE_ACCOUNT on the prod-backend environment" >&2; exit 1; }
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.GCP_PROJECT }}
+
+      - name: Build, smoke, and shift traffic
+        run: |
+          set -euo pipefail
+          gcloud builds submit . \
+            --project="${GCP_PROJECT}" \
+            --config=cloudbuild.backend.yaml \
+            --substitutions="COMMIT_SHA=${{ steps.resolve.outputs.sha }},_SERVICE=${CLOUD_RUN_SERVICE}"

--- a/.github/workflows/promote-web-prod.yml
+++ b/.github/workflows/promote-web-prod.yml
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2026 wahl.chat
+#
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+# Promote a commit to the production Vercel deployment (wahl.chat).
+#
+# develop keeps auto-deploying to dev.wahl.chat via the Vercel git integration.
+# This workflow is the only prod path: it rebuilds the chosen SHA with
+# Production env vars (do not "promote" a develop preview — NEXT_PUBLIC_* is
+# baked in at build time and would keep pointing at the dev backend).
+#
+# One-time GitHub setup (Settings → Environments → prod-web):
+#   Required reviewers — without this the button is not a gate.
+#   secrets.VERCEL_TOKEN
+#   vars.VERCEL_ORG_ID       team id (team_…) from vercel.com/wahl-chat/~/settings
+#   vars.VERCEL_PROJECT_ID   project id from vercel.com/wahl-chat/web/settings
+#
+# One-time Vercel setup: keep the Production Branch as main, and do not attach
+# develop to Production. web/vercel.json disables git deploys from main, so a
+# merge to main no longer ships wahl.chat.
+
+name: Promote web
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: Full git SHA to promote (empty = tip of develop)
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: promote-web-prod
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    environment: prod-web
+    timeout-minutes: 20
+    env:
+      VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: Resolve commit
+        id: resolve
+        working-directory: .
+        env:
+          SHA_INPUT: ${{ inputs.sha }}
+        run: |
+          set -euo pipefail
+          if [ -n "${SHA_INPUT}" ]; then
+            git fetch --depth=1 origin "${SHA_INPUT}"
+            sha="$(git rev-parse --verify "${SHA_INPUT}^{commit}")"
+          else
+            sha="$(git rev-parse --verify 'origin/develop^{commit}')"
+          fi
+          echo "sha=${sha}" >> "${GITHUB_OUTPUT}"
+          echo "Promoting ${sha}"
+
+      - name: Check out commit to promote
+        working-directory: .
+        run: git checkout --detach "${{ steps.resolve.outputs.sha }}"
+
+      - name: Check required configuration
+        working-directory: .
+        run: |
+          set -euo pipefail
+          test -n "${VERCEL_TOKEN}" || { echo "Set secrets.VERCEL_TOKEN on the prod-web environment" >&2; exit 1; }
+          test -n "${VERCEL_ORG_ID}" || { echo "Set vars.VERCEL_ORG_ID on the prod-web environment" >&2; exit 1; }
+          test -n "${VERCEL_PROJECT_ID}" || { echo "Set vars.VERCEL_PROJECT_ID on the prod-web environment" >&2; exit 1; }
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@59
+
+      - name: Pull production environment
+        run: vercel pull --yes --environment=production --token="${VERCEL_TOKEN}"
+
+      - name: Build
+        run: vercel build --prod --token="${VERCEL_TOKEN}"
+
+      - name: Deploy
+        run: vercel deploy --prebuilt --prod --token="${VERCEL_TOKEN}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,7 @@ corporate networks. Other routers: `pro_con`, `voting_behavior`, `misc`, plus a
 | `firebase/` | Firestore rules (`firestore.rules`), Cloud Functions, seed script (`scripts/seed_firestore.py`), rules tests (`tests/`). |
 | `infra/` | Scheduled-ingestion deployment — planned Terraform workstream (Cloud Run Jobs + Scheduler); see `infra/README.md`. |
 | `scripts/` | Repo-root scripts: `check_gdpr_wall.py` (CI guard), `setup-agent-docs.sh`. |
+| `.github/workflows/` | Manual prod promotes (`promote-backend-prod.yml`, `promote-web-prod.yml`). |
 | `Makefile` | Developer convenience targets (install, stores, dev, test, lint, ingestion runs). |
 | `docker-compose.yml` | Local Qdrant service. |
 
@@ -203,6 +204,16 @@ Run individual services directly if you prefer:
 cd web && bun run dev                       # frontend
 cd ai-backend && uv run python -m src.app   # backend (add --debug for verbose logs)
 ```
+
+### Deploying
+
+`develop` auto-deploys the **dev** environment (Vercel `dev.wahl.chat`, Cloud Run
+`wahl-chat-backend-dev`). Production is two independent manual GitHub Actions —
+**Promote backend** and **Promote web** — each taking an optional SHA (default:
+tip of `develop`). They are the only prod path; a merge to `main` must not ship.
+Backend promote submits `cloudbuild.backend.yaml` against the `wahl-chat`
+project. Web promote rebuilds on Vercel with Production env vars (never promote
+a develop preview: `NEXT_PUBLIC_*` is compile-time).
 
 ### Running ingestion connectors
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,20 @@ make stores-down
 | `make test-local-mode` | Run the seed-script emulator-guard tests (needs live local stores: `make stores-up` first) |
 | `make lint` | Lint web (biome) + backend (ruff) |
 
+## Deploying
+
+Merges to `develop` deploy the **dev** environment automatically: Vercel → [dev.wahl.chat](https://dev.wahl.chat), Cloud Build → `wahl-chat-backend-dev`.
+
+Production is a manual promote of a git SHA (defaults to the tip of `develop`), so backend and web can ship independently and in either order:
+
+1. GitHub → Actions → **Promote backend** or **Promote web**
+2. Leave the SHA empty to promote `develop`, or paste a full commit SHA
+3. Approve the `prod-backend` / `prod-web` environment if reviewers are configured
+
+Do not merge to `main` to ship. After this is in place, disable the Cloud Build trigger that fires on `main`, and keep Vercel’s Production Branch as `main` (git deploys from `main` are turned off in `web/vercel.json`).
+
+Required one-time secrets and environment variables are listed in the workflow files under `.github/workflows/`.
+
 ## Contributing
 
 We appreciate contributions from our community. Please take a look at the open issues if you are interested.

--- a/ai-backend/README.md
+++ b/ai-backend/README.md
@@ -170,6 +170,8 @@ docker run --env-file .env \
 
 Set `ENV=prod` in `.env` and use `wahl-chat-firebase-adminsdk.json` for production deployments.
 
+Hosted Cloud Run: merges to `develop` auto-deploy `wahl-chat-backend-dev`. Production (`wahl-chat-backend`) is the manual **Promote backend** GitHub Action — see the [root README](../README.md#deploying).
+
 ## Test
 
 The suite mocks Qdrant/embeddings (see `tests/conftest.py`), so no running backend or live stores are required.

--- a/cloudbuild.backend.yaml
+++ b/cloudbuild.backend.yaml
@@ -2,12 +2,14 @@
 #
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
-# Build, verify, and promote the backend deployed from develop or main. Each
-# trigger overrides _SERVICE for its environment. The candidate receives no
-# traffic until the FastAPI chat route is proven to exist.
-# Required trigger substitutions:
-#   develop: _SERVICE=wahl-chat-backend-dev
-#   main:    _SERVICE=wahl-chat-backend
+# Build, verify, and shift traffic for a Cloud Run backend revision. The
+# candidate receives no traffic until POST /api/v1/chat is proven to exist.
+#
+# Attach this file only to the develop Cloud Build trigger
+# (_SERVICE=wahl-chat-backend-dev, or omit it — that is the default).
+# Production is a manual GitHub Action (Promote backend) that submits this
+# same pipeline against the wahl-chat project with _SERVICE=wahl-chat-backend.
+# Do not attach a push-to-main trigger to this file.
 steps:
   - id: build
     name: gcr.io/cloud-builders/docker
@@ -84,6 +86,7 @@ steps:
 
 substitutions:
   _REGION: europe-west1
+  _SERVICE: wahl-chat-backend-dev
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/web/README.md
+++ b/web/README.md
@@ -41,7 +41,9 @@ Open http://localhost:3000.
 
 ## Deployment
 
-Deployed via the [Vercel Platform](https://vercel.com). See the [Next.js deployment docs](https://nextjs.org/docs/app/building-your-application/deploying) for details.
+Merges to `develop` auto-deploy to [dev.wahl.chat](https://dev.wahl.chat). Production ([wahl.chat](https://wahl.chat)) is a manual **Promote web** GitHub Action so it can ship independently of the backend. That workflow rebuilds the chosen SHA with Production env vars — do not promote a develop preview, because `NEXT_PUBLIC_*` is baked in at build time.
+
+`vercel.json` disables git deploys from `main`. Keep Vercel’s Production Branch set to `main` (unused for auto-deploy) and do not point it at `develop`. See the [root README](../README.md#deploying) and `.github/workflows/promote-web-prod.yml` for the secrets to set.
 
 ### Cache Revalidation
 

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,0 +1,7 @@
+{
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Keep `develop` auto-deploying the dev environment (Vercel → `dev.wahl.chat`, Cloud Build → `wahl-chat-backend-dev`).
- Add two `workflow_dispatch` Actions — **Promote backend** and **Promote web** — so production can ship per component, in either order, from a SHA (default: tip of `develop`).
- Stop treating a merge to `main` as the prod switch: `web/vercel.json` disables git deploys from `main`, and `cloudbuild.backend.yaml` is documented as develop-only (disable the existing push-to-`main` Cloud Build trigger after merge).

## Test plan
- [ ] After merge, confirm a push to `develop` still deploys `dev.wahl.chat` and `wahl-chat-backend-dev`.
- [ ] Set required reviewers plus the vars/secrets listed in the workflow file headers on the `prod-backend` and `prod-web` GitHub Environments.
- [ ] Disable the Cloud Build trigger that fires on `main`. Keep Vercel’s Production Branch as `main` (do not point it at `develop`).
- [ ] Dry-run **Promote backend** against a known-good SHA (or cancel after the environment approval gate) and confirm it submits `cloudbuild.backend.yaml` to the `wahl-chat` project with `_SERVICE=wahl-chat-backend`.
- [ ] Dry-run **Promote web** and confirm it rebuilds with Production env vars (not a develop preview).
- [ ] Confirm a merge to `main` no longer deploys either prod surface.


Made with [Cursor](https://cursor.com)