### PR TITLE
feat(web): make landing page chat-first

### DIFF
--- a/web/app/(landing)/layout.tsx
+++ b/web/app/(landing)/layout.tsx
@@ -1,4 +1,7 @@
 import LandingFooter from '@/components/landing/landing-footer';
+import LandingHeader from '@/components/landing/landing-header';
+import { getNextUpcomingElection } from '@/lib/elections';
+import { getContexts } from '@/lib/firebase/firebase-server';
 
 type Props = {
   children: React.ReactNode;
@@ -7,16 +10,17 @@ type Props = {
 /**
  * Shell for the landing page.
  *
- * / deliberately does not use the shared header: the hero fills the viewport
- * and carries the site logo itself, so a bar above it would only compete with
- * the call to action. It does get a footer, outside <main> so it is a real
- * contentinfo landmark — the page is a long scrolling document now, and the
- * links a visitor still needs belong at the end of it rather than crammed
- * under the hero.
+ * / uses its own compact header and footer around the server-rendered landing
+ * content. The shared application header depends on an election context, while
+ * this page lets the visitor choose that context before entering the chat.
  */
-function LandingLayout({ children }: Props) {
+async function LandingLayout({ children }: Props) {
+  const contexts = await getContexts();
+  const featured = getNextUpcomingElection(contexts) ?? contexts[0];
+
   return (
     <>
+      <LandingHeader contextId={featured?.context_id} />
       <main className="flex w-full flex-col">{children}</main>
       <LandingFooter />
     </>

--- a/web/app/(landing)/page.tsx
+++ b/web/app/(landing)/page.tsx
@@ -3,25 +3,24 @@ import GitHubCard from '@/components/home/github-card';
 import KnownFrom from '@/components/home/known-from';
 import SupportUsCard from '@/components/home/support-us-card';
 import HowToIntro from '@/components/how-to-intro';
-import BrandBlurBackdrop from '@/components/landing/brand-blur-backdrop';
 import DataSources from '@/components/landing/data-sources';
 import ElectionLinks from '@/components/landing/election-links';
 import ExampleQuestions, {
   type QuestionGroup,
 } from '@/components/landing/example-questions';
-import HeroCta from '@/components/landing/hero-cta';
-import HeroLogo from '@/components/landing/hero-logo';
+import LandingChatHero from '@/components/landing/landing-chat-hero';
 import LandingFaq from '@/components/landing/landing-faq';
 import LandingSection from '@/components/landing/landing-section';
 import LandingStats from '@/components/landing/landing-stats';
-import ScreenshotWheel from '@/components/landing/screenshot-wheel';
-import ScrollCue from '@/components/landing/scroll-cue';
 import JsonLd from '@/components/seo/json-ld';
-import { isUpcomingElection, splitElectionsByDate } from '@/lib/elections';
+import { splitElectionsByDate } from '@/lib/elections';
 import {
   getContexts,
   getGroupProposedQuestionsForContext,
+  getHomeInputProposedQuestions,
   getPartiesForContext,
+  getSystemStatus,
+  getUser,
 } from '@/lib/firebase/firebase-server';
 import {
   flattenAccordionContentToText,
@@ -33,8 +32,7 @@ import {
   buildFaqPageMainEntity,
   productionRobots,
 } from '@/lib/seo';
-import { IS_EMBEDDED, formatGermanDate } from '@/lib/utils';
-import { CalendarIcon } from 'lucide-react';
+import { IS_EMBEDDED, shuffleArray } from '@/lib/utils';
 import type { Metadata } from 'next';
 
 // The featured election is derived from the context dates, so it rolls over on
@@ -86,7 +84,6 @@ export default async function Landing() {
   // Between elections there is nothing upcoming; fall back to the most recent
   // one so the page still leads somewhere rather than dead-ending.
   const featuredElection = upcoming[0] ?? past[0];
-  const featuredDate = formatGermanDate(featuredElection?.date);
 
   // Sample questions for every live election, not just the featured one.
   // Between elections there is nothing upcoming, so fall back to the most
@@ -96,35 +93,48 @@ export default async function Landing() {
   // of these are cached reads issued in parallel, so it is a handful of data
   // cache hits rather than a fan-out of Firestore round trips.
   const questionElections = upcoming.length > 0 ? upcoming : past.slice(0, 1);
-  const questionGroups: QuestionGroup[] = (
-    await Promise.all(
-      questionElections.map(async (context) => {
-        const [questions, parties] = await Promise.all([
-          getGroupProposedQuestionsForContext(context.context_id),
-          getPartiesForContext(context.context_id),
-        ]);
+  const [homeQuestions, systemStatus, user, electionContent] =
+    await Promise.all([
+      getHomeInputProposedQuestions(),
+      getSystemStatus(),
+      getUser(),
+      Promise.all(
+        contexts.map(async (context) => {
+          const [questions, parties] = await Promise.all([
+            getGroupProposedQuestionsForContext(context.context_id),
+            getPartiesForContext(context.context_id),
+          ]);
 
-        return { context, questions, parties };
-      }),
-    )
-  ).filter((group) => group.questions.length > 0);
+          return { context, questions, parties };
+        }),
+      ),
+    ]);
 
-  // The elections section lists the ones the hero does not already lead with.
-  const otherUpcoming = upcoming.filter(
-    (context) => context.context_id !== featuredElection?.context_id,
+  const electionContentById = new Map(
+    electionContent.map((content) => [content.context.context_id, content]),
   );
-  const otherPast = past.filter(
-    (context) => context.context_id !== featuredElection?.context_id,
+  const questionGroups: QuestionGroup[] = questionElections
+    .map((context) => electionContentById.get(context.context_id))
+    .filter((group): group is QuestionGroup =>
+      Boolean(group?.questions.length),
+    );
+  const partiesByContext = Object.fromEntries(
+    electionContent.map(({ context, parties }) => [
+      context.context_id,
+      shuffleArray(parties),
+    ]),
   );
-  const hasOtherElections = otherUpcoming.length > 0 || otherPast.length > 0;
+  const questionsByContext = Object.fromEntries(
+    electionContent.map(({ context, questions }) => [
+      context.context_id,
+      questions,
+    ]),
+  );
 
-  // The cue points at whatever section actually comes first, so it never lands
-  // on an anchor that an empty election list has removed.
-  const firstSectionAnchor = hasOtherElections
-    ? ELECTIONS_ANCHOR
-    : questionGroups.length > 0
-      ? QUESTIONS_ANCHOR
-      : ABOUT_ANCHOR;
+  // The selector is interactive rather than a set of links. Keep every
+  // election in this server-rendered list so the crawlable markup and the
+  // structured ItemList continue to describe the same destinations.
+  const hasElections = upcoming.length > 0 || past.length > 0;
 
   const faqItems = getLandingFaqItems();
 
@@ -146,10 +156,9 @@ export default async function Landing() {
     ),
   };
 
-  // Every election the page links to — the hero's featured one plus the
-  // section listing the rest — so the structured data and the crawlable markup
-  // cannot drift apart. Each item points at the @id the context page declares
-  // for itself, so the graph resolves rather than repeating a bare URL.
+  // Every election the page links to, so the structured data and crawlable
+  // markup cannot drift apart. Each item points at the @id the context page
+  // declares for itself, so the graph resolves rather than repeating a bare URL.
   const orderedElections = [...upcoming, ...past];
   const electionList = {
     '@type': 'ItemList',
@@ -174,86 +183,30 @@ export default async function Landing() {
     <>
       <JsonLd data={jsonLd} />
 
-      {/* The hero fills the viewport but is no longer the whole page. svh
-          rather than dvh: dvh tracks the mobile URL bar collapsing mid-scroll,
-          which would resize the hero and shift every section below it.
+      {featuredElection ? (
+        <LandingChatHero
+          contexts={contexts}
+          initialContextId={featuredElection.context_id}
+          partiesByContext={partiesByContext}
+          fallbackQuestions={homeQuestions}
+          questionsByContext={questionsByContext}
+          initialSystemStatus={systemStatus}
+          hasValidServerUser={!user?.isAnonymous}
+        />
+      ) : (
+        <section className="px-5 py-16 text-center">
+          <h1 className="text-3xl font-bold">
+            Politik verstehen mit wahl.chat
+          </h1>
+          <p className="mt-3 text-muted-foreground">
+            Aktuell ist keine Wahl verfügbar.
+          </p>
+        </section>
+      )}
 
-          This section is also the clip boundary for BrandBlurBackdrop — the
-          blobs are positioned in % of their container and drift past its edge,
-          so overflow-hidden here is what keeps them off the rest of the
-          document. Every other section is a sibling of this one, never a
-          child. */}
-      <section className="relative flex min-h-svh w-full flex-col overflow-hidden">
-        <BrandBlurBackdrop />
-        <ScreenshotWheel />
-
-        {/* Mobile-first three-part hero: the mark sits top-left where a site
-            logo belongs, the headline takes the middle, and the call to action
-            is pinned to the bottom of the panel where a thumb reaches it.
-            The auto margins do that rather than justify-*, so each part can be
-            placed independently.
-
-            On desktop there is no thumb to reach with, and a button stranded
-            at the foot of a tall viewport reads as unrelated to the headline —
-            so md: collapses the text and the button back into one centred
-            group while the mark stays in its own top row. */}
-        <div className="relative flex flex-1 flex-col px-5 py-6 md:py-14">
-          <HeroLogo />
-
-          <div className="flex flex-1 flex-col items-center gap-6 text-center">
-            <div className="my-auto flex max-w-3xl flex-col gap-4 md:mb-0 md:mt-auto">
-              <h1 className="text-balance text-3xl font-bold tracking-tight text-foreground sm:text-3xl md:text-4xl">
-                <span className="block">Fragen stellen.</span>
-                <span className="block">Politik verstehen.</span>
-                <span className="block">Informiert wählen.</span>
-              </h1>
-
-              {/* An h2 rather than a p: now that the h1 is a short claim, this
-                  line carries the page's keywords and reads as the hero's
-                  subhead. Styled down to the supporting sentence it is — the
-                  page still has exactly one h1, directly above it. */}
-              <h2 className="text-pretty text-base font-normal text-muted-foreground md:text-lg">
-                Welche Partei passt zu dir? Vergleiche Parteien, belegt durch
-                Plenarprotokolle, namentliche Abstimmungen und Wahlprogramme.
-              </h2>
-            </div>
-
-            {featuredElection && (
-              <div className="flex w-full flex-col items-center gap-2 md:mb-auto">
-                <p className="text-balance font-medium text-foreground">
-                  {isUpcomingElection(featuredElection)
-                    ? 'Nächste Wahl'
-                    : 'Letzte Wahl'}
-                  : {featuredElection.name}
-                </p>
-
-                {featuredDate && (
-                  <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
-                    <CalendarIcon
-                      className="size-4 shrink-0"
-                      aria-hidden="true"
-                    />
-                    {featuredDate}
-                  </p>
-                )}
-
-                <div className="mt-2 flex w-full justify-center">
-                  <HeroCta context={featuredElection} />
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
-
-        <ScrollCue href={`#${firstSectionAnchor}`} />
-      </section>
-
-      {hasOtherElections && (
-        <LandingSection
-          id={ELECTIONS_ANCHOR}
-          title="Weitere Wahlen auf wahl.chat"
-        >
-          <ElectionLinks upcoming={otherUpcoming} past={otherPast} />
+      {hasElections && (
+        <LandingSection id={ELECTIONS_ANCHOR} title="Wahlen auf wahl.chat">
+          <ElectionLinks upcoming={upcoming} past={past} />
         </LandingSection>
       )}
 

--- a/web/components/chat/chat-group-party-select-submit-button.tsx
+++ b/web/components/chat/chat-group-party-select-submit-button.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button';
+import { buildChatSessionUrl } from '@/lib/chat-route';
 import { DEFAULT_CONTEXT_ID } from '@/lib/constants';
 import { useRouter } from 'next/navigation';
 import { useEffect, useMemo } from 'react';
@@ -20,12 +21,7 @@ function ChatGroupPartySelectSubmitButton({
   const router = useRouter();
 
   const navigateUrl = useMemo(() => {
-    const searchParams = new URLSearchParams();
-    selectedPartyIds.forEach((partyId) => {
-      searchParams.append('party_id', partyId);
-    });
-
-    return `/${contextId}/session?${searchParams.toString()}`;
+    return buildChatSessionUrl({ contextId, partyIds: selectedPartyIds });
   }, [selectedPartyIds, contextId]);
 
   const handleSubmit = () => {

--- a/web/components/chat/chat-group-party-select.tsx
+++ b/web/components/chat/chat-group-party-select.tsx
@@ -14,6 +14,8 @@ type Props = {
   selectedPartyIdsInStore?: string[];
   addPartiesToChat?: boolean;
   contextId?: string;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 };
 
 function ChatGroupPartySelect({
@@ -22,9 +24,11 @@ function ChatGroupPartySelect({
   selectedPartyIdsInStore,
   addPartiesToChat,
   contextId,
+  open,
+  onOpenChange,
 }: Props) {
   return (
-    <ResponsiveDialog>
+    <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
       <ResponsiveDialogTrigger asChild>{children}</ResponsiveDialogTrigger>
       <ResponsiveDialogContent>
         <ResponsiveDialogHeader className="text-left">

--- a/web/components/dynamic-rate-limit-sticky-input.tsx
+++ b/web/components/dynamic-rate-limit-sticky-input.tsx
@@ -4,7 +4,7 @@ import { listenToSystemStatus } from '@/lib/firebase/firebase';
 import type { LlmSystemStatus } from '@/lib/firebase/firebase.types';
 import { useEffect, useState } from 'react';
 import { useAnonymousAuth } from './anonymous-auth';
-import StickyInput from './sticky-input';
+import StickyInput, { type StickyInputAppearance } from './sticky-input';
 import StickyInputRateLimit from './sticky-input-rate-limit';
 
 type Props = {
@@ -14,6 +14,9 @@ type Props = {
   className?: string;
   initialSystemStatus: LlmSystemStatus;
   hasValidServerUser?: boolean;
+  appearance?: StickyInputAppearance;
+  headerActions?: React.ReactNode;
+  footerActions?: React.ReactNode;
 };
 
 function DynamicRateLimitStickyInput({
@@ -23,6 +26,9 @@ function DynamicRateLimitStickyInput({
   className,
   initialSystemStatus,
   hasValidServerUser,
+  appearance,
+  headerActions,
+  footerActions,
 }: Props) {
   const { user } = useAnonymousAuth();
   const [isAtRateLimit, setIsAtRateLimit] = useState(
@@ -48,6 +54,7 @@ function DynamicRateLimitStickyInput({
         onSubmit={onSubmit}
         quickReplies={quickReplies}
         className={className}
+        appearance={appearance}
       />
     );
   }
@@ -58,6 +65,9 @@ function DynamicRateLimitStickyInput({
       onSubmit={onSubmit}
       quickReplies={quickReplies}
       className={className}
+      appearance={appearance}
+      headerActions={headerActions}
+      footerActions={footerActions}
     />
   );
 }

--- a/web/components/home/election-select.tsx
+++ b/web/components/home/election-select.tsx
@@ -18,7 +18,7 @@ function CompactElectionContent({ context }: { context: Context }) {
   return (
     <div className="flex min-w-0 flex-1 items-center gap-2">
       <ContextIcon context={context} />
-      <span className="truncate text-sm font-medium text-foreground">
+      <span className="line-clamp-2 text-left text-sm font-medium leading-tight text-foreground">
         {context.name}
       </span>
       <span className="hidden shrink-0 items-center gap-3 text-xs text-muted-foreground sm:flex">
@@ -39,15 +39,24 @@ function CompactElectionContent({ context }: { context: Context }) {
   );
 }
 
-export function ElectionSelect() {
+type Props = {
+  onContextChange?: (contextId: string) => void;
+};
+
+export function ElectionSelect({ onContextChange }: Props = {}) {
   const currentContext = useCurrentContext();
   const contexts = useContexts();
   const router = useRouter();
 
   const handleContextChange = (contextId: string) => {
-    if (contextId !== currentContext.context_id) {
-      router.push(`/${contextId}`);
+    if (contextId === currentContext.context_id) return;
+
+    if (onContextChange) {
+      onContextChange(contextId);
+      return;
     }
+
+    router.push(`/${contextId}`);
   };
 
   // A lone context is not a choice — render it as a status line instead.

--- a/web/components/home/home-input.tsx
+++ b/web/components/home/home-input.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import DynamicRateLimitStickyInput from '@/components/dynamic-rate-limit-sticky-input';
+import type { StickyInputAppearance } from '@/components/sticky-input';
+import { buildChatSessionUrl } from '@/lib/chat-route';
 import { DEFAULT_CONTEXT_ID } from '@/lib/constants';
 import type {
   LlmSystemStatus,
@@ -17,6 +19,9 @@ type Props = {
   initialSystemStatus: LlmSystemStatus;
   hasValidServerUser?: boolean;
   contextId?: string;
+  appearance?: StickyInputAppearance;
+  headerActions?: React.ReactNode;
+  footerActions?: React.ReactNode;
 };
 
 function HomeInput({
@@ -25,6 +30,9 @@ function HomeInput({
   initialSystemStatus,
   hasValidServerUser,
   contextId = DEFAULT_CONTEXT_ID,
+  appearance,
+  headerActions,
+  footerActions,
 }: Props) {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
@@ -38,7 +46,7 @@ function HomeInput({
       question,
       context: contextId,
     });
-    router.push(`/${contextId}/session?q=${question}`);
+    router.push(buildChatSessionUrl({ contextId, question }));
   };
 
   return (
@@ -49,6 +57,9 @@ function HomeInput({
       initialSystemStatus={initialSystemStatus}
       hasValidServerUser={hasValidServerUser}
       className={cn('mt-4', className)}
+      appearance={appearance}
+      headerActions={headerActions}
+      footerActions={footerActions}
     />
   );
 }

--- a/web/components/landing/landing-chat-hero.tsx
+++ b/web/components/landing/landing-chat-hero.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import ChatGroupPartySelect from '@/components/chat/chat-group-party-select';
+import ElectionSelect from '@/components/home/election-select';
+import HomeInput from '@/components/home/home-input';
+import AiDisclaimer from '@/components/legal/ai-disclaimer';
+import { ContextProvider } from '@/components/providers/context-provider';
+import { Button } from '@/components/ui/button';
+import type {
+  Context,
+  LlmSystemStatus,
+  ProposedQuestion,
+} from '@/lib/firebase/firebase.types';
+import type { PartyDetails } from '@/lib/party-details';
+import { ChevronDownIcon, GitCompareIcon } from 'lucide-react';
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+
+type Props = {
+  contexts: Context[];
+  initialContextId: string;
+  partiesByContext: Record<string, PartyDetails[]>;
+  fallbackQuestions: ProposedQuestion[];
+  questionsByContext: Record<string, ProposedQuestion[]>;
+  initialSystemStatus: LlmSystemStatus;
+  hasValidServerUser?: boolean;
+};
+
+function LandingChatHero({
+  contexts,
+  initialContextId,
+  partiesByContext,
+  fallbackQuestions,
+  questionsByContext,
+  initialSystemStatus,
+  hasValidServerUser,
+}: Props) {
+  const [selectedContextId, setSelectedContextId] = useState(initialContextId);
+  const [isPartySelectOpen, setIsPartySelectOpen] = useState(false);
+  const selectedContext = useMemo(
+    () =>
+      contexts.find((context) => context.context_id === selectedContextId) ??
+      contexts[0],
+    [contexts, selectedContextId],
+  );
+
+  if (!selectedContext) return null;
+
+  const selectedQuestions = questionsByContext[selectedContext.context_id];
+  const questions = selectedQuestions?.length
+    ? selectedQuestions
+    : fallbackQuestions;
+
+  const handleContextChange = (contextId: string) => {
+    setIsPartySelectOpen(false);
+    setSelectedContextId(contextId);
+  };
+
+  const headerActions = (
+    <>
+      <Button
+        asChild
+        variant="secondary"
+        size="sm"
+        className="h-7 shrink-0 rounded-full px-2 text-xs font-normal"
+      >
+        <Link href="/how-to">Was kann ich fragen?</Link>
+      </Button>
+      <Button
+        asChild
+        variant="secondary"
+        size="sm"
+        className="h-7 shrink-0 rounded-full px-2 text-xs font-normal"
+      >
+        <Link href={`/${selectedContext.context_id}/sources`}>
+          Wie entstehen die Antworten?
+        </Link>
+      </Button>
+      <Button
+        variant="secondary"
+        size="sm"
+        className="h-7 shrink-0 rounded-full px-2 text-xs font-normal"
+        type="button"
+        onClick={() => setIsPartySelectOpen(true)}
+      >
+        Kann ich mehrere Parteien fragen?
+      </Button>
+    </>
+  );
+  const partySelector = (
+    <ChatGroupPartySelect
+      contextId={selectedContext.context_id}
+      open={isPartySelectOpen}
+      onOpenChange={setIsPartySelectOpen}
+    >
+      <Button
+        id="party-selection"
+        variant="secondary"
+        className="mt-2 w-full border border-border font-normal"
+        type="button"
+        aria-label="Parteien zum Vergleichen auswählen, optional"
+      >
+        <GitCompareIcon aria-hidden="true" />
+        <span>Parteien zum Vergleichen auswählen</span>
+        <span className="text-xs text-muted-foreground">optional</span>
+        <ChevronDownIcon className="ml-auto" aria-hidden="true" />
+      </Button>
+    </ChatGroupPartySelect>
+  );
+
+  return (
+    <ContextProvider
+      context={selectedContext}
+      contexts={contexts}
+      parties={partiesByContext[selectedContext.context_id]}
+    >
+      <section className="px-4 pb-12 pt-9 md:px-6 md:pb-16 md:pt-14">
+        <div className="mx-auto flex w-full max-w-3xl flex-col">
+          <p className="mb-4 flex items-center gap-2 text-sm font-medium">
+            <span
+              className="size-1.5 rounded-full bg-muted-foreground"
+              aria-hidden="true"
+            />
+            Weniger suchen. Mehr verstehen.
+          </p>
+
+          <h1 className="max-w-3xl text-balance text-4xl font-bold leading-[0.98] tracking-tight sm:text-5xl md:text-6xl">
+            Was möchtest du politisch verstehen
+            <span className="text-[#ED3833]">?</span>
+          </h1>
+
+          <p className="mt-4 max-w-xl text-pretty text-base text-muted-foreground md:text-lg">
+            Deine Fragen. Die Wahlprogramme. Ein Gespräch, das Klarheit schafft.
+          </p>
+
+          <div className="mt-7">
+            <ElectionSelect onContextChange={handleContextChange} />
+          </div>
+
+          <HomeInput
+            questions={questions}
+            initialSystemStatus={initialSystemStatus}
+            hasValidServerUser={hasValidServerUser}
+            contextId={selectedContext.context_id}
+            appearance="hero"
+            headerActions={headerActions}
+            footerActions={partySelector}
+          />
+
+          <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+            <p>Einfach losfragen. Keine Parteiauswahl nötig.</p>
+            <p className="hidden sm:block">⌘ / Strg + Enter zum Senden</p>
+          </div>
+
+          <AiDisclaimer className="text-left" />
+        </div>
+      </section>
+    </ContextProvider>
+  );
+}
+
+export default LandingChatHero;

--- a/web/components/landing/landing-header.tsx
+++ b/web/components/landing/landing-header.tsx
@@ -1,0 +1,47 @@
+import Logo from '@/components/chat/logo';
+import { ThemeModeToggle } from '@/components/chat/theme-mode-toggle';
+import { SITE_LINKS, sourcesLink } from '@/lib/site-links';
+import Link from 'next/link';
+
+type Props = {
+  contextId?: string;
+};
+
+function LandingHeader({ contextId }: Props) {
+  const sources = contextId ? sourcesLink(contextId) : undefined;
+
+  return (
+    <header className="border-b border-border px-4 py-3 md:px-6">
+      <div className="mx-auto flex w-full max-w-5xl items-center justify-between gap-4">
+        <Link href="/" aria-label="wahl.chat Startseite">
+          <Logo className="h-9 w-auto" />
+        </Link>
+
+        <div className="flex items-center gap-1 sm:gap-3">
+          <nav
+            aria-label="Hauptnavigation"
+            className="hidden items-center gap-1 sm:flex"
+          >
+            <Link
+              href={SITE_LINKS.howTo.href}
+              className="rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-muted"
+            >
+              {SITE_LINKS.howTo.label}
+            </Link>
+            {sources && (
+              <Link
+                href={sources.href}
+                className="rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-muted"
+              >
+                Quellen &amp; Transparenz
+              </Link>
+            )}
+          </nav>
+          <ThemeModeToggle align="end" />
+        </div>
+      </div>
+    </header>
+  );
+}
+
+export default LandingHeader;

--- a/web/components/sticky-input-rate-limit.tsx
+++ b/web/components/sticky-input-rate-limit.tsx
@@ -4,12 +4,14 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { useEffect, useRef, useState } from 'react';
 import MessageLoadingBorderTrail from './chat/message-loading-border-trail';
+import type { StickyInputAppearance } from './sticky-input';
 
 type Props = {
   isLoading: boolean;
   onSubmit: (message: string) => void;
   quickReplies?: string[];
   className?: string;
+  appearance?: StickyInputAppearance;
 };
 
 function StickyInputRateLimit({
@@ -17,6 +19,7 @@ function StickyInputRateLimit({
   onSubmit,
   quickReplies,
   className,
+  appearance = 'default',
 }: Props) {
   const [isSticky, setIsSticky] = useState(true);
   const ref = useRef<HTMLDivElement>(null);
@@ -42,8 +45,9 @@ function StickyInputRateLimit({
     <div
       ref={ref}
       className={cn(
-        'sticky bottom-[-1px] -mx-2 md:pb-2 pb-4 z-40 transition-all duration-300 ease-out',
-        !isSticky && 'mx-0',
+        appearance === 'default' &&
+          'sticky bottom-[-1px] -mx-2 z-40 pb-4 transition-all duration-300 ease-out md:pb-2',
+        appearance === 'default' && !isSticky && 'mx-0',
         className,
       )}
     >
@@ -51,7 +55,8 @@ function StickyInputRateLimit({
         className={cn(
           'relative w-full overflow-hidden rounded-lg border border-input bg-muted py-3 md:py-4',
           'shadow-2xl transition-shadow',
-          !isSticky && 'shadow-none',
+          appearance === 'hero' && 'rounded-[20px] shadow-none',
+          appearance === 'default' && !isSticky && 'shadow-none',
         )}
       >
         {quickReplies && quickReplies.length > 0 && (

--- a/web/components/sticky-input.tsx
+++ b/web/components/sticky-input.tsx
@@ -7,17 +7,31 @@ import Logo from './chat/logo';
 import MessageLoadingBorderTrail from './chat/message-loading-border-trail';
 import { Button } from './ui/button';
 
+export type StickyInputAppearance = 'default' | 'hero';
+
 type Props = {
   isLoading: boolean;
   onSubmit: (message: string) => void;
   quickReplies?: string[];
   className?: string;
+  appearance?: StickyInputAppearance;
+  headerActions?: React.ReactNode;
+  footerActions?: React.ReactNode;
 };
 
-function StickyInput({ isLoading, onSubmit, quickReplies, className }: Props) {
+function StickyInput({
+  isLoading,
+  onSubmit,
+  quickReplies,
+  className,
+  appearance = 'default',
+  headerActions,
+  footerActions,
+}: Props) {
   const [input, setInput] = useState('');
   const [isSticky, setIsSticky] = useState(true);
   const ref = useRef<HTMLDivElement>(null);
+  const isHero = appearance === 'hero';
 
   useEffect(() => {
     const cachedRef = ref.current;
@@ -38,6 +52,8 @@ function StickyInput({ isLoading, onSubmit, quickReplies, className }: Props) {
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    if (!input.trim() || isLoading) return;
+
     onSubmit(input);
   };
 
@@ -45,12 +61,20 @@ function StickyInput({ isLoading, onSubmit, quickReplies, className }: Props) {
     onSubmit(reply);
   };
 
+  const handleHeroKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key !== 'Enter' || (!e.metaKey && !e.ctrlKey)) return;
+
+    e.preventDefault();
+    e.currentTarget.form?.requestSubmit();
+  };
+
   return (
     <div
       ref={ref}
       className={cn(
-        'sticky bottom-[-1px] -mx-2 md:pb-2 pb-4 z-40 transition-all duration-300 ease-out',
-        !isSticky && 'mx-0',
+        !isHero &&
+          'sticky bottom-[-1px] -mx-2 z-40 pb-4 transition-all duration-300 ease-out md:pb-2',
+        !isHero && !isSticky && 'mx-0',
         className,
       )}
     >
@@ -58,51 +82,103 @@ function StickyInput({ isLoading, onSubmit, quickReplies, className }: Props) {
         onSubmit={handleSubmit}
         className={cn(
           'relative shadow-2xl transition-shadow duration-300 max-w-xl mx-auto w-full grid overflow-hidden rounded-[20px] border border-input dark:focus-within:border-zinc-700 focus-within:border-zinc-300 bg-chat-input ease-out md:shadow-none',
-          !isSticky && 'shadow-none',
+          isHero && 'max-w-none shadow-none',
+          !isHero && !isSticky && 'shadow-none',
         )}
       >
         {isLoading && <MessageLoadingBorderTrail />}
 
-        <div className="flex gap-1 overflow-x-auto whitespace-nowrap px-2 pt-2 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-          {quickReplies?.map((reply) => {
-            return (
-              <button
-                key={reply}
-                className={cn(
-                  'shrink-0 rounded-full bg-muted px-2 py-1 transition-colors enabled:hover:bg-muted/70 disabled:cursor-not-allowed disabled:opacity-50',
-                )}
-                type="button"
-                onClick={() => handleQuickReplyClick(reply)}
-              >
-                <p className="line-clamp-1 text-xs">{reply}</p>
-              </button>
-            );
-          })}
-        </div>
+        {isHero ? (
+          headerActions && (
+            <div className="flex gap-1 overflow-x-auto whitespace-nowrap px-2 pt-2 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+              {headerActions}
+            </div>
+          )
+        ) : (
+          <div className="flex gap-1 overflow-x-auto whitespace-nowrap px-2 pt-2 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+            {quickReplies?.map((reply) => {
+              return (
+                <button
+                  key={reply}
+                  className={cn(
+                    'shrink-0 rounded-full bg-muted px-2 py-1 transition-colors enabled:hover:bg-muted/70 disabled:cursor-not-allowed disabled:opacity-50',
+                  )}
+                  type="button"
+                  onClick={() => handleQuickReplyClick(reply)}
+                >
+                  <p className="line-clamp-1 text-xs">{reply}</p>
+                </button>
+              );
+            })}
+          </div>
+        )}
 
         <Logo
           variant="small"
-          className="absolute bottom-2 left-2 size-8 translate-y-0 rounded-full border border-border p-1"
+          className={cn(
+            'absolute left-2 size-8 rounded-full border border-border p-1',
+            isHero ? 'top-12' : 'bottom-2 translate-y-0',
+          )}
         />
-        <input
-          className="w-full bg-chat-input px-12 py-3 text-[16px] placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-0 disabled:cursor-not-allowed"
-          name="question"
-          placeholder="Frage die Parteien..."
-          value={input}
-          type="text"
-          onChange={(e) => setInput(e.target.value)}
-          maxLength={500}
-        />
+        {isHero ? (
+          <textarea
+            className="min-h-28 w-full resize-none bg-chat-input px-12 py-4 text-[16px] placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-0 disabled:cursor-not-allowed"
+            name="question"
+            aria-label="Deine politische Frage"
+            placeholder="Frage die Parteien..."
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleHeroKeyDown}
+            maxLength={500}
+            rows={3}
+          />
+        ) : (
+          <input
+            className="w-full bg-chat-input px-12 py-3 text-[16px] placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-0 disabled:cursor-not-allowed"
+            name="question"
+            aria-label="Deine politische Frage"
+            placeholder="Frage die Parteien..."
+            value={input}
+            type="text"
+            onChange={(e) => setInput(e.target.value)}
+            maxLength={500}
+          />
+        )}
         <Button
           type="submit"
+          aria-label="Frage stellen"
           className={cn(
             'absolute right-2 bottom-2 translate-y-0 flex size-8 items-center justify-center rounded-full bg-foreground text-background transition-colors hover:bg-foreground/80 disabled:bg-foreground/20 disabled:text-muted',
           )}
-          disabled={!input.length || isLoading}
+          disabled={!input.trim() || isLoading}
         >
-          <ArrowUp className="size-4 font-bold" />
+          <ArrowUp className="size-4 font-bold" aria-hidden="true" />
         </Button>
       </form>
+
+      {isHero && footerActions}
+
+      {isHero && quickReplies && quickReplies.length > 0 && (
+        <div
+          className="mt-3 flex items-center gap-2 overflow-x-auto whitespace-nowrap pb-1 text-xs text-muted-foreground [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          aria-label="Beispielfragen"
+        >
+          <span className="shrink-0">Zum Beispiel</span>
+          {quickReplies.slice(0, 3).map((reply) => (
+            <Button
+              key={reply}
+              variant="outline"
+              size="sm"
+              className="h-9 max-w-64 shrink-0 rounded-full px-3 font-normal"
+              type="button"
+              onClick={() => handleQuickReplyClick(reply)}
+              disabled={isLoading}
+            >
+              <span className="truncate">{reply}</span>
+            </Button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/lib/chat-route.test.ts
+++ b/web/lib/chat-route.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+import { buildChatSessionUrl } from './chat-route';
+
+describe('buildChatSessionUrl', () => {
+  test('keeps a question with query syntax in one q parameter', () => {
+    const url = buildChatSessionUrl({
+      contextId: 'mv2026',
+      question: 'Was gilt für Miete & Energie?',
+    });
+    const parsed = new URL(url, 'https://wahl.chat');
+
+    expect(parsed.pathname).toBe('/mv2026/session');
+    expect(parsed.searchParams.get('q')).toBe('Was gilt für Miete & Energie?');
+    expect([...parsed.searchParams.keys()]).toEqual(['q']);
+  });
+
+  test('preserves every selected party as a repeated parameter', () => {
+    const url = buildChatSessionUrl({
+      contextId: 'berlin2026',
+      partyIds: ['spd', 'cdu'],
+    });
+    const parsed = new URL(url, 'https://wahl.chat');
+
+    expect(parsed.searchParams.getAll('party_id')).toEqual(['spd', 'cdu']);
+  });
+
+  test('does not add an empty query string', () => {
+    expect(buildChatSessionUrl({ contextId: 'mv2026' })).toBe(
+      '/mv2026/session',
+    );
+  });
+});

--- a/web/lib/chat-route.ts
+++ b/web/lib/chat-route.ts
@@ -1,0 +1,21 @@
+type ChatSessionUrlOptions = {
+  contextId: string;
+  question?: string;
+  partyIds?: string[];
+};
+
+export function buildChatSessionUrl({
+  contextId,
+  question,
+  partyIds = [],
+}: ChatSessionUrlOptions): string {
+  const searchParams = new URLSearchParams();
+
+  if (question) searchParams.set('q', question);
+  partyIds.forEach((partyId) => searchParams.append('party_id', partyId));
+
+  const query = searchParams.toString();
+  const path = `/${encodeURIComponent(contextId)}/session`;
+
+  return query ? `${path}?${query}` : path;
+}


### PR DESCRIPTION
## Why

The landing page currently delays the product's core interaction behind a generic CTA and a large visual hero. This moves the first viewport toward the approved chat-first “Direkt” direction while keeping the existing wahl.chat component language and real election/chat behavior.

## What changed

- Replaces the full-viewport animated hero with a compact header, the official stacked logo, and the “Was möchtest du politisch verstehen?” chat-first composition.
- Reuses the real election selector, context/date/crest data, multiline question input, rate-limit guard, session routing, and optional multi-party comparison dialog.
- Keeps starter questions data-driven and updates them when the selected election changes.
- Preserves the root canonical/metadata/JSON-LD and a server-rendered link to every available election, along with the existing lower-page content and source links.
- Centralizes question and multi-party session URLs so query text and repeated party IDs remain correctly encoded.

## Testing

- `bun run typecheck`
- `bun run test` (25 passing)
- `bun run lint` (passes with existing unrelated warnings)
- `bun run build`
- Production-mode Playwright checks against seeded Firestore emulator data: desktop, 375×667 mobile, dark mode, empty/enabled submit, election switch, optional party dialog, keyboard submission routing, canonical/JSON-LD, source links, and all election links.

The local AI backend was not started, so visual verification stops after the real session route accepts the submitted question; generated answer streaming was not exercised.