### PR TITLE
fix(legal): name the operating entity in the Impressum

### DIFF
--- a/web/app/(with-header)/impressum/page.tsx
+++ b/web/app/(with-header)/impressum/page.tsx
@@ -10,11 +10,12 @@ export const metadata: Metadata = {
 function Impressum() {
   const markdown = `
 # Impressum
-        
+
 ## Adresse
-*Robin Frasch*  
-An der Verbindungsbahn 7 
-20146 Hamburg  
+**Center for Tech-Enabled Citizenship (CTEC) gUG (haftungsbeschränkt)**\\
+Geschäftsführer: Robin Frasch\\
+An der Verbindungsbahn 7\\
+20146 Hamburg\\
 Deutschland
 
 ## Kontakt


### PR DESCRIPTION
The Impressum address block named a private individual rather than the company that operates wahl.chat.

```
Center for Tech-Enabled Citizenship (CTEC) gUG (haftungsbeschränkt)
Geschäftsführer: Robin Frasch
An der Verbindungsbahn 7
20146 Hamburg
Deutschland
```

Line breaks are CommonMark backslash hard breaks rather than two trailing spaces. The `trailing-whitespace` pre-commit hook strips trailing spaces, so the previous markup could not survive an edit — and `An der Verbindungsbahn 7` already had only one trailing space, so the street and the postcode were rendering on the same line.

Mostly so that is recognisable when someone checks out the page when reviewing the Demokratie leben application